### PR TITLE
Bound the compiler caches with a max size

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -66,6 +66,7 @@ jobs:
           key: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           restore-keys: ${{ runner.os }}-standalone-buffer-${{ matrix.cmake_build_type }}
           create-symlink: true
+          max-size: 500M
 
       - name: make standalone_buffer
         run: |
@@ -147,6 +148,11 @@ jobs:
         key: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-${{ matrix.cmake_build_type }}
         create-symlink: true
+        # Bound the cache so it does not grow without limit across the rolling
+        # key. A master push or nightly run saves this cache; pull requests
+        # restore it (a PR on a non-default base branch cannot, so it runs
+        # cold).
+        max-size: 1500M
 
     - name: make gtest BUILD_QT=OFF
       run: |
@@ -513,6 +519,7 @@ jobs:
         key: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-sanitizer-${{ matrix.cmake_build_type }}
         create-symlink: true
+        max-size: 1500M
 
     - name: make gtest USE_SANITIZER=ON
       run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,6 +93,7 @@ jobs:
         key: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         restore-keys: ${{ runner.os }}-tidy-${{ matrix.cmake_build_type }}
         create-symlink: true
+        max-size: 1500M
 
     - name: make cformat (clang-format check)
       run: |

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -79,6 +79,7 @@ jobs:
           key: ${{ runner.os }}-Release
           restore-keys: ${{ runner.os }}-Release
           create-symlink: true
+          max-size: 1500M
 
       - name: setup.py install build_ext
         run: |


### PR DESCRIPTION
Give each ccache a `max-size` so the rolling-key caches stay bounded: a master push or nightly run saves a bounded cache that PRs restore. The standalone-buffer cache is small (500M); the full `build`, `lint`, `sanitizer`, and `nouse_install` caches get 1500M. The `sccache` cache already had 500M (step 1).

Keys are deliberately left unchanged: the `${{ runner.os }}-Release` cache is shared — `build` saves it, `profiling`/`nouse_install` restore it — so churning keys would break that sharing. The `vcpkg-${{ runner.os }}-openblas-lapack` cache already has a stable key + restore-keys prefix.

Note: cross-PR warm restore is populated by `master` push / nightly runs (a PR on a non-default base branch runs cold); that warm path is validated upstream, where push jobs run.