### PR TITLE
Auto-skip heavy CI for docs-only and non-C++ pull requests

### DIFF
--- a/.github/workflows/check_skip_ci.yml
+++ b/.github/workflows/check_skip_ci.yml
@@ -29,6 +29,12 @@ on:
           "true" when CI should be skipped for the triggering pull request,
           "false" or empty otherwise.
         value: ${{ jobs.check.outputs.skip }}
+      cpp:
+        description: >-
+          "true" when the pull request touches C++ or build files (so the C++
+          matrix must run), "false" when it does not, empty for non-pull_request
+          events.
+        value: ${{ jobs.check.outputs.cpp }}
 
 permissions: {}
 
@@ -49,6 +55,7 @@ jobs:
 
     outputs:
       skip: ${{ steps.check.outputs.skip }}
+      cpp: ${{ steps.check.outputs.cpp }}
 
     steps:
 
@@ -101,4 +108,34 @@ jobs:
               return;
             }
 
+            // 4. Path-based gating. A documentation-only pull request skips all
+            // heavy CI automatically; a pull request that touches no C++ or
+            // build files reports cpp=false so the C++-only jobs can opt out
+            // while the Python tests and lint still run.
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+            const paths = files.map(file => file.filename);
+            const isDoc = p =>
+              p.startsWith('doc/') || p.endsWith('.md') ||
+              p.endsWith('.rst') || p.startsWith('contrib/prompt/');
+            const isCpp = p =>
+              p.startsWith('cpp/') || p.startsWith('gtests/') ||
+              p.startsWith('thirdparty/') || p.startsWith('.github/') ||
+              p.endsWith('CMakeLists.txt') || p.endsWith('.cmake') ||
+              p.endsWith('.mk') || p === 'Makefile' || p === 'setup.py';
+
+            if (paths.length && paths.every(isDoc)) {
+              core.notice('CI skipped: documentation-only pull request.');
+              core.setOutput('skip', 'true');
+              core.setOutput('cpp', 'false');
+              return;
+            }
+
+            core.setOutput('cpp', paths.some(isCpp) ? 'true' : 'false');
             core.setOutput('skip', 'false');

--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -238,8 +238,11 @@ jobs:
     # as a dependency here; standalone_buffer is the fast in-workflow gate.)
     needs: [check_skip, standalone_buffer]
 
+    # cpp != 'false' keeps the expensive Windows build off pull requests that
+    # touch no C++ or build files (it is empty, so truthy, for push/schedule).
     if: |
-      needs.check_skip.outputs.skip != 'true' && (
+      needs.check_skip.outputs.skip != 'true' &&
+      needs.check_skip.outputs.cpp != 'false' && (
       github.event_name == 'pull_request' ||
       (github.event_name == 'push' &&
        (vars.MMGH_PUSH_RUN_BRANCH == '*' ||


### PR DESCRIPTION
`check_skip_ci` now inspects the PR's changed files (via `pulls.listFiles`):

- **Docs-only** PR (`doc/**`, `*.md`, `*.rst`, `contrib/prompt/**`) -> sets `skip=true`, skipping all heavy CI automatically, so it no longer needs a maintainer to apply `skip-ci`. A docs-only PR then finishes in seconds.
- New **`cpp`** output reports whether any C++/build file changed (`cpp/**`, `gtests/**`, `thirdparty/**`, `.github/**`, `CMakeLists.txt`, `*.cmake`, `*.mk`, `Makefile`, `setup.py`). The expensive `build_windows` opts out when it is `false`.

`build` (which carries pytest) and `lint` keep running on non-C++ PRs so pure-Python changes retain coverage; `standalone_buffer` stays as the smoke gate (`build`/`build_windows` depend on it). `cpp` is empty (truthy) for push/schedule, so those always run the full matrix.

CI note: this PR edits `.github/**`, so `cpp=true` and the full matrix runs here. The skip behavior is verified separately with a docs-only probe PR after merge.