### PR TITLE
Add surface-with-edges representation and per-object opacity

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -159,6 +159,36 @@ bool RDomainWidget::meshStyleShown(std::string const & name) const
     return false;
 }
 
+void RDomainWidget::setRepresentation(std::string const & name)
+{
+    if ("surface" == name)
+    {
+        m_show_surface = true;
+        m_show_wireframe = m_show_points = false;
+    }
+    else if ("wireframe" == name)
+    {
+        m_show_wireframe = true;
+        m_show_surface = m_show_points = false;
+    }
+    else if ("points" == name)
+    {
+        m_show_points = true;
+        m_show_surface = m_show_wireframe = false;
+    }
+    else if ("surface_edges" == name)
+    {
+        m_show_surface = m_show_wireframe = true;
+        m_show_points = false;
+    }
+    else
+    {
+        return; // Ignore an unknown name.
+    }
+    applyMeshVisibility();
+    update();
+}
+
 void RDomainWidget::applyMeshVisibility()
 {
     if (nullptr != m_mesh_surface)
@@ -172,6 +202,24 @@ void RDomainWidget::applyMeshVisibility()
     if (nullptr != m_mesh_points)
     {
         m_mesh_points->setVisible(m_mesh_shown && m_show_points);
+    }
+}
+
+void RDomainWidget::setMeshOpacity(float opacity)
+{
+    if (nullptr != m_mesh_frame)
+    {
+        m_mesh_frame->setOpacity(opacity);
+        update();
+    }
+}
+
+void RDomainWidget::setFieldOpacity(float opacity)
+{
+    if (nullptr != m_field)
+    {
+        m_field->setOpacity(opacity);
+        update();
     }
 }
 

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -68,6 +68,18 @@ public:
     void showMeshStyle(std::string const & name, bool show);
     bool meshStyleShown(std::string const & name) const;
 
+    /// Select a named representation as a preset over the mesh styles:
+    /// "surface", "wireframe", "points", or "surface_edges" (the lit surface
+    /// with the wireframe drawn over it). An unknown name is ignored.
+    void setRepresentation(std::string const & name);
+
+    /// Set the mesh wireframe opacity, a [0, 1] fraction (1 opaque).
+    void setMeshOpacity(float opacity);
+
+    /// Set the color-field surface opacity, a [0, 1] fraction (1 opaque).
+    /// Lower it to read the wireframe drawn over the shaded surface.
+    void setFieldOpacity(float opacity);
+
     /// Replace the colored field: per-vertex-colored triangles from a vertex
     /// table (nvert, 3), a matching color table (nvert, 3), and a triangle
     /// index table (ntri, 3). Swappable at runtime.

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -42,10 +42,13 @@ void RDrawable::prepare(
     m_srb->create();
 
     m_material = std::make_unique<RMaterial>(materialKind());
+    // Blend is enabled unconditionally so a later setOpacity takes effect
+    // without rebuilding the pipeline; a fully opaque alpha of 1 makes the
+    // source-over blend an identity, so opaque drawables render unchanged.
     m_pipeline.reset(m_material->buildPipeline(
         rhi, m_srb.get(), rpdesc, vertexInputLayout(), topology(), sample_count,
         /*depth_test*/ true,
-        /*alpha_blend*/ false,
+        /*alpha_blend*/ true,
         depthBias(),
         slopeScaledDepthBias()));
     m_ready = (nullptr != m_pipeline);
@@ -71,7 +74,8 @@ void RDrawable::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const 
         return;
     }
     batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, view_proj.constData());
-    float const color[4] = {m_color.x(), m_color.y(), m_color.z(), m_color.w()};
+    float const color[4] = {
+        m_color.x(), m_color.y(), m_color.z(), m_color.w() * m_opacity};
     batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, color);
     float const light[4] = {m_light_dir.x(), m_light_dir.y(), m_light_dir.z(), 0.0f};
     batch->updateDynamicBuffer(m_ubuf.get(), 80, 16, light);

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -62,6 +62,15 @@ public:
     /// ignored by the others. The widget refreshes it as the camera moves.
     void setLightDir(QVector3D const & dir) { m_light_dir = dir; }
 
+    /// Set the drawable opacity, a [0, 1] multiplier on the color alpha.
+    /// 1 is fully opaque, 0 fully transparent. Clamped to the range.
+    void setOpacity(float opacity)
+    {
+        m_opacity = (opacity < 0.0f) ? 0.0f : (opacity > 1.0f) ? 1.0f
+                                                               : opacity;
+    }
+    float opacity() const { return m_opacity; }
+
     /// Create the device resources if they do not exist yet. Idempotent.
     void prepare(
         QRhi * rhi,
@@ -110,6 +119,7 @@ protected:
 
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
     QVector3D m_light_dir{0.0f, 0.0f, 1.0f};
+    float m_opacity = 1.0f;
     bool m_visible = true;
 
     std::unique_ptr<QRhiBuffer> m_vbuf;

--- a/cpp/solvcon/pilot/shaders/vcolor.vert
+++ b/cpp/solvcon/pilot/shaders/vcolor.vert
@@ -6,13 +6,13 @@ layout(location = 1) in vec3 vertexColor;
 layout(std140, binding = 0) uniform buf
 {
     mat4 mvp;
-    vec4 color; // unused by the per-vertex-color variant
+    vec4 color; // only the alpha (opacity) is used by this variant
 } ubuf;
 
 layout(location = 0) out vec4 v_color;
 
 void main()
 {
-    v_color = vec4(vertexColor, 1.0);
+    v_color = vec4(vertexColor, ubuf.color.a);
     gl_Position = ubuf.mvp * vec4(position, 1.0);
 }

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -152,6 +152,8 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
             .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
+            .def("setMeshOpacity", &wrapped_type::setMeshOpacity, py::arg("opacity"))
+            .def("setFieldOpacity", &wrapped_type::setFieldOpacity, py::arg("opacity"))
             .def(
                 "showMeshStyle",
                 &wrapped_type::showMeshStyle,
@@ -164,6 +166,13 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 &wrapped_type::meshStyleShown,
                 py::arg("name"),
                 "Whether the named mesh style is currently shown.")
+            .def(
+                "setRepresentation",
+                &wrapped_type::setRepresentation,
+                py::arg("name"),
+                "Select a representation preset over the mesh styles: "
+                "\"surface\", \"wireframe\", \"points\", or \"surface_edges\" "
+                "(the lit surface with the wireframe over it).")
             .def(
                 "updateColorField",
                 &wrapped_type::updateColorField,
@@ -544,8 +553,10 @@ void wrap_pilot(pybind11::module & mod)
         mod,
         "RDomainWidget",
         "Interactive QRhi viewer for 2D and 3D unstructured-mesh domains and "
-        "fields. Drive it with updateMesh / showMesh / showMeshStyle, "
-        "updateColorField, showBoundary, and showAxis; navigate with cameraMode, the "
+        "fields. Drive it with updateMesh / showMesh / showMeshStyle / "
+        "setRepresentation / setMeshOpacity, "
+        "updateColorField / setFieldOpacity, "
+        "showBoundary, and showAxis; navigate with cameraMode, the "
         "cameraPosition / cameraTarget / cameraUp pose, rotateCamera / "
         "panCamera / zoomCamera / pinchCamera, and fitCameraToScene; capture "
         "frames with "

--- a/doc/source/pilot/domain.md
+++ b/doc/source/pilot/domain.md
@@ -47,7 +47,28 @@ viewer.updateMesh(mesh)                   # wireframe only, the default
 viewer.showMeshStyle("surface", True)     # add the lit shaded surface
 viewer.showMeshStyle("wireframe", False)  # drop the wireframe over it
 viewer.meshStyleShown("points")           # False
+viewer.setRepresentation("surface_edges")  # surface with the wireframe over it
 ```
+
+## Layering and opacity
+
+The wireframe and the colored field are separate layers drawn in the same
+scene, so showing both draws the wireframe over the shaded surface as one
+representation. Each layer takes an adjustable opacity, a fraction from `0`
+(fully transparent) to `1` (fully opaque, the default):
+
+- `setFieldOpacity(alpha)` fades the shaded surface. Lower it to read the
+  wireframe and any structure behind the surface.
+- `setMeshOpacity(alpha)` fades the wireframe.
+
+```python
+viewer.updateMesh(mesh)                    # wireframe layer
+viewer.updateColorField(verts, cols, tris)  # shaded surface layer
+viewer.setFieldOpacity(0.5)                # see the wireframe through it
+```
+
+The opacity is applied on the next frame, so it takes effect immediately in the
+live viewer and in a captured frame.
 
 ## Camera navigation
 

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -344,6 +344,37 @@ class RDomainWidgetStyleTC(unittest.TestCase):
         self.assertFalse(widget.meshStyleShown("wireframe"))
         self.assertTrue(widget.meshStyleShown("surface"))
 
+    def test_representation_presets_map_to_styles(self):
+        """setRepresentation drives the style flags as mutually exclusive
+        presets, and surface_edges lights up both the surface and wireframe."""
+        widget = pilot.RDomainWidget()
+        widget.setRepresentation("surface")
+        self.assertEqual(
+            [widget.meshStyleShown(n)
+             for n in ("surface", "wireframe", "points")],
+            [True, False, False])
+        widget.setRepresentation("points")
+        self.assertEqual(
+            [widget.meshStyleShown(n)
+             for n in ("surface", "wireframe", "points")],
+            [False, False, True])
+        widget.setRepresentation("surface_edges")
+        self.assertEqual(
+            [widget.meshStyleShown(n)
+             for n in ("surface", "wireframe", "points")],
+            [True, True, False])
+
+    def test_unknown_representation_is_ignored(self):
+        """An unknown representation name leaves the styles untouched."""
+        widget = pilot.RDomainWidget()
+        widget.setRepresentation("surface_edges")
+        before = [widget.meshStyleShown(n)
+                  for n in ("surface", "wireframe", "points")]
+        widget.setRepresentation("bogus")
+        after = [widget.meshStyleShown(n)
+                 for n in ("surface", "wireframe", "points")]
+        self.assertEqual(before, after)
+
     def test_unknown_style_is_ignored(self):
         """An unknown style name toggles nothing and reads back false."""
         widget = pilot.RDomainWidget()
@@ -463,6 +494,55 @@ class RDomainWidgetFieldTC(unittest.TestCase):
         indices = np.array([(0, 1, 9), (0, 1, 2)], dtype='uint32')
         with self.assertRaises(ValueError):
             _update_field(widget, vertices, colors, indices)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetOpacityTC(unittest.TestCase):
+    """Adjustable per-drawable opacity for the wireframe and the surface."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_field_opacity_fades_toward_background(self):
+        """Lowering the field opacity blends the shaded surface toward the
+        white background, so far fewer pixels stay strongly saturated."""
+        vertices, colors, indices = _make_color_field()
+
+        opaque = pilot.RDomainWidget()
+        opaque.resize(320, 240)
+        _update_field(opaque, vertices, colors, indices)
+        strong_opaque = _count_colored(_grab_or_skip(opaque), 100)
+        self.assertGreater(strong_opaque, 0)
+
+        faded = pilot.RDomainWidget()
+        faded.resize(320, 240)
+        _update_field(faded, vertices, colors, indices)
+        faded.setFieldOpacity(0.3)
+        strong_faded = _count_colored(_grab_or_skip(faded), 100)
+        self.assertLess(strong_faded, strong_opaque)
+
+    def test_mesh_opacity_fades_wireframe(self):
+        """A low mesh opacity fades the black wireframe toward white, so its
+        lines fall below the foreground threshold."""
+        opaque = pilot.RDomainWidget()
+        opaque.resize(320, 240)
+        opaque.updateMesh(_make_2d_mesh())
+        shown = _count_foreground(_grab_or_skip(opaque))
+        self.assertGreater(shown, 0)
+
+        faded = pilot.RDomainWidget()
+        faded.resize(320, 240)
+        faded.updateMesh(_make_2d_mesh())
+        faded.setMeshOpacity(0.2)
+        self.assertLess(_count_foreground(_grab_or_skip(faded)), shown)
+
+    def test_set_opacity_without_drawable_is_noop(self):
+        """Setting opacity before a mesh or field exists is a harmless no-op,
+        not a crash."""
+        widget = pilot.RDomainWidget()
+        widget.setMeshOpacity(0.5)
+        widget.setFieldOpacity(0.5)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
## Summary

Adds the surface-with-edges representation and per-object opacity to the
pilot domain viewer (`RDomainWidget`).

- `setRepresentation("surface" | "wireframe" | "points" | "surface_edges")`
  selects a representation preset over the independent mesh styles;
  `surface_edges` draws the lit surface with the wireframe over it.
- Per-drawable opacity: `RDrawable` scales the color alpha and blends
  source-over unconditionally, so `setMeshOpacity` / `setFieldOpacity` fade a
  layer at runtime without rebuilding the pipeline. An alpha of 1 is an
  identity blend, so opaque drawables are unchanged.

## Verification

- `make` (pilot build) and `make lint` clean.
- `make pytest PYTEST_OPTS=tests/test_pilot_domain_widget.py` green; new
  tests cover the representation presets and the opacity fade.

This is a step PR into `meshvisual`; it is one milestone of the mesh
visualization prototype.
