### PR TITLE
Cache the Windows compile with sccache

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -307,6 +307,14 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: sccache
+        uses: hendrikmuhs/ccache-action@v1.2.23
+        with:
+          variant: sccache
+          key: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          restore-keys: ${{ runner.os }}-sccache-${{ matrix.cmake_build_type }}
+          max-size: 500M
+
       - name: Cache vcpkg (install artifacts)
         uses: actions/cache@v4
         with:
@@ -363,23 +371,26 @@ jobs:
       - name: cmake ALL_BUILD
         run: |
           echo "::group::cmake ALL_BUILD"
-          cmake `
+          # Use the Ninja generator: CMAKE_<LANG>_COMPILER_LAUNCHER (the
+          # sccache hook) is honored only by Ninja/Makefile generators, not
+          # the Visual Studio (MSBuild) generator, which silently ignores it.
+          cmake -GNinja `
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
+            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
+            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
             -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
             -DVCPKG_TARGET_TRIPLET="x64-windows" `
             -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
             -S${{ github.workspace }} `
             -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
-            --target ALL_BUILD
+          cmake --build ${{ github.workspace }}/build
           echo "::endgroup::"
 
       - name: cmake run_gtest
         run: |
           echo "::group::cmake run_gtest"
           cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
             --target run_gtest
           echo "::endgroup::"
 
@@ -387,7 +398,6 @@ jobs:
         run: |
           echo "::group::cmake run_pilot_pytest"
           cmake --build ${{ github.workspace }}/build `
-            --config ${{ matrix.cmake_build_type }} `
             --target run_pilot_pytest
           echo "::endgroup::"
 
@@ -432,12 +442,14 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the pilot
+          # Configure and build the pilot. The build dir is already
+          # configured with the Ninja single-config generator above, so reuse
+          # it without --config and read pilot.exe from the non-config path.
           cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --config Release --target pilot
+          cmake --build build --target pilot
 
           # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\pilot\Release\pilot.exe" -Destination $destination
+          Copy-Item -Path ".\build\cpp\binary\pilot\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
           # Also include potential thirdparty


### PR DESCRIPTION
Wrap MSVC `cl.exe` with [sccache](https://github.com/mozilla/sccache) in the `build_windows` job so the compile is served from a shared cache instead of recompiling the whole tree on every run.

- Add `hendrikmuhs/ccache-action` with `variant: sccache` (keyed per build type, 500M cap).
- Switch `build_windows` to the **Ninja generator**: `CMAKE_<LANG>_COMPILER_LAUNCHER` (sccache's hook) is honored only by Ninja/Makefile generators; the Visual Studio (MSBuild) generator silently ignores it, so the launcher never runs. Drop the now-unused `--config`/`--target ALL_BUILD` and read `pilot.exe` from Ninja's single-config output path.
- Pass `-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache`.
- Set `-DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded` (`/Z7`) so debug info lands in the objects; the default shared PDB is not cacheable by sccache.

First run primes the cache (compile requests stored as misses); a warm re-run shows `sccache --show-stats` hits and a much shorter Windows critical path.