### PR TITLE
PROBE docs-only auto-skip (do not merge)

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -15,3 +15,5 @@ make html                         # -> build/html/index.html
 empty (a warning, not an error) until the XML exists.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->
+
+<!-- ci probe: verify docs-only auto-skip -->


### PR DESCRIPTION
Throwaway probe: a docs-only change to confirm check_skip_ci auto-skips heavy CI. Will be closed.