### PR TITLE
Drop the no-op sanitizer rebuild from the build job

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -226,21 +226,6 @@ jobs:
         make run_pilot_pytest VERBOSE=1
         echo "::endgroup::"
 
-    # FIXME: turn off until all issues resolved
-    - name: make cmake USE_SANITIZER=ON & make pytest
-      run: |
-        echo "::group::make cmake USE_SANITIZER=ON & make pytest"
-        export ASAN_OPTIONS=verify_asan_link_order=0
-        rm -f build/*/Makefile
-        make cmake \
-          VERBOSE=1 USE_CLANG_TIDY=OFF \
-          BUILD_QT=OFF \
-          CMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
-          CMAKE_ARGS="-DPYTHON_EXECUTABLE=$(which python3) -DUSE_SANITIZER=OFF"
-        make buildext VERBOSE=1
-        make pytest VERBOSE=1
-        echo "::endgroup::"
-
   build_windows:
 
     needs: [check_skip]


### PR DESCRIPTION
The last step of the `build` job ran `make cmake ... -DUSE_SANITIZER=OFF` followed by a full `make buildext` + `make pytest`. With the sanitizer **off** it reproduced the pytest already run earlier in the same job, costing one extra full build+test per `build` matrix leg with no added coverage.

Remove it from the PR path. A real `-DUSE_SANITIZER=ON` ASAN/UBSAN build is added to the nightly schedule in a later change.