### PR TITLE
Run the Windows Debug build nightly only

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -262,8 +262,11 @@ jobs:
     strategy:
       matrix:
         os: [windows-2022]
-        # Build Debug because there is not a job for windows in lint.yml (which uses the Debug build type)
-        cmake_build_type: [Release, Debug]
+        # Release runs on every pull request and master push. Debug is the
+        # only Windows Debug compile (lint.yml has no Windows job), but it is
+        # heavy and rarely breaks on its own, so it runs on the nightly
+        # schedule only.
+        cmake_build_type: ${{ (github.event_name == 'schedule' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
 
       fail-fast: false
 


### PR DESCRIPTION
`build_windows` compiled both Release and Debug on every PR and `master` push. Debug is the only Windows Debug configuration, but it is heavy and rarely fails independently of Release.

Select the matrix from the event so Release runs everywhere and Debug is added only on the nightly `schedule`:
```yaml
cmake_build_type: ${{ (github.event_name == 'schedule' && fromJSON('["Release", "Debug"]')) || fromJSON('["Release"]') }}
```
This drops one full Windows compile from every PR; nightly still covers Debug.

CI note: this PR should show only `build_windows-2022_Release` (no Debug).