### PR TITLE
Gate the heavy build matrix behind the smoke compile

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -76,7 +76,11 @@ jobs:
 
   build:
 
-    needs: [check_skip]
+    # Gate the heavy build behind the fast standalone_buffer smoke compile so
+    # a broken build short-circuits before the full matrix launches. (lint
+    # lives in a separate workflow, so it cannot be named here as a dependency;
+    # standalone_buffer is the fast in-workflow gate.)
+    needs: [check_skip, standalone_buffer]
 
     if: |
       needs.check_skip.outputs.skip != 'true' && (
@@ -228,7 +232,11 @@ jobs:
 
   build_windows:
 
-    needs: [check_skip]
+    # Gate the expensive Windows build behind the fast standalone_buffer smoke
+    # compile so it does not burn runner minutes in parallel with a build that
+    # is already broken. (lint lives in a separate workflow and cannot be named
+    # as a dependency here; standalone_buffer is the fast in-workflow gate.)
+    needs: [check_skip, standalone_buffer]
 
     if: |
       needs.check_skip.outputs.skip != 'true' && (


### PR DESCRIPTION
`build` and `build_windows` launched in parallel with the fast checks, so a trivial build break still paid for a full Windows compile before failing.

Add `standalone_buffer` to their `needs` so the fast standalone-buffer compile gates the heavy matrix; a failure there short-circuits the expensive jobs instead of burning runner minutes alongside them.

`lint` lives in a separate workflow file, so GitHub Actions cannot name it as a cross-workflow dependency. `standalone_buffer` is the fast in-workflow smoke gate (the plan's stated alternative). `nouse_install` moves off the PR path in a later change, so it is not gated here.

CI note: the build jobs now start only after `standalone_buffer` passes.