### PR TITLE
Run the macOS lint leg nightly only

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -57,10 +57,15 @@ jobs:
 
     strategy:
       matrix:
+        # The formatting, flake8, and ASCII/whitespace checks are platform
+        # independent, so running them on ubuntu covers every pull request.
+        # The macOS leg (a second clang-tidy compile billed at the higher
+        # macOS rate) adds only macOS-specific clang-tidy coverage, so it runs
+        # on the nightly schedule only. macos-26 is arm64 with 7 GB RAM;
+        # parallelism is capped via NPROC in the env block above so clang-tidy
+        # does not OOM.
         # https://github.com/actions/runner-images/blob/main/images/macos/macos-26-Readme.md
-        # macos-26 is arm64 with 7 GB RAM; parallelism is capped via NPROC
-        # in the env block above so clang-tidy does not OOM.
-        os: [ubuntu-24.04, macos-26]
+        os: ${{ (github.event_name == 'schedule' && fromJSON('["ubuntu-24.04", "macos-26"]')) || fromJSON('["ubuntu-24.04"]') }}
         cmake_build_type: [Debug]
 
       fail-fast: false


### PR DESCRIPTION
After moving `nouse_install` off the PR path, macOS was still compiled twice per PR: by `build` (Release, full + Metal pytest) and by `lint` (Debug, clang-tidy). The formatting/flake8/ASCII/whitespace checks are platform-independent, so the ubuntu lint leg already covers them; the macOS lint leg only adds macOS-specific clang-tidy coverage at the higher macOS billing rate.

Select the lint `os` matrix from the event:
```yaml
os: ${{ (github.event_name == 'schedule' && fromJSON('["ubuntu-24.04", "macos-26"]')) || fromJSON('["ubuntu-24.04"]') }}
```
PRs lint on ubuntu only; the macOS leg runs nightly. macOS is then compiled exactly once per PR (by `build`).

CI note: this PR should show a single `lint` leg (ubuntu), no macOS lint.