### PR TITLE
Color the mesh by a categorical cell attribute

### DIFF
--- a/cpp/solvcon/pilot/RColormap.cpp
+++ b/cpp/solvcon/pilot/RColormap.cpp
@@ -67,6 +67,22 @@ constexpr float GRAYSCALE[] = {
     0.0f, 0.0f, 0.0f,
     1.0f, 1.0f, 1.0f};
 
+// A 12-color qualitative palette for categorical coloring: neighbors are
+// picked far apart in hue and value so adjacent categories stay distinct.
+constexpr float QUALITATIVE[] = {
+    0.90f, 0.10f, 0.10f,
+    0.12f, 0.47f, 0.71f,
+    0.17f, 0.63f, 0.17f,
+    1.00f, 0.50f, 0.05f,
+    0.58f, 0.40f, 0.74f,
+    0.55f, 0.34f, 0.29f,
+    0.89f, 0.47f, 0.76f,
+    0.50f, 0.50f, 0.50f,
+    0.74f, 0.74f, 0.13f,
+    0.09f, 0.75f, 0.81f,
+    0.10f, 0.10f, 0.55f,
+    0.60f, 0.85f, 0.20f};
+
 // clang-format on
 
 } /* end namespace */
@@ -99,6 +115,11 @@ RColormap RColormap::named(std::string const & name)
     throw std::invalid_argument(
         "RColormap: unknown colormap \"" + name +
         "\"; pick one of \"viridis\", \"coolwarm\", \"jet\", \"grayscale\"");
+}
+
+RColormap RColormap::categorical()
+{
+    return RColormap("categorical", QUALITATIVE, sizeof(QUALITATIVE) / sizeof(float) / 3);
 }
 
 QVector3D RColormap::sample(float t) const

--- a/cpp/solvcon/pilot/RColormap.hpp
+++ b/cpp/solvcon/pilot/RColormap.hpp
@@ -42,6 +42,10 @@ public:
     /// Throws std::invalid_argument for anything else.
     static RColormap named(std::string const & name);
 
+    /// A qualitative map for categorical coloring: a fixed set of visually
+    /// distinct colors. Used with an integer scalar over [0, ncat - 1].
+    static RColormap categorical();
+
     std::string const & name() const { return m_name; }
 
     /// Piecewise-linear sample of the ramp at @p t clamped to [0, 1].

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -300,6 +300,235 @@ void RDomainWidget::setScalarBarTitle(std::string const & title)
     update();
 }
 
+void RDomainWidget::colorByCellType()
+{
+    if (nullptr == m_mesh)
+    {
+        return;
+    }
+    StaticMesh const & mh = *m_mesh;
+    std::vector<int32_t> category;
+    if (3 == mh.ndim())
+    {
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        category.reserve(bndfcs.shape(0));
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            category.push_back(mh.cltpn(mh.fcicl(bndfcs(ibnd, 0))));
+        }
+    }
+    else
+    {
+        category.reserve(mh.ncell());
+        for (uint32_t icl = 0; icl < mh.ncell(); ++icl)
+        {
+            category.push_back(mh.cltpn(icl));
+        }
+    }
+    installCategoryField(category, "cell type");
+}
+
+void RDomainWidget::colorByCellGroup()
+{
+    if (nullptr == m_mesh)
+    {
+        return;
+    }
+    StaticMesh const & mh = *m_mesh;
+    std::vector<int32_t> category;
+    if (3 == mh.ndim())
+    {
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        category.reserve(bndfcs.shape(0));
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            category.push_back(mh.clgrp(mh.fcicl(bndfcs(ibnd, 0))));
+        }
+    }
+    else
+    {
+        category.reserve(mh.ncell());
+        for (uint32_t icl = 0; icl < mh.ncell(); ++icl)
+        {
+            category.push_back(mh.clgrp(icl));
+        }
+    }
+    installCategoryField(category, "cell group");
+}
+
+void RDomainWidget::colorByBoundary()
+{
+    if (nullptr == m_mesh)
+    {
+        return;
+    }
+    StaticMesh const & mh = *m_mesh;
+    SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+    std::vector<int32_t> category;
+    if (3 == mh.ndim())
+    {
+        // The 3D surface is the boundary shell, one primitive per boundary
+        // face, so the boundary set is the face's own set.
+        category.reserve(bndfcs.shape(0));
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            category.push_back(bndfcs(ibnd, 1));
+        }
+    }
+    else
+    {
+        // The 2D surface is the cells, so color each cell by a boundary set it
+        // owns; interior cells share one extra "none" category past the top set.
+        int32_t max_bc = -1;
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            max_bc = std::max(max_bc, bndfcs(ibnd, 1));
+        }
+        category.assign(mh.ncell(), max_bc + 1);
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            int32_t const icl = mh.fcicl(bndfcs(ibnd, 0));
+            if (icl >= 0 && static_cast<size_t>(icl) < category.size())
+            {
+                category[icl] = bndfcs(ibnd, 1);
+            }
+        }
+    }
+    installCategoryField(category, "boundary set");
+}
+
+void RDomainWidget::clearCellColoring()
+{
+    m_scene.removeDrawable(m_field);
+    m_field = nullptr;
+    m_scalar_field = nullptr;
+    m_has_field_bbox = false;
+    m_range_pinned = false;
+    m_scalar_bar.setVisible(false);
+    update();
+}
+
+void RDomainWidget::installCategoryField(
+    std::vector<int32_t> const & primitive_category, std::string const & title)
+{
+    if (nullptr == m_mesh)
+    {
+        return;
+    }
+    StaticMesh const & mh = *m_mesh;
+    uint32_t const ndim = mh.ndim();
+
+    // Dense-index the distinct categories so the colors pack from the palette
+    // start and the legend runs 0..ncat-1.
+    std::vector<int32_t> distinct(primitive_category);
+    std::sort(distinct.begin(), distinct.end());
+    distinct.erase(std::unique(distinct.begin(), distinct.end()), distinct.end());
+    if (distinct.empty())
+    {
+        return;
+    }
+    int const ncat = static_cast<int>(distinct.size());
+    auto dense = [&distinct](int32_t v) -> float
+    {
+        return static_cast<float>(
+            std::lower_bound(distinct.begin(), distinct.end(), v) - distinct.begin());
+    };
+
+    auto node_coord = [&mh, ndim](int32_t ind, uint32_t dim) -> float
+    { return (dim < ndim) ? static_cast<float>(mh.ndcrd(ind, dim)) : 0.0f; };
+
+    std::vector<float> verts; // x, y, z per vertex
+    std::vector<float> scals; // one category per vertex
+    std::vector<uint32_t> tris; // triangle indices
+
+    // Fan-triangulate one surface polygon, giving every emitted vertex the
+    // primitive's category so the whole face reads one flat color.
+    auto add_polygon = [&](auto node, int32_t nnd, float scalar)
+    {
+        for (int32_t k = 1; k + 1 < nnd; ++k)
+        {
+            int32_t const tri[3] = {node(0), node(k), node(k + 1)};
+            uint32_t const base = static_cast<uint32_t>(verts.size() / 3);
+            for (int32_t const ind : tri)
+            {
+                verts.push_back(node_coord(ind, 0));
+                verts.push_back(node_coord(ind, 1));
+                verts.push_back(node_coord(ind, 2));
+                scals.push_back(scalar);
+            }
+            tris.push_back(base + 0);
+            tris.push_back(base + 1);
+            tris.push_back(base + 2);
+        }
+    };
+
+    if (3 == ndim)
+    {
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        size_t const nprim = std::min(bndfcs.shape(0), primitive_category.size());
+        for (size_t ibnd = 0; ibnd < nprim; ++ibnd)
+        {
+            int32_t const ifc = bndfcs(ibnd, 0);
+            add_polygon(
+                [&mh, ifc](int32_t k)
+                { return mh.fcnds(ifc, k + 1); },
+                mh.fcnds(ifc, 0),
+                dense(primitive_category[ibnd]));
+        }
+    }
+    else
+    {
+        size_t const nprim = std::min(static_cast<size_t>(mh.ncell()), primitive_category.size());
+        for (uint32_t icl = 0; icl < nprim; ++icl)
+        {
+            add_polygon(
+                [&mh, icl](int32_t k)
+                { return mh.clnds(icl, k + 1); },
+                mh.clnds(icl, 0),
+                dense(primitive_category[icl]));
+        }
+    }
+
+    if (verts.empty())
+    {
+        return;
+    }
+
+    size_t const nvert = verts.size() / 3;
+    size_t const ntri = tris.size() / 3;
+    SimpleArray<float> va(std::vector<size_t>{nvert, 3});
+    SimpleArray<float> sa(std::vector<size_t>{nvert});
+    SimpleArray<uint32_t> ia(std::vector<size_t>{ntri, 3});
+    for (size_t i = 0; i < nvert; ++i)
+    {
+        va(i, 0) = verts[3 * i + 0];
+        va(i, 1) = verts[3 * i + 1];
+        va(i, 2) = verts[3 * i + 2];
+        sa(i) = scals[i];
+    }
+    for (size_t t = 0; t < ntri; ++t)
+    {
+        ia(t, 0) = tris[3 * t + 0];
+        ia(t, 1) = tris[3 * t + 1];
+        ia(t, 2) = tris[3 * t + 2];
+    }
+
+    m_colormap = RColormap::categorical();
+    float const hi = (ncat > 1) ? static_cast<float>(ncat - 1) : 1.0f;
+    auto field = std::make_unique<RScalarField>(va, sa, ia, m_colormap);
+    field->setScalarRange(0.0f, hi);
+    m_range_pinned = true;
+    m_range_lo = 0.0f;
+    m_range_hi = hi;
+    m_scalar_bar.setColormap(m_colormap);
+    m_scalar_bar.setRange(0.0f, hi);
+    m_scalar_bar.setTitle(title);
+    m_scalar_bar.setVisible(true);
+    RScalarField * scalar_field = field.get();
+    installField(std::move(field));
+    m_scalar_field = (m_field == scalar_field) ? scalar_field : nullptr;
+}
+
 void RDomainWidget::showBoundary(int ibc, bool show)
 {
     // Remove an existing highlight for this set so a re-show stays single and

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -32,6 +32,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 #include <utility>
 
 namespace solvcon
@@ -127,6 +128,15 @@ public:
     /// Show or hide a short arrow at every face center along its normal.
     void showNormals(bool show);
 
+    // Color the mesh cells by a categorical attribute through the qualitative
+    // colormap with a legend: element type, cell group, or boundary set. Each
+    // replaces the field with a per-cell-colored surface; clearCellColoring
+    // drops it.
+    void colorByCellType();
+    void colorByCellGroup();
+    void colorByBoundary();
+    void clearCellColoring();
+
     /// Frame the camera so the whole domain is in view.
     void fitCameraToScene();
 
@@ -185,6 +195,15 @@ private:
     /// scene around its bounding box.
     template <typename FieldT>
     void installField(std::unique_ptr<FieldT> field);
+
+    /// Build a categorical scalar field over the mesh surface primitives (2D
+    /// cells, or 3D boundary faces) from a per-primitive category value, and
+    /// install it colored through the qualitative colormap with a legend
+    /// titled @p title. @p primitive_category is indexed in the surface build
+    /// order.
+    void installCategoryField(
+        std::vector<int32_t> const & primitive_category,
+        std::string const & title);
 
     QRhi * m_rhi = nullptr; ///< Tracked to detect device changes.
     QRhiRenderPassDescriptor * m_rpdesc = nullptr; ///< Tracked to detect target changes.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -217,6 +217,25 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def("showBoundary", &wrapped_type::showBoundary, py::arg("ibc"), py::arg("show"))
             .def("showFeatureEdges", &wrapped_type::showFeatureEdges, py::arg("show"))
             .def("showNormals", &wrapped_type::showNormals, py::arg("show"))
+            .def(
+                "colorByCellType",
+                &wrapped_type::colorByCellType,
+                "Color the mesh by the cell element type through a discrete "
+                "colormap with a legend.")
+            .def(
+                "colorByCellGroup",
+                &wrapped_type::colorByCellGroup,
+                "Color the mesh by the cell group (clgrp) through a discrete "
+                "colormap with a legend.")
+            .def(
+                "colorByBoundary",
+                &wrapped_type::colorByBoundary,
+                "Color the mesh by boundary set through a discrete colormap "
+                "with a legend.")
+            .def(
+                "clearCellColoring",
+                &wrapped_type::clearCellColoring,
+                "Remove the categorical cell coloring and its legend.")
             .def("showAxis", &wrapped_type::showAxis, py::arg("show"))
             .def("fitCameraToScene", &wrapped_type::fitCameraToScene)
             .def_property(

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -847,6 +847,90 @@ class RDomainWidgetOverlayTC(unittest.TestCase):
         self.assertLess(_count_green(image), 5)
 
 
+def _distinct_field_colors(image):
+    """Count distinct saturated (non-black, non-white) colors, quantized.
+
+    The categorical coloring paints each cell category a distinct qualitative
+    color; this counts how many show. Near-white background and near-black
+    wireframe pixels are dropped so only the filled categories are counted.
+    """
+    import numpy as np
+    array = _rgb_array(image).astype('int16')
+    flat = array.reshape(-1, 3)
+    lo = flat.min(axis=1)
+    hi = flat.max(axis=1)
+    colored = flat[(hi < 230) & (lo > 25) & ((hi - lo) > 25)]
+    if colored.size == 0:
+        return 0
+    quant = colored // 40
+    return len(np.unique(quant, axis=0))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetCellColoringTC(unittest.TestCase):
+    """Categorical coloring of the mesh by a cell attribute."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_color_by_cell_type_shows_distinct_categories(self):
+        """The mixed 2D mesh (two triangles, one quad) colors its two element
+        types in distinct colors."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.showMeshStyle("wireframe", False)
+        widget.colorByCellType()
+        image = _grab_or_skip(widget)
+        self.assertGreaterEqual(_distinct_field_colors(image), 2)
+
+    def test_color_by_cell_group_renders(self):
+        """Coloring by cell group fills the mesh with colored pixels."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.showMeshStyle("wireframe", False)
+        widget.colorByCellGroup()
+        self.assertGreater(_count_colored(_grab_or_skip(widget)), 0)
+
+    def test_color_by_boundary_renders(self):
+        """Coloring by boundary set fills the mesh with colored pixels."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.showMeshStyle("wireframe", False)
+        widget.colorByBoundary()
+        self.assertGreater(_count_colored(_grab_or_skip(widget)), 0)
+
+    def test_clear_cell_coloring_removes_the_field(self):
+        """clearCellColoring drops the categorical field, leaving far fewer
+        colored pixels than while it was shown."""
+        colored = pilot.RDomainWidget()
+        colored.resize(320, 240)
+        colored.updateMesh(_make_2d_mesh())
+        colored.showMeshStyle("wireframe", False)
+        colored.colorByCellType()
+        shown = _count_colored(_grab_or_skip(colored))
+        self.assertGreater(shown, 0)
+
+        cleared = pilot.RDomainWidget()
+        cleared.resize(320, 240)
+        cleared.updateMesh(_make_2d_mesh())
+        cleared.showMeshStyle("wireframe", False)
+        cleared.colorByCellType()
+        cleared.clearCellColoring()
+        self.assertLess(_count_colored(_grab_or_skip(cleared)), shown)
+
+    def test_color_by_cell_type_without_mesh_is_noop(self):
+        """Coloring before a mesh loads is a harmless no-op, not a crash."""
+        widget = pilot.RDomainWidget()
+        widget.colorByCellType()
+        widget.colorByCellGroup()
+        widget.colorByBoundary()
+        widget.clearCellColoring()
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneTC(unittest.TestCase):
     """Scene framing and the fit-to-scene camera (step 4)."""


### PR DESCRIPTION
## Summary

Color the mesh surface by a categorical per-cell attribute through a discrete
colormap with a legend: element type (`cltpn`), cell group (`clgrp`), or
boundary set.

Each maps the distinct attribute values onto a qualitative colormap, one
color per category. `RColormap` gains a `categorical()` palette; the widget
builds a per-cell-flat scalar field over the surface primitives (2D cells or
the 3D boundary shell) and installs it with a pinned `[0, ncat-1]` range.

Python: `colorByCellType`, `colorByCellGroup`, `colorByBoundary`,
`clearCellColoring`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; new tests check distinct-category rendering, the group
  and boundary colorings, the clear, and the no-mesh no-op.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
