### PR TITLE
Install pybind11 from the pip wheel instead of source

### DIFF
--- a/.github/actions/setup_linux/action.yml
+++ b/.github/actions/setup_linux/action.yml
@@ -186,11 +186,16 @@ runs:
         clang-format --version
         echo "::endgroup::"
 
-    - name: dependency (manual)
+    - name: install pybind11 (pip wheel)
       shell: bash
       run: |
-        echo "::group::dependency (manual)"
-        sudo ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        echo "::group::install pybind11 (pip wheel)"
+        # Install the pybind11 wheel instead of building it from source. The
+        # wheel ships the headers and the CMake package config; exporting
+        # pybind11_ROOT lets find_package(pybind11) in CMakeLists.txt locate
+        # it without rebuilding the library on every job.
+        sudo pip3 install 'pybind11==3.0.1'
+        echo "pybind11_ROOT=$(python3 -c 'import os, pybind11; print(os.path.dirname(pybind11.__file__))')" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     - name: show dependency

--- a/.github/actions/setup_macos/action.yml
+++ b/.github/actions/setup_macos/action.yml
@@ -99,11 +99,16 @@ runs:
         clang-format --version
         echo "::endgroup::"
 
-    - name: dependency (manual)
+    - name: install pybind11 (pip wheel)
       shell: bash
       run: |
-        echo "::group::dependency (manual)"
-        sudo NO_INSTALL_PREFIX=1 ${GITHUB_WORKSPACE}/contrib/dependency/install.sh pybind11
+        echo "::group::install pybind11 (pip wheel)"
+        # Install the pybind11 wheel instead of building it from source. The
+        # wheel ships the headers and the CMake package config; exporting
+        # pybind11_ROOT lets find_package(pybind11) in CMakeLists.txt locate
+        # it without rebuilding the library on every job.
+        python3 -m pip install --break-system-packages --upgrade 'pybind11==3.0.1'
+        echo "pybind11_ROOT=$(python3 -c 'import os, pybind11; print(os.path.dirname(pybind11.__file__))')" >> "$GITHUB_ENV"
         echo "::endgroup::"
 
     - name: dependency (manual) for build

--- a/contrib/standalone_buffer/Makefile
+++ b/contrib/standalone_buffer/Makefile
@@ -12,6 +12,7 @@ CFLAGS := \
 	-std=c++23 -fPIC \
 	-I$(SETUPROOT) \
 	-I$(shell python3 -c 'import numpy as np; print(np.get_include())') \
+	-I$(shell python3 -c 'import pybind11; print(pybind11.get_include())') \
 	-I$(shell $(DIRNAME_PYTHON)/python3-config --prefix)/include \
 	$(shell $(DIRNAME_PYTHON)/python3-config --cflags)
 


### PR DESCRIPTION
The Linux and macOS setup actions built pybind11 from a source tarball on every job (download + cmake configure + `make install`). The pybind11 wheel ships the same headers and CMake package config, so install it with pip and export `pybind11_ROOT` so `find_package(pybind11 ... )` (CMP0074) locates it — no call-site changes needed.

Pinned to `pybind11==3.0.1` to match the prior source version; the Windows job already uses the pip wheel.

CI note: this PR touches `.github/**`, so the full Linux+macOS matrix runs and exercises pybind11 discovery via the wheel.