### PR TITLE
Run the setup.py install path nightly only

### DIFF
--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -24,13 +24,16 @@ jobs:
 
     needs: [check_skip]
 
+    # The setup.py install path re-verifies packaging and duplicates the build
+    # job's pytest; the macOS leg is the worst cost offender. It does not gate
+    # correctness on a pull request, so it runs on the nightly schedule and on
+    # release tag pushes only, not on pull requests or master pushes. Set the
+    # MMGH_FORCE_NOUSE_INSTALL variable to 'enable' to force it on a fork.
     if: |
       needs.check_skip.outputs.skip != 'true' && (
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'push' &&
-       (vars.MMGH_PUSH_RUN_BRANCH == '*' ||
-        contains(vars.MMGH_PUSH_RUN_BRANCH, github.ref_name))) ||
-      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable'))
+      (github.event_name == 'schedule' && vars.MMGH_NIGHTLY == 'enable') ||
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) ||
+      vars.MMGH_FORCE_NOUSE_INSTALL == 'enable')
 
     name: nouse_install_${{ matrix.os }}_Release
 


### PR DESCRIPTION
`nouse_install` re-verifies `setup.py install` and duplicates the `build` job's pytest on both ubuntu and macOS for every PR. The macOS leg is the worst cost offender (a third macOS compile billed at the higher macOS rate) and gates nothing on a PR.

Restrict the job to the nightly `schedule` and release tag pushes; drop it from PRs and `master` pushes. `MMGH_FORCE_NOUSE_INSTALL=enable` forces it on a fork for testing (mirrors `profiling.yml`).

CI note: on this PR both `nouse_install` legs should be skipped.