### PR TITLE
Color scalar fields on the GPU through a lookup table

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -10,6 +10,9 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RColormap.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScalarField.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScalarBar.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RBoundary.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RRibbon.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RFeatureEdges.hpp
@@ -34,6 +37,9 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RDrawable.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMeshFrame.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RField.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RColormap.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScalarField.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RScalarBar.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RBoundary.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RRibbon.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RFeatureEdges.cpp
@@ -65,6 +71,8 @@ set(SOLVCON_PILOT_SHADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/color.vert
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/color.frag
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/vcolor.vert
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/scalar.vert
+    ${CMAKE_CURRENT_SOURCE_DIR}/shaders/scalar.frag
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/texture.vert
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/texture.frag
     ${CMAKE_CURRENT_SOURCE_DIR}/shaders/lit.vert

--- a/cpp/solvcon/pilot/RColormap.cpp
+++ b/cpp/solvcon/pilot/RColormap.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RColormap.hpp> // Must be the first include.
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// One RGB anchor triple per row, spaced uniformly on [0, 1].
+// clang-format off
+
+// The 20-anchor viridis palette (the widely published viridis(20) table).
+constexpr float VIRIDIS[] = {
+    0.267f, 0.005f, 0.329f,
+    0.282f, 0.084f, 0.404f,
+    0.282f, 0.150f, 0.467f,
+    0.271f, 0.216f, 0.506f,
+    0.251f, 0.278f, 0.533f,
+    0.224f, 0.337f, 0.549f,
+    0.200f, 0.388f, 0.553f,
+    0.176f, 0.439f, 0.557f,
+    0.157f, 0.490f, 0.557f,
+    0.137f, 0.541f, 0.553f,
+    0.122f, 0.588f, 0.545f,
+    0.125f, 0.639f, 0.529f,
+    0.161f, 0.686f, 0.498f,
+    0.235f, 0.733f, 0.459f,
+    0.333f, 0.776f, 0.404f,
+    0.451f, 0.816f, 0.333f,
+    0.584f, 0.847f, 0.251f,
+    0.722f, 0.871f, 0.161f,
+    0.863f, 0.890f, 0.098f,
+    0.993f, 0.906f, 0.144f};
+
+// Approximate anchors of Moreland's smooth diverging blue-white-red map.
+constexpr float COOLWARM[] = {
+    0.230f, 0.299f, 0.754f,
+    0.484f, 0.620f, 0.974f,
+    0.865f, 0.865f, 0.865f,
+    0.926f, 0.502f, 0.412f,
+    0.706f, 0.016f, 0.150f};
+
+// The compact four-stop jet approximation; the anchors sit on the k/8
+// breakpoints of its triangle-wave channels, so the piecewise-linear ramp
+// reproduces the formula exactly.
+constexpr float JET[] = {
+    0.0f, 0.0f, 0.5f,
+    0.0f, 0.0f, 1.0f,
+    0.0f, 0.5f, 1.0f,
+    0.0f, 1.0f, 1.0f,
+    0.5f, 1.0f, 0.5f,
+    1.0f, 1.0f, 0.0f,
+    1.0f, 0.5f, 0.0f,
+    1.0f, 0.0f, 0.0f,
+    0.5f, 0.0f, 0.0f};
+
+constexpr float GRAYSCALE[] = {
+    0.0f, 0.0f, 0.0f,
+    1.0f, 1.0f, 1.0f};
+
+// clang-format on
+
+} /* end namespace */
+
+RColormap::RColormap(std::string name, float const * anchors, size_t count)
+    : m_name(std::move(name))
+    , m_anchors(anchors)
+    , m_count(count)
+{
+}
+
+RColormap RColormap::named(std::string const & name)
+{
+    if ("viridis" == name)
+    {
+        return RColormap(name, VIRIDIS, sizeof(VIRIDIS) / sizeof(float) / 3);
+    }
+    if ("coolwarm" == name)
+    {
+        return RColormap(name, COOLWARM, sizeof(COOLWARM) / sizeof(float) / 3);
+    }
+    if ("jet" == name)
+    {
+        return RColormap(name, JET, sizeof(JET) / sizeof(float) / 3);
+    }
+    if ("grayscale" == name)
+    {
+        return RColormap(name, GRAYSCALE, sizeof(GRAYSCALE) / sizeof(float) / 3);
+    }
+    throw std::invalid_argument(
+        "RColormap: unknown colormap \"" + name +
+        "\"; pick one of \"viridis\", \"coolwarm\", \"jet\", \"grayscale\"");
+}
+
+QVector3D RColormap::sample(float t) const
+{
+    t = std::clamp(t, 0.0f, 1.0f);
+    float const pos = t * static_cast<float>(m_count - 1);
+    size_t const lo = std::min(static_cast<size_t>(pos), m_count - 2);
+    float const frac = pos - static_cast<float>(lo);
+    float const * a = m_anchors + 3 * lo;
+    float const * b = a + 3;
+    return QVector3D(
+        a[0] + frac * (b[0] - a[0]),
+        a[1] + frac * (b[1] - a[1]),
+        a[2] + frac * (b[2] - a[2]));
+}
+
+QImage RColormap::image(int width) const
+{
+    QImage img(width, 1, QImage::Format_RGBA8888);
+    for (int i = 0; i < width; ++i)
+    {
+        float const t = (width > 1) ? static_cast<float>(i) / static_cast<float>(width - 1) : 0.0f;
+        QVector3D const c = sample(t);
+        img.setPixel(
+            i,
+            0,
+            qRgba(
+                static_cast<int>(std::lround(c.x() * 255.0f)),
+                static_cast<int>(std::lround(c.y() * 255.0f)),
+                static_cast<int>(std::lround(c.z() * 255.0f)),
+                255));
+    }
+    return img;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RColormap.hpp
+++ b/cpp/solvcon/pilot/RColormap.hpp
@@ -1,0 +1,65 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Named one-dimensional color lookup tables for scalar-field rendering.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <QImage>
+#include <QVector3D>
+
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief A named one-dimensional color lookup table.
+ *
+ * A colormap is a piecewise-linear ramp over a static table of RGB anchor
+ * points spaced uniformly on [0, 1]. It bakes into a one-row QImage that a
+ * drawable uploads as the LUT texture sampled by the scalar-color material,
+ * and the same table drives the scalar-bar strip so the on-screen report
+ * always matches the mapping on the GPU.
+ *
+ * @ingroup group_domain
+ */
+class RColormap
+{
+
+public:
+
+    /// The available names: "viridis", "coolwarm", "jet", "grayscale".
+    /// Throws std::invalid_argument for anything else.
+    static RColormap named(std::string const & name);
+
+    std::string const & name() const { return m_name; }
+
+    /// Piecewise-linear sample of the ramp at @p t clamped to [0, 1].
+    QVector3D sample(float t) const;
+
+    /// Bake the ramp into a @p width x 1 RGBA image for the LUT texture.
+    QImage image(int width = 256) const;
+
+private:
+
+    RColormap(std::string name, float const * anchors, size_t count);
+
+    std::string m_name;
+    float const * m_anchors; ///< Static table of RGB triples.
+    size_t m_count;
+
+}; /* end class RColormap */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -10,6 +10,7 @@
 #include <solvcon/pilot/RField.hpp>
 #include <solvcon/pilot/RMeshFrame.hpp>
 #include <solvcon/pilot/RNormals.hpp>
+#include <solvcon/pilot/RScalarField.hpp>
 
 #include <QGestureEvent>
 #include <QKeyEvent>
@@ -20,6 +21,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <stdexcept>
 
 namespace solvcon
 {
@@ -105,10 +107,9 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
         m_scene.extendBoundingBox(lo, hi);
     }
     // A field set earlier still draws, so keep it inside the framed box.
-    if (nullptr != m_field)
+    if (m_has_field_bbox)
     {
-        auto * field = static_cast<RField *>(m_field);
-        m_scene.extendBoundingBox(field->bboxLo(), field->bboxHi());
+        m_scene.extendBoundingBox(m_field_lo, m_field_hi);
     }
 
     m_scene.fitCameraToScene(viewportAspect());
@@ -230,28 +231,72 @@ void RDomainWidget::updateColorField(
     SimpleArray<float> const & colors,
     SimpleArray<uint32_t> const & indices)
 {
-    // Drop the previous field and replace it; the field is swappable.
-    m_scene.removeDrawable(m_field);
-    m_field = nullptr;
-
     auto field = std::make_unique<RField>(vertices, colors, indices);
-    if (field->hasGeometry())
-    {
-        QVector3D const lo = field->bboxLo();
-        QVector3D const hi = field->bboxHi();
-        // With no mesh to set the dimensionality, infer it: a field with no
-        // depth extent is viewed head-on like a 2D domain.
-        if (!m_scene.hasBoundingBox())
-        {
-            float const span = (hi - lo).length();
-            m_scene.setDimension(((hi.z() - lo.z()) > 1.0e-6f * span) ? 3 : 2);
-        }
-        m_scene.extendBoundingBox(lo, hi);
-        m_field = field.get();
-        m_scene.addDrawable(std::move(field));
-        m_scene.fitCameraToScene(viewportAspect());
-    }
+    installField(std::move(field));
+}
 
+void RDomainWidget::updateScalarField(
+    SimpleArray<float> const & vertices,
+    SimpleArray<float> const & scalars,
+    SimpleArray<uint32_t> const & indices)
+{
+    auto field = std::make_unique<RScalarField>(vertices, scalars, indices, m_colormap);
+    if (m_range_pinned)
+    {
+        field->setScalarRange(m_range_lo, m_range_hi);
+    }
+    m_scalar_bar.setRange(field->rangeLo(), field->rangeHi());
+    RScalarField * scalar_field = field.get();
+    installField(std::move(field));
+    m_scalar_field = (m_field == scalar_field) ? scalar_field : nullptr;
+}
+
+void RDomainWidget::setColormap(std::string const & name)
+{
+    m_colormap = RColormap::named(name);
+    if (nullptr != m_scalar_field)
+    {
+        m_scalar_field->setColormap(m_colormap);
+    }
+    m_scalar_bar.setColormap(m_colormap);
+    update();
+}
+
+void RDomainWidget::setScalarRange(float lo, float hi)
+{
+    if (hi < lo)
+    {
+        throw std::invalid_argument("RDomainWidget: scalar range must have hi >= lo");
+    }
+    m_range_pinned = true;
+    m_range_lo = lo;
+    m_range_hi = hi;
+    if (nullptr != m_scalar_field)
+    {
+        m_scalar_field->setScalarRange(lo, hi);
+    }
+    m_scalar_bar.setRange(lo, hi);
+    update();
+}
+
+std::pair<float, float> RDomainWidget::scalarRange() const
+{
+    if (nullptr != m_scalar_field)
+    {
+        return {m_scalar_field->rangeLo(), m_scalar_field->rangeHi()};
+    }
+    return {m_range_lo, m_range_hi};
+}
+
+void RDomainWidget::showScalarBar(bool show)
+{
+    m_scalar_bar.setVisible(show);
+    update();
+}
+
+void RDomainWidget::setScalarBarTitle(std::string const & title)
+{
+    m_scalar_bar.setTitle(title);
     update();
 }
 
@@ -502,6 +547,7 @@ void RDomainWidget::initialize(QRhiCommandBuffer *)
         // (the pipelines are tied to the render-pass descriptor).
         m_scene.releaseAll();
         m_gizmo.release();
+        m_scalar_bar.release();
         m_rhi = rhi();
         m_rpdesc = rpdesc;
         m_sample_count = sampleCount();
@@ -538,6 +584,7 @@ void RDomainWidget::render(QRhiCommandBuffer * cb)
     QVector3D const camera_forward = m_scene.camera().target() - m_scene.camera().position();
     m_gizmo.update(
         m_rhi, rpdesc, sampleCount(), pixel_size, camera_forward, m_scene.camera().up(), batch);
+    m_scalar_bar.update(m_rhi, rpdesc, sampleCount(), pixel_size, batch);
 
     QColor const clear_color = QColor::fromRgbF(1.0f, 1.0f, 1.0f, 1.0f);
     QRhiDepthStencilClearValue const ds_clear(1.0f, 0);
@@ -550,6 +597,7 @@ void RDomainWidget::render(QRhiCommandBuffer * cb)
         drawable->draw(cb);
     }
     m_gizmo.draw(cb);
+    m_scalar_bar.draw(cb);
     cb->endPass();
 }
 
@@ -557,6 +605,7 @@ void RDomainWidget::releaseResources()
 {
     m_scene.releaseAll();
     m_gizmo.release();
+    m_scalar_bar.release();
     m_rhi = nullptr;
     m_rpdesc = nullptr;
     m_sample_count = 0;

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -16,6 +16,8 @@
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
 #include <solvcon/pilot/RAxisGizmo.hpp>
+#include <solvcon/pilot/RColormap.hpp>
+#include <solvcon/pilot/RScalarBar.hpp>
 #include <solvcon/pilot/RScene.hpp>
 #include <solvcon/pilot/RDrawable.hpp>
 
@@ -30,9 +32,12 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 
 namespace solvcon
 {
+
+class RScalarField;
 
 /**
  * @brief Interactive 2D/3D viewer for spatial domains and fields on
@@ -87,6 +92,31 @@ public:
         SimpleArray<float> const & vertices,
         SimpleArray<float> const & colors,
         SimpleArray<uint32_t> const & indices);
+
+    /// Replace the scalar field: triangles from a vertex table (nvert, 3), a
+    /// per-vertex scalar table (nvert,), and a triangle index table
+    /// (ntri, 3), colored on the GPU through the active colormap LUT.
+    /// Swappable at runtime.
+    void updateScalarField(
+        SimpleArray<float> const & vertices,
+        SimpleArray<float> const & scalars,
+        SimpleArray<uint32_t> const & indices);
+
+    /// Select the named colormap ("viridis", "coolwarm", "jet",
+    /// "grayscale") for the scalar field and the scalar bar.
+    void setColormap(std::string const & name);
+    std::string colormap() const { return m_colormap.name(); }
+
+    /// Pin the scalar-to-color mapping range. Until called, each
+    /// updateScalarField maps its own data min/max.
+    void setScalarRange(float lo, float hi);
+    std::pair<float, float> scalarRange() const;
+
+    /// Show or hide the on-screen scalar bar.
+    void showScalarBar(bool show);
+
+    /// Set the title text over the scalar bar.
+    void setScalarBarTitle(std::string const & title);
 
     /// Show or hide the highlight ribbon for boundary set @p ibc.
     void showBoundary(int ibc, bool show);
@@ -151,17 +181,24 @@ private:
     /// three mesh drawables' visibility.
     void applyMeshVisibility();
 
+    /// Swap in a new field drawable (color or scalar) and re-frame the
+    /// scene around its bounding box.
+    template <typename FieldT>
+    void installField(std::unique_ptr<FieldT> field);
+
     QRhi * m_rhi = nullptr; ///< Tracked to detect device changes.
     QRhiRenderPassDescriptor * m_rpdesc = nullptr; ///< Tracked to detect target changes.
     int m_sample_count = 0; ///< Tracked to detect MSAA changes.
 
     RScene m_scene;
     RAxisGizmo m_gizmo;
+    RScalarBar m_scalar_bar;
     // Non-owning; the drawables live in the scene. One per mesh representation.
     RDrawable * m_mesh_surface = nullptr;
     RDrawable * m_mesh_frame = nullptr;
     RDrawable * m_mesh_points = nullptr;
     RDrawable * m_field = nullptr;
+    RScalarField * m_scalar_field = nullptr; ///< m_field when it is scalar.
 
     // Per-style show flags; any combination may be on at once. Only the
     // wireframe is on by default, so a fresh viewer looks unchanged.
@@ -170,12 +207,52 @@ private:
     bool m_show_points = false;
     bool m_mesh_shown = true; ///< The showMesh toggle, applied atop the styles.
 
+    RColormap m_colormap = RColormap::named("viridis");
+    bool m_range_pinned = false; ///< setScalarRange overrides auto-ranging.
+    float m_range_lo = 0.0f;
+    float m_range_hi = 1.0f;
+    QVector3D m_field_lo; ///< Field bounding box, kept for re-framing.
+    QVector3D m_field_hi;
+    bool m_has_field_bbox = false;
+
     std::shared_ptr<StaticMesh> m_mesh;
 
     QPoint m_last_mouse_pos; ///< Last cursor position during a drag.
     bool m_panning = false; ///< A non-left-button drag pans in both modes.
 
 }; /* end class RDomainWidget */
+
+template <typename FieldT>
+void RDomainWidget::installField(std::unique_ptr<FieldT> field)
+{
+    // Drop the previous field and replace it; the field is swappable.
+    m_scene.removeDrawable(m_field);
+    m_field = nullptr;
+    m_scalar_field = nullptr;
+    m_has_field_bbox = false;
+
+    if (field->hasGeometry())
+    {
+        QVector3D const lo = field->bboxLo();
+        QVector3D const hi = field->bboxHi();
+        // With no mesh to set the dimensionality, infer it: a field with no
+        // depth extent is viewed head-on like a 2D domain.
+        if (!m_scene.hasBoundingBox())
+        {
+            float const span = (hi - lo).length();
+            m_scene.setDimension(((hi.z() - lo.z()) > 1.0e-6f * span) ? 3 : 2);
+        }
+        m_scene.extendBoundingBox(lo, hi);
+        m_field_lo = lo;
+        m_field_hi = hi;
+        m_has_field_bbox = true;
+        m_field = field.get();
+        m_scene.addDrawable(std::move(field));
+        m_scene.fitCameraToScene(viewportAspect());
+    }
+
+    update();
+}
 
 } /* end namespace solvcon */
 

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -32,13 +32,15 @@ void RDrawable::prepare(
     m_ubuf.reset(rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, UBUF_SIZE));
     m_ubuf->create();
 
+    std::vector<QRhiShaderResourceBinding> bindings;
+    bindings.push_back(QRhiShaderResourceBinding::uniformBuffer(
+        0,
+        QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+        m_ubuf.get()));
+    extendBindings(rhi, batch, bindings);
+
     m_srb.reset(rhi->newShaderResourceBindings());
-    m_srb->setBindings({
-        QRhiShaderResourceBinding::uniformBuffer(
-            0,
-            QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
-            m_ubuf.get()),
-    });
+    m_srb->setBindings(bindings.begin(), bindings.end());
     m_srb->create();
 
     m_material = std::make_unique<RMaterial>(materialKind());
@@ -52,6 +54,10 @@ void RDrawable::prepare(
         depthBias(),
         slopeScaledDepthBias()));
     m_ready = (nullptr != m_pipeline);
+}
+
+void RDrawable::extendBindings(QRhi *, QRhiResourceUpdateBatch *, std::vector<QRhiShaderResourceBinding> &)
+{
 }
 
 void RDrawable::release()

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -23,6 +23,7 @@
 #include <QVector4D>
 
 #include <memory>
+#include <vector>
 
 namespace solvcon
 {
@@ -79,11 +80,11 @@ public:
         QRhiResourceUpdateBatch * batch);
 
     /// Drop all device resources (device lost or render target changed).
-    void release();
+    virtual void release();
 
     /// Write the current model-view-projection and color into the uniform
     /// buffer. The model transform is identity for now.
-    void updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const & view_proj);
+    virtual void updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const & view_proj);
 
     /// Record the draw call. Requires an active render pass and a viewport
     /// already set on the command buffer. A no-op while hidden or unprepared.
@@ -116,6 +117,14 @@ protected:
     /// cloud drawn over it is not lost to the depth test; the default is none.
     virtual int depthBias() const { return 0; }
     virtual float slopeScaledDepthBias() const { return 0.0f; }
+
+    /// Create and append shader resources past the shared uniform block
+    /// (e.g. a sampled texture). Called from prepare(); adds nothing by
+    /// default.
+    virtual void extendBindings(
+        QRhi * rhi,
+        QRhiResourceUpdateBatch * batch,
+        std::vector<QRhiShaderResourceBinding> & bindings);
 
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
     QVector3D m_light_dir{0.0f, 0.0f, 1.0f};

--- a/cpp/solvcon/pilot/RMaterial.cpp
+++ b/cpp/solvcon/pilot/RMaterial.cpp
@@ -45,6 +45,10 @@ RMaterial::RMaterial(Kind kind)
         m_vert = loadShader(QStringLiteral(":/solvcon/pilot/shaders/lit.vert.qsb"));
         m_frag = loadShader(QStringLiteral(":/solvcon/pilot/shaders/lit.frag.qsb"));
         break;
+    case Kind::ScalarColor:
+        m_vert = loadShader(QStringLiteral(":/solvcon/pilot/shaders/scalar.vert.qsb"));
+        m_frag = loadShader(QStringLiteral(":/solvcon/pilot/shaders/scalar.frag.qsb"));
+        break;
     }
 }
 

--- a/cpp/solvcon/pilot/RMaterial.hpp
+++ b/cpp/solvcon/pilot/RMaterial.hpp
@@ -49,6 +49,7 @@ public:
         VertexColor, ///< A per-vertex color attribute.
         Textured, ///< A sampled texture tinted by the uniform color.
         Lit, ///< A per-vertex normal shaded by a directional light.
+        ScalarColor, ///< A per-vertex scalar mapped through a LUT texture.
     };
 
     explicit RMaterial(Kind kind);

--- a/cpp/solvcon/pilot/RScalarBar.cpp
+++ b/cpp/solvcon/pilot/RScalarBar.cpp
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RScalarBar.hpp> // Must be the first include.
+
+#include <QColor>
+#include <QFont>
+#include <QPainter>
+
+#include <algorithm>
+#include <utility>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// The bar image is painted at a fixed pixel size and scaled into an
+// aspect-preserving viewport, so the layout below is in image pixels.
+constexpr int BAR_WIDTH = 128;
+constexpr int BAR_HEIGHT = 384;
+constexpr int STRIP_LEFT = 14;
+constexpr int STRIP_TOP = 56;
+constexpr int STRIP_WIDTH = 30;
+constexpr int STRIP_HEIGHT = 304;
+constexpr float VIEWPORT_MARGIN = 8.0f;
+
+} /* end namespace */
+
+RScalarBar::RScalarBar()
+    : m_colormap(RColormap::named("viridis"))
+{
+}
+
+RScalarBar::~RScalarBar() = default;
+
+void RScalarBar::setTitle(std::string const & title)
+{
+    m_title = QString::fromStdString(title);
+    m_dirty = true;
+}
+
+void RScalarBar::setColormap(RColormap colormap)
+{
+    m_colormap = std::move(colormap);
+    m_dirty = true;
+}
+
+void RScalarBar::setRange(float lo, float hi)
+{
+    if (lo != m_lo || hi != m_hi)
+    {
+        m_lo = lo;
+        m_hi = hi;
+        m_dirty = true;
+    }
+}
+
+QImage RScalarBar::renderImage() const
+{
+    QImage image(BAR_WIDTH, BAR_HEIGHT, QImage::Format_RGBA8888);
+    image.fill(Qt::transparent);
+    QPainter painter(&image);
+    painter.setRenderHint(QPainter::Antialiasing, true);
+
+    QFont font;
+    font.setPixelSize(15);
+    font.setBold(true);
+    painter.setFont(font);
+    painter.setPen(Qt::black);
+    painter.drawText(QRect(0, 4, BAR_WIDTH, 20), Qt::AlignHCenter | Qt::AlignVCenter, m_title);
+
+    font.setPixelSize(13);
+    font.setBold(false);
+    painter.setFont(font);
+    painter.drawText(
+        QRect(0, 26, BAR_WIDTH, 18),
+        Qt::AlignHCenter | Qt::AlignVCenter,
+        QString::fromStdString(m_colormap.name()));
+
+    // The color strip, painted from the same table the GPU LUT is baked
+    // from; the high end is at the top.
+    QRect const strip(STRIP_LEFT, STRIP_TOP, STRIP_WIDTH, STRIP_HEIGHT);
+    QImage const lut = m_colormap.image(STRIP_HEIGHT);
+    painter.save();
+    painter.translate(strip.left(), strip.top() + strip.height());
+    painter.rotate(-90.0);
+    painter.drawImage(QRect(0, 0, strip.height(), strip.width()), lut);
+    painter.restore();
+    painter.setPen(Qt::black);
+    painter.drawRect(strip.adjusted(0, 0, -1, -1));
+
+    int const label_left = strip.right() + 7;
+    int const label_width = BAR_WIDTH - label_left - 2;
+    painter.drawText(
+        QRect(label_left, strip.top() - 9, label_width, 18),
+        Qt::AlignLeft | Qt::AlignVCenter,
+        QString::number(m_hi, 'g', 4));
+    painter.drawText(
+        QRect(label_left, strip.bottom() - 8, label_width, 18),
+        Qt::AlignLeft | Qt::AlignVCenter,
+        QString::number(m_lo, 'g', 4));
+
+    painter.end();
+    return image;
+}
+
+void RScalarBar::prepare(
+    QRhi * rhi, QRhiRenderPassDescriptor * rpdesc, int sample_count, QRhiResourceUpdateBatch * batch)
+{
+    // A single quad over the whole (aspect-preserving) viewport; the image
+    // top row maps to the top of the viewport.
+    // clang-format off
+    float const quad[6 * 5] = {
+        // x, y, z, u, v
+        -1.0f, -1.0f, 0.0f, 0.0f, 1.0f,
+        1.0f, -1.0f, 0.0f, 1.0f, 1.0f,
+        1.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+        -1.0f, -1.0f, 0.0f, 0.0f, 1.0f,
+        1.0f, 1.0f, 0.0f, 1.0f, 0.0f,
+        -1.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+    };
+    // clang-format on
+    m_vbuf.reset(rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, sizeof(quad)));
+    m_vbuf->create();
+    batch->uploadStaticBuffer(m_vbuf.get(), quad);
+
+    m_ubuf.reset(rhi->newBuffer(QRhiBuffer::Dynamic, QRhiBuffer::UniformBuffer, 64 + 16));
+    m_ubuf->create();
+
+    m_sampler.reset(rhi->newSampler(
+        QRhiSampler::Linear,
+        QRhiSampler::Linear,
+        QRhiSampler::None,
+        QRhiSampler::ClampToEdge,
+        QRhiSampler::ClampToEdge));
+    m_sampler->create();
+
+    m_texture.reset(rhi->newTexture(QRhiTexture::RGBA8, QSize(BAR_WIDTH, BAR_HEIGHT)));
+    m_texture->create();
+    batch->uploadTexture(m_texture.get(), renderImage());
+    m_dirty = false;
+
+    m_srb.reset(rhi->newShaderResourceBindings());
+    m_srb->setBindings({
+        QRhiShaderResourceBinding::uniformBuffer(
+            0,
+            QRhiShaderResourceBinding::VertexStage | QRhiShaderResourceBinding::FragmentStage,
+            m_ubuf.get()),
+        QRhiShaderResourceBinding::sampledTexture(
+            1, QRhiShaderResourceBinding::FragmentStage, m_texture.get(), m_sampler.get()),
+    });
+    m_srb->create();
+
+    QRhiVertexInputLayout layout;
+    layout.setBindings({{5 * sizeof(float)}});
+    layout.setAttributes({
+        {0, 0, QRhiVertexInputAttribute::Float3, 0},
+        {0, 1, QRhiVertexInputAttribute::Float2, 3 * sizeof(float)},
+    });
+
+    // The bar draws over the scene: depth test off, alpha blend on so only
+    // the painted parts of the image cover the frame.
+    m_material = std::make_unique<RMaterial>(RMaterial::Kind::Textured);
+    m_pipeline.reset(m_material->buildPipeline(
+        rhi, m_srb.get(), rpdesc, layout, QRhiGraphicsPipeline::Triangles, sample_count, false, true));
+
+    m_ready = (nullptr != m_pipeline);
+}
+
+void RScalarBar::update(
+    QRhi * rhi,
+    QRhiRenderPassDescriptor * rpdesc,
+    int sample_count,
+    QSize pixel_size,
+    QRhiResourceUpdateBatch * batch)
+{
+    m_drawable = false;
+    if (!m_visible)
+    {
+        return;
+    }
+    if (!m_ready)
+    {
+        prepare(rhi, rpdesc, sample_count, batch);
+        if (!m_ready)
+        {
+            return;
+        }
+    }
+
+    if (m_dirty)
+    {
+        batch->uploadTexture(m_texture.get(), renderImage());
+        m_dirty = false;
+    }
+
+    // An aspect-preserving viewport centered on the right edge.
+    float const height = std::clamp(
+        0.62f * static_cast<float>(pixel_size.height()),
+        140.0f,
+        static_cast<float>(BAR_HEIGHT));
+    float const width = height * static_cast<float>(BAR_WIDTH) / static_cast<float>(BAR_HEIGHT);
+    float const x = static_cast<float>(pixel_size.width()) - width - VIEWPORT_MARGIN;
+    float const y = 0.5f * (static_cast<float>(pixel_size.height()) - height);
+    m_viewport = QRhiViewport(x, y, width, height);
+
+    QMatrix4x4 const mvp = rhi->clipSpaceCorrMatrix();
+    batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, mvp.constData());
+    float const white[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+    batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, white);
+
+    m_drawable = true;
+}
+
+void RScalarBar::draw(QRhiCommandBuffer * cb)
+{
+    if (!m_visible || !m_drawable)
+    {
+        return;
+    }
+
+    cb->setViewport(m_viewport);
+    cb->setGraphicsPipeline(m_pipeline.get());
+    cb->setShaderResources(m_srb.get());
+    QRhiCommandBuffer::VertexInput const quad_in(m_vbuf.get(), 0);
+    cb->setVertexInput(0, 1, &quad_in);
+    cb->draw(6);
+}
+
+void RScalarBar::release()
+{
+    m_pipeline.reset();
+    m_srb.reset();
+    m_texture.reset();
+    m_sampler.reset();
+    m_ubuf.reset();
+    m_vbuf.reset();
+    m_material.reset();
+    m_ready = false;
+    m_drawable = false;
+    m_dirty = true;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RScalarBar.hpp
+++ b/cpp/solvcon/pilot/RScalarBar.hpp
@@ -1,0 +1,105 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Edge-of-viewport scalar bar reporting the active colormap and range.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <solvcon/pilot/RColormap.hpp>
+#include <solvcon/pilot/RMaterial.hpp>
+
+#include <rhi/qrhi.h>
+
+#include <QImage>
+#include <QSize>
+#include <QString>
+
+#include <memory>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief An on-screen scalar bar reporting the active scalar-color mapping.
+ *
+ * Renders the title, the colormap name, the color strip (painted from the
+ * same RColormap table the GPU LUT is baked from), and the range end labels
+ * into one QImage, uploaded as a texture and drawn as a single overlay quad
+ * along the right edge of the viewport with the depth test off. The bar
+ * follows the gizmo pattern: resource updates happen in update() before the
+ * render pass, draw calls in draw() inside the pass.
+ *
+ * @ingroup group_domain
+ */
+class RScalarBar
+{
+
+public:
+
+    RScalarBar();
+    ~RScalarBar();
+
+    RScalarBar(RScalarBar const &) = delete;
+    RScalarBar & operator=(RScalarBar const &) = delete;
+
+    void setVisible(bool visible) { m_visible = visible; }
+    bool isVisible() const { return m_visible; }
+
+    void setTitle(std::string const & title);
+    void setColormap(RColormap colormap);
+    void setRange(float lo, float hi);
+
+    /// Create or update the device resources. Call before the render pass.
+    void update(
+        QRhi * rhi,
+        QRhiRenderPassDescriptor * rpdesc,
+        int sample_count,
+        QSize pixel_size,
+        QRhiResourceUpdateBatch * batch);
+
+    /// Record the draw calls into the active render pass.
+    void draw(QRhiCommandBuffer * cb);
+
+    /// Drop every device resource.
+    void release();
+
+private:
+
+    QImage renderImage() const;
+    void prepare(QRhi * rhi, QRhiRenderPassDescriptor * rpdesc, int sample_count, QRhiResourceUpdateBatch * batch);
+
+    bool m_visible = false;
+    bool m_ready = false;
+    bool m_drawable = false; ///< update() succeeded for this frame.
+    bool m_dirty = true; ///< The bar image needs a repaint and re-upload.
+
+    QString m_title;
+    RColormap m_colormap;
+    float m_lo = 0.0f;
+    float m_hi = 1.0f;
+
+    QRhiViewport m_viewport;
+
+    std::unique_ptr<RMaterial> m_material;
+    std::unique_ptr<QRhiBuffer> m_vbuf;
+    std::unique_ptr<QRhiBuffer> m_ubuf;
+    std::unique_ptr<QRhiSampler> m_sampler;
+    std::unique_ptr<QRhiTexture> m_texture;
+    std::unique_ptr<QRhiShaderResourceBindings> m_srb;
+    std::unique_ptr<QRhiGraphicsPipeline> m_pipeline;
+
+}; /* end class RScalarBar */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RScalarField.cpp
+++ b/cpp/solvcon/pilot/RScalarField.cpp
@@ -1,0 +1,185 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RScalarField.hpp> // Must be the first include.
+
+#include <limits>
+#include <stdexcept>
+#include <utility>
+
+namespace solvcon
+{
+
+RScalarField::RScalarField(
+    SimpleArray<float> const & vertices,
+    SimpleArray<float> const & scalars,
+    SimpleArray<uint32_t> const & indices,
+    RColormap colormap)
+    : m_colormap(std::move(colormap))
+{
+    // Require (nvert, 3) vertices, a matching (nvert,) scalar table, and
+    // (ntri, 3) triangle indices; mismatches would feed malformed buffers.
+    if (vertices.ndim() != 2 || vertices.shape(1) != 3)
+    {
+        throw std::invalid_argument("RScalarField: vertices must have shape (nvert, 3)");
+    }
+    if (scalars.ndim() != 1 || scalars.shape(0) != vertices.shape(0))
+    {
+        throw std::invalid_argument("RScalarField: scalars must have shape (nvert,) matching vertices");
+    }
+    if (indices.ndim() != 2 || indices.shape(1) != 3)
+    {
+        throw std::invalid_argument("RScalarField: indices must have shape (ntri, 3)");
+    }
+
+    size_t const nvert = vertices.shape(0);
+    size_t const ntri = indices.shape(0);
+    if (0 == nvert || 0 == ntri)
+    {
+        return;
+    }
+
+    float lo[3] = {
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max()};
+    float hi[3] = {
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest()};
+    float smin = std::numeric_limits<float>::max();
+    float smax = std::numeric_limits<float>::lowest();
+
+    m_interleaved.reserve(nvert * 4);
+    for (size_t i = 0; i < nvert; ++i)
+    {
+        for (size_t d = 0; d < 3; ++d)
+        {
+            float const v = vertices(i, d);
+            m_interleaved.push_back(v);
+            lo[d] = std::min(lo[d], v);
+            hi[d] = std::max(hi[d], v);
+        }
+        float const s = scalars(i);
+        m_interleaved.push_back(s);
+        smin = std::min(smin, s);
+        smax = std::max(smax, s);
+    }
+    m_lo = QVector3D(lo[0], lo[1], lo[2]);
+    m_hi = QVector3D(hi[0], hi[1], hi[2]);
+
+    m_indices.reserve(ntri * 3);
+    for (size_t i = 0; i < ntri; ++i)
+    {
+        for (size_t k = 0; k < 3; ++k)
+        {
+            uint32_t const idx = indices(i, k);
+            if (idx >= nvert)
+            {
+                throw std::invalid_argument("RScalarField: triangle index out of range [0, nvert)");
+            }
+            m_indices.push_back(idx);
+        }
+    }
+
+    m_range_lo = smin;
+    m_range_hi = smax;
+    packRange();
+}
+
+void RScalarField::setColormap(RColormap colormap)
+{
+    m_colormap = std::move(colormap);
+    m_lut_dirty = true;
+}
+
+void RScalarField::setScalarRange(float lo, float hi)
+{
+    if (hi < lo)
+    {
+        throw std::invalid_argument("RScalarField: scalar range must have hi >= lo");
+    }
+    m_range_lo = lo;
+    m_range_hi = hi;
+    packRange();
+}
+
+void RScalarField::packRange()
+{
+    float const span = m_range_hi - m_range_lo;
+    m_color = QVector4D(m_range_lo, (span > 0.0f) ? 1.0f / span : 0.0f, 0.0f, 0.0f);
+}
+
+QRhiVertexInputLayout RScalarField::vertexInputLayout() const
+{
+    QRhiVertexInputLayout layout;
+    layout.setBindings({{4 * sizeof(float)}});
+    layout.setAttributes({
+        {0, 0, QRhiVertexInputAttribute::Float3, 0},
+        {0, 1, QRhiVertexInputAttribute::Float, 3 * sizeof(float)},
+    });
+    return layout;
+}
+
+void RScalarField::createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch)
+{
+    if (0 == m_interleaved.size() || 0 == m_indices.size())
+    {
+        return;
+    }
+
+    quint32 const vbytes = static_cast<quint32>(m_interleaved.size() * sizeof(float));
+    m_vbuf.reset(rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::VertexBuffer, vbytes));
+    m_vbuf->create();
+    batch->uploadStaticBuffer(m_vbuf.get(), m_interleaved.data());
+    m_vertex_count = static_cast<quint32>(m_interleaved.size() / 4);
+
+    quint32 const ibytes = static_cast<quint32>(m_indices.size() * sizeof(uint32_t));
+    m_ibuf.reset(rhi->newBuffer(QRhiBuffer::Immutable, QRhiBuffer::IndexBuffer, ibytes));
+    m_ibuf->create();
+    batch->uploadStaticBuffer(m_ibuf.get(), m_indices.data());
+    m_index_count = static_cast<quint32>(m_indices.size());
+}
+
+void RScalarField::extendBindings(
+    QRhi * rhi, QRhiResourceUpdateBatch * batch, std::vector<QRhiShaderResourceBinding> & bindings)
+{
+    m_sampler.reset(rhi->newSampler(
+        QRhiSampler::Linear,
+        QRhiSampler::Linear,
+        QRhiSampler::None,
+        QRhiSampler::ClampToEdge,
+        QRhiSampler::ClampToEdge));
+    m_sampler->create();
+
+    m_lut.reset(rhi->newTexture(QRhiTexture::RGBA8, QSize(LUT_WIDTH, 1)));
+    m_lut->create();
+    batch->uploadTexture(m_lut.get(), m_colormap.image(LUT_WIDTH));
+    m_lut_dirty = false;
+
+    bindings.push_back(QRhiShaderResourceBinding::sampledTexture(
+        1, QRhiShaderResourceBinding::FragmentStage, m_lut.get(), m_sampler.get()));
+}
+
+void RScalarField::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const & view_proj)
+{
+    RDrawable::updateUniform(batch, view_proj);
+    if (m_lut_dirty && m_lut)
+    {
+        batch->uploadTexture(m_lut.get(), m_colormap.image(LUT_WIDTH));
+        m_lut_dirty = false;
+    }
+}
+
+void RScalarField::release()
+{
+    m_lut.reset();
+    m_sampler.reset();
+    RDrawable::release();
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RScalarField.hpp
+++ b/cpp/solvcon/pilot/RScalarField.hpp
@@ -1,0 +1,114 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * A drawable field of scalar-valued triangles colored through a GPU lookup
+ * table.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <solvcon/pilot/RColormap.hpp>
+#include <solvcon/pilot/RDrawable.hpp>
+
+#include <solvcon/solvcon.hpp>
+
+#include <QVector3D>
+
+namespace solvcon
+{
+
+/**
+ * @brief A field of triangles colored by a per-vertex scalar on the GPU.
+ *
+ * Takes a vertex table (nvert, 3), a matching scalar table (nvert,), and a
+ * triangle index table (ntri, 3). The scalar is uploaded interleaved with the
+ * positions as a vertex attribute; the fragment stage normalizes it by the
+ * mapping range and samples the colormap LUT texture, so recoloring by range
+ * or by map never touches the vertex data.
+ *
+ * The mapping range rides the color slot of the shared uniform block as
+ * (vmin, 1/(vmax - vmin)); see shaders/scalar.frag.
+ *
+ * @ingroup group_domain
+ */
+class RScalarField
+    : public RDrawable
+{
+
+public:
+
+    RScalarField(
+        SimpleArray<float> const & vertices,
+        SimpleArray<float> const & scalars,
+        SimpleArray<uint32_t> const & indices,
+        RColormap colormap);
+
+    bool hasGeometry() const { return m_indices.size() > 0; }
+
+    QVector3D bboxLo() const { return m_lo; }
+    QVector3D bboxHi() const { return m_hi; }
+
+    RColormap const & colormap() const { return m_colormap; }
+    /// Swap the lookup table; takes effect on the next frame.
+    void setColormap(RColormap colormap);
+
+    /// Set the value-to-[0, 1] mapping range for the LUT sampling.
+    void setScalarRange(float lo, float hi);
+    float rangeLo() const { return m_range_lo; }
+    float rangeHi() const { return m_range_hi; }
+
+    void updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const & view_proj) override;
+
+    void release() override;
+
+protected:
+
+    RMaterial::Kind materialKind() const override { return RMaterial::Kind::ScalarColor; }
+
+    QRhiGraphicsPipeline::Topology topology() const override { return QRhiGraphicsPipeline::Triangles; }
+
+    QRhiVertexInputLayout vertexInputLayout() const override;
+
+    void createGeometry(QRhi * rhi, QRhiResourceUpdateBatch * batch) override;
+
+    void extendBindings(
+        QRhi * rhi,
+        QRhiResourceUpdateBatch * batch,
+        std::vector<QRhiShaderResourceBinding> & bindings) override;
+
+private:
+
+    static constexpr int LUT_WIDTH = 256;
+
+    /// Pack (vmin, 1/span) into the color slot of the shared uniform block.
+    void packRange();
+
+    RColormap m_colormap;
+
+    // Interleaved [x, y, z, s] per vertex, captured at construction.
+    SimpleCollector<float> m_interleaved;
+    SimpleCollector<uint32_t> m_indices;
+
+    QVector3D m_lo;
+    QVector3D m_hi;
+
+    float m_range_lo = 0.0f;
+    float m_range_hi = 1.0f;
+    bool m_lut_dirty = false;
+
+    std::unique_ptr<QRhiTexture> m_lut;
+    std::unique_ptr<QRhiSampler> m_sampler;
+
+}; /* end class RScalarField */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/shaders/scalar.frag
+++ b/cpp/solvcon/pilot/shaders/scalar.frag
@@ -1,0 +1,21 @@
+#version 440
+
+layout(location = 0) in float v_scalar;
+
+layout(binding = 1) uniform sampler2D lut;
+
+layout(std140, binding = 0) uniform buf
+{
+    mat4 mvp;
+    // The scalar variant packs the mapping range into the color slot:
+    // (vmin, 1 / (vmax - vmin), unused, unused).
+    vec4 color;
+} ubuf;
+
+layout(location = 0) out vec4 fragColor;
+
+void main()
+{
+    float t = clamp((v_scalar - ubuf.color.x) * ubuf.color.y, 0.0, 1.0);
+    fragColor = texture(lut, vec2(t, 0.5));
+}

--- a/cpp/solvcon/pilot/shaders/scalar.vert
+++ b/cpp/solvcon/pilot/shaders/scalar.vert
@@ -1,0 +1,20 @@
+#version 440
+
+layout(location = 0) in vec3 position;
+layout(location = 1) in float scalar;
+
+layout(std140, binding = 0) uniform buf
+{
+    mat4 mvp;
+    // The scalar variant packs the mapping range into the color slot:
+    // (vmin, 1 / (vmax - vmin), unused, unused).
+    vec4 color;
+} ubuf;
+
+layout(location = 0) out float v_scalar;
+
+void main()
+{
+    v_scalar = scalar;
+    gl_Position = ubuf.mvp * vec4(position, 1.0);
+}

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -179,6 +179,41 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 py::arg("vertices"),
                 py::arg("colors"),
                 py::arg("indices"))
+            .def(
+                "updateScalarField",
+                &wrapped_type::updateScalarField,
+                py::arg("vertices"),
+                py::arg("scalars"),
+                py::arg("indices"))
+            .def_property(
+                "colormap",
+                [](wrapped_type & self)
+                {
+                    return self.colormap();
+                },
+                [](wrapped_type & self, std::string const & name)
+                {
+                    self.setColormap(name);
+                },
+                "Named colormap for the scalar field and the scalar bar: "
+                "\"viridis\", \"coolwarm\", \"jet\", or \"grayscale\".")
+            .def(
+                "setScalarRange",
+                &wrapped_type::setScalarRange,
+                py::arg("lo"),
+                py::arg("hi"))
+            .def_property_readonly(
+                "scalarRange",
+                [](wrapped_type & self)
+                {
+                    auto const range = self.scalarRange();
+                    return py::make_tuple(range.first, range.second);
+                })
+            .def("showScalarBar", &wrapped_type::showScalarBar, py::arg("show"))
+            .def(
+                "setScalarBarTitle",
+                &wrapped_type::setScalarBarTitle,
+                py::arg("title"))
             .def("showBoundary", &wrapped_type::showBoundary, py::arg("ibc"), py::arg("show"))
             .def("showFeatureEdges", &wrapped_type::showFeatureEdges, py::arg("show"))
             .def("showNormals", &wrapped_type::showNormals, py::arg("show"))

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -515,6 +515,217 @@ class RDomainWidgetFieldTC(unittest.TestCase):
             _update_field(widget, vertices, colors, indices)
 
 
+def _make_scalar_field():
+    """A quad (two triangles) with a left-to-right scalar ramp."""
+    import numpy as np
+    vertices = np.array([(0, 0, 0), (1, 0, 0), (1, 1, 0), (0, 1, 0)],
+                        dtype='float32')
+    scalars = np.array([0.0, 1.0, 1.0, 0.0], dtype='float32')
+    indices = np.array([(0, 1, 2), (0, 2, 3)], dtype='uint32')
+    return vertices, scalars, indices
+
+
+def _update_scalar_field(widget, vertices, scalars, indices):
+    """Wrap numpy tables in solvcon arrays and push them to the widget."""
+    core = solvcon.core
+    widget.updateScalarField(
+        core.SimpleArrayFloat32(array=vertices.astype('float32')),
+        core.SimpleArrayFloat32(array=scalars.astype('float32')),
+        core.SimpleArrayUint32(array=indices.astype('uint32')))
+
+
+def _count_saturated(image):
+    """Count strongly saturated pixels: a wide channel spread rejects the
+    white background, the black wireframe, and every gray."""
+    array = _rgb_array(image).astype('int16')
+    spread = array.max(axis=2) - array.min(axis=2)
+    return int((spread > 60).sum())
+
+
+def _count_dominant(image, channel):
+    """Count pixels where one channel dominates muted others; catches the
+    dark jet range ends ((0, 0, 0.5) and (0.5, 0, 0)) that the saturated
+    masks miss."""
+    array = _rgb_array(image)
+    others = [c for c in range(3) if c != channel]
+    mask = ((array[:, :, channel] > 100)
+            & (array[:, :, others[0]] < 80)
+            & (array[:, :, others[1]] < 80))
+    return int(mask.sum())
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetScalarFieldTC(unittest.TestCase):
+    """GPU LUT scalar coloring and the scalar bar."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_scalar_field_renders(self):
+        """updateScalarField draws triangles colored through the LUT."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        vertices, scalars, indices = _make_scalar_field()
+        _update_scalar_field(widget, vertices, scalars, indices)
+        image = _grab_or_skip(widget)
+        self.assertGreater(_count_colored(image), 0)
+
+    def test_scalar_field_is_swappable(self):
+        """A second updateScalarField replaces the first and still
+        renders."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        vertices, scalars, indices = _make_scalar_field()
+        _update_scalar_field(widget, vertices, scalars, indices)
+        _update_scalar_field(widget, vertices, scalars * 0.5, indices)
+        self.assertGreater(_count_colored(_grab_or_skip(widget)), 0)
+
+    def test_colormap_round_trip(self):
+        """The colormap defaults to viridis and switches by name."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.colormap, "viridis")
+        widget.colormap = "jet"
+        self.assertEqual(widget.colormap, "jet")
+
+    def test_colormap_rejects_unknown_name(self):
+        """An unknown colormap name raises instead of rendering garbage."""
+        widget = pilot.RDomainWidget()
+        with self.assertRaises(ValueError):
+            widget.colormap = "no-such-map"
+
+    def test_lut_matches_named_map_at_range_ends(self):
+        """With jet and a pinned [0, 2] range, a constant-0 field samples the
+        LUT start (dark blue) and a constant-2 field the LUT end (red)."""
+        import numpy as np
+        vertices, _, indices = _make_scalar_field()
+
+        low_widget = pilot.RDomainWidget()
+        low_widget.resize(320, 240)
+        low_widget.colormap = "jet"
+        low_widget.setScalarRange(0.0, 2.0)
+        _update_scalar_field(low_widget, vertices,
+                             np.zeros(4, dtype='float32'), indices)
+        low = _grab_or_skip(low_widget)
+        self.assertGreater(_count_dominant(low, 2), 100)
+        self.assertLess(_count_dominant(low, 0), 5)
+
+        high_widget = pilot.RDomainWidget()
+        high_widget.resize(320, 240)
+        high_widget.colormap = "jet"
+        high_widget.setScalarRange(0.0, 2.0)
+        _update_scalar_field(high_widget, vertices,
+                             np.full(4, 2.0, dtype='float32'), indices)
+        high = _grab_or_skip(high_widget)
+        self.assertGreater(_count_dominant(high, 0), 100)
+        self.assertLess(_count_dominant(high, 2), 5)
+
+    def test_grayscale_map_stays_gray(self):
+        """The grayscale map colors the ramp without any saturated pixel,
+        where a live swap to jet turns the quad saturated and red-ended.
+
+        Each state grabs a freshly configured widget once: a second grab
+        of a mutated widget is unreliable on the headless software
+        rasterizer (see test_color_field_is_swappable).
+        """
+        vertices, scalars, indices = _make_scalar_field()
+
+        gray_widget = pilot.RDomainWidget()
+        gray_widget.resize(320, 240)
+        gray_widget.colormap = "grayscale"
+        _update_scalar_field(gray_widget, vertices, scalars, indices)
+        gray_image = _grab_or_skip(gray_widget)
+        self.assertGreater(_count_colored(gray_image), 0)
+        self.assertLess(_count_saturated(gray_image), 5)
+
+        # Swap the map after the field exists so the grab exercises the
+        # live LUT re-upload; red-dominant pixels appear only under jet
+        # (the default viridis has none).
+        jet_widget = pilot.RDomainWidget()
+        jet_widget.resize(320, 240)
+        _update_scalar_field(jet_widget, vertices, scalars, indices)
+        jet_widget.colormap = "jet"
+        jet_image = _grab_or_skip(jet_widget)
+        self.assertGreater(_count_saturated(jet_image), 100)
+        self.assertGreater(_count_dominant(jet_image, 0), 50)
+
+    def test_scalar_range_defaults_to_data_range(self):
+        """Without setScalarRange the mapping spans the field data."""
+        import numpy as np
+        widget = pilot.RDomainWidget()
+        vertices, _, indices = _make_scalar_field()
+        scalars = np.array([2.0, 8.0, 8.0, 2.0], dtype='float32')
+        _update_scalar_field(widget, vertices, scalars, indices)
+        self.assertEqual(widget.scalarRange, (2.0, 8.0))
+
+    def test_scalar_range_pins_across_updates(self):
+        """setScalarRange overrides auto-ranging for later field updates."""
+        widget = pilot.RDomainWidget()
+        widget.setScalarRange(0.0, 10.0)
+        vertices, scalars, indices = _make_scalar_field()
+        _update_scalar_field(widget, vertices, scalars, indices)
+        self.assertEqual(widget.scalarRange, (0.0, 10.0))
+
+    def test_scalar_range_rejects_inverted_range(self):
+        """A hi below lo raises instead of feeding a negative span."""
+        widget = pilot.RDomainWidget()
+        with self.assertRaises(ValueError):
+            widget.setScalarRange(1.0, 0.0)
+
+    def test_scalar_field_rejects_mismatched_scalars(self):
+        """A scalar table shorter than the vertex table is rejected."""
+        import numpy as np
+        widget = pilot.RDomainWidget()
+        vertices, _, indices = _make_scalar_field()
+        with self.assertRaises(ValueError):
+            _update_scalar_field(widget, vertices,
+                                 np.zeros(3, dtype='float32'), indices)
+
+    def test_scalar_bar_hidden_by_default(self):
+        """Without showScalarBar an empty scene stays the white clear."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        image = _grab_or_skip(widget)
+        self.assertEqual(_count_foreground(image), 0)
+
+    def test_scalar_bar_renders_on_the_right(self):
+        """showScalarBar draws the colormap strip along the right edge."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.colormap = "jet"
+        widget.setScalarBarTitle("density")
+        widget.showScalarBar(True)
+        image = _grab_or_skip(widget)
+        array = _rgb_array(image).astype('int16')
+        spread = array.max(axis=2) - array.min(axis=2)
+        left, right = spread[:, :160], spread[:, 160:]
+        self.assertGreater(int((right > 60).sum()), 100)
+        self.assertEqual(int((left > 60).sum()), 0)
+
+    def test_scalar_bar_toggles_off(self):
+        """showScalarBar(False) clears the overlay again.
+
+        Each state grabs a fresh widget once (the double-grab caveat of
+        test_grayscale_map_stays_gray), and saturated pixels stand in for
+        the bar: an emptied frame can read back from the software
+        rasterizer as uniformly dark, which a white-difference count
+        would mistake for content."""
+        shown_widget = pilot.RDomainWidget()
+        shown_widget.resize(320, 240)
+        shown_widget.colormap = "jet"
+        shown_widget.showScalarBar(True)
+        shown = _count_saturated(_grab_or_skip(shown_widget))
+        self.assertGreater(shown, 100)
+
+        hidden_widget = pilot.RDomainWidget()
+        hidden_widget.resize(320, 240)
+        hidden_widget.colormap = "jet"
+        hidden_widget.showScalarBar(True)
+        hidden_widget.showScalarBar(False)
+        hidden = _count_saturated(_grab_or_skip(hidden_widget))
+        self.assertLess(hidden, shown * 0.1)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetOpacityTC(unittest.TestCase):
     """Adjustable per-drawable opacity for the wireframe and the surface."""


### PR DESCRIPTION
## Summary

Move scalar-to-color mapping onto the GPU and report it with an on-screen
scalar bar.

- `RColormap`: named 1D lookup tables (viridis, coolwarm, jet, grayscale)
  baked into a `QRhiTexture`.
- `RScalarField`: a drawable carrying a per-vertex scalar attribute that
  samples the LUT in the fragment stage; recoloring is a uniform update, the
  vertex data never moves.
- `RScalarBar`: an overlay reporting the map, range, and title.

Python: `updateScalarField`, the `colormap` property, `setScalarRange`,
`scalarRange`, `showScalarBar`, `setScalarBarTitle`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; new tests cover the mapping, ranging, errors, and the
  scalar bar.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
