### PR TITLE
Build the Windows portable artifact nightly only

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -402,7 +402,7 @@ jobs:
           echo "::endgroup::"
 
       - name: generate portable
-        if: ${{ matrix.cmake_build_type == 'Release' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
         run: |
           echo "::group::generate portable"
           # Get the Python version installed and extract the major+minor version components
@@ -457,7 +457,7 @@ jobs:
           echo "::endgroup::"
 
       - name: archive portable artifacts
-        if: ${{ matrix.cmake_build_type == 'Release' }}
+        if: ${{ matrix.cmake_build_type == 'Release' && github.event_name == 'schedule' }}
         uses: actions/upload-artifact@v7
         with:
           name: solvcon-pilot-win64


### PR DESCRIPTION
The `generate portable` and `archive portable artifacts` steps in `build_windows` run a second full pilot build plus download the embeddable Python and pip packages on every Windows Release run, yet the distributable artifact gates nothing on a PR.

Gate both steps on `github.event_name == 'schedule'` so PRs and `master` pushes skip the extra pilot rebuild and downloads; the nightly run still produces the artifact.

CI note: on this PR both steps are expected to show as skipped (they only run on the nightly `schedule`).