### PR TITLE
Add a trackball orbit style and orbit pivot control

### DIFF
--- a/cpp/solvcon/pilot/RCameraController.cpp
+++ b/cpp/solvcon/pilot/RCameraController.cpp
@@ -54,6 +54,20 @@ std::string RCameraController::modeName(Mode mode)
     }
 }
 
+RCameraController::OrbitStyle RCameraController::orbitStyleFromName(std::string const & name)
+{
+    if ("trackball" == name)
+    {
+        return OrbitStyle::Trackball;
+    }
+    return OrbitStyle::Turntable;
+}
+
+std::string RCameraController::orbitStyleName(OrbitStyle style)
+{
+    return (OrbitStyle::Trackball == style) ? "trackball" : "turntable";
+}
+
 QVector3D RCameraController::forward() const
 {
     QVector3D const dir = m_target - m_position;
@@ -110,7 +124,22 @@ QMatrix4x4 RCameraController::viewMatrix() const
 
 void RCameraController::rotate(float dx, float dy)
 {
-    if (Mode::Orbit == m_mode)
+    if (Mode::Orbit == m_mode && OrbitStyle::Trackball == m_orbit_style)
+    {
+        // Tumble freely: yaw about the current up axis and pitch about the
+        // right axis, then roll the up axis with the same rotation so the
+        // horizon is free to tilt. No pole guard, so the eye can pass over the
+        // top and keep going, the way a virtual-trackball drag does.
+        QVector3D const offset = m_position - m_target;
+        QQuaternion const yaw =
+            QQuaternion::fromAxisAndAngle(m_up, -dx * LOOK_DEGREES_PER_PIXEL);
+        QQuaternion const pitch =
+            QQuaternion::fromAxisAndAngle(rightAxis(), -dy * LOOK_DEGREES_PER_PIXEL);
+        QQuaternion const rot = yaw * pitch;
+        m_position = m_target + rot.rotatedVector(offset);
+        m_up = rot.rotatedVector(m_up).normalized();
+    }
+    else if (Mode::Orbit == m_mode)
     {
         // Swing the eye around the fixed target (the pivot): yaw about the up
         // axis and pitch about the right axis, applied to the eye offset with

--- a/cpp/solvcon/pilot/RCameraController.hpp
+++ b/cpp/solvcon/pilot/RCameraController.hpp
@@ -64,6 +64,27 @@ public:
     static Mode modeFromName(std::string const & name);
     static std::string modeName(Mode mode);
 
+    /**
+     * The orbit style. Turntable holds the up axis fixed so the horizon never
+     * rolls; Trackball tumbles freely, rolling the up axis with the drag.
+     *
+     * @ingroup group_domain
+     */
+    enum class OrbitStyle
+    {
+        Turntable,
+        Trackball,
+    };
+
+    void setOrbitStyle(OrbitStyle style) { m_orbit_style = style; }
+    OrbitStyle orbitStyle() const { return m_orbit_style; }
+    static OrbitStyle orbitStyleFromName(std::string const & name);
+    static std::string orbitStyleName(OrbitStyle style);
+
+    /// Set the orbit pivot: the point the Orbit mode swings the eye around.
+    /// The eye stays put, so the next drag rotates about the new center.
+    void setPivot(QVector3D const & pivot) { m_target = pivot; }
+
     /// Frame the camera onto the bounding box [lo, hi] for an @p ndim domain
     /// at the given viewport @p aspect (width / height).
     void fitToBoundingBox(QVector3D const & lo, QVector3D const & hi, uint32_t ndim, float aspect);
@@ -109,6 +130,7 @@ private:
     QVector3D rightAxis() const;
 
     Mode m_mode = Mode::Orbit; ///< Default; a 2D domain switches to PanZoom.
+    OrbitStyle m_orbit_style = OrbitStyle::Turntable; ///< Default orbit style.
 
     QVector3D m_position{0.0f, 0.0f, 1.0f};
     QVector3D m_target{0.0f, 0.0f, 0.0f};

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -834,6 +834,31 @@ std::string RDomainWidget::projection() const
     return m_scene.projectionName();
 }
 
+void RDomainWidget::setOrbitStyle(std::string const & name)
+{
+    m_scene.camera().setOrbitStyle(RCameraController::orbitStyleFromName(name));
+    update();
+}
+
+std::string RDomainWidget::orbitStyle() const
+{
+    return RCameraController::orbitStyleName(m_scene.camera().orbitStyle());
+}
+
+void RDomainWidget::setPivot(float x, float y, float z)
+{
+    m_scene.camera().setPivot(QVector3D(x, y, z));
+    update();
+}
+
+void RDomainWidget::frameSelected()
+{
+    // No selection exists yet (it arrives with picking), so frame the whole
+    // scene.
+    m_scene.fitCameraToScene(viewportAspect());
+    update();
+}
+
 void RDomainWidget::setCameraMode(std::string const & name)
 {
     m_scene.camera().setMode(RCameraController::modeFromName(name));

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -159,6 +159,17 @@ public:
     void setProjection(std::string const & name);
     std::string projection() const;
 
+    /// Select the orbit style: "turntable" (up axis fixed, horizon level) or
+    /// "trackball" (free tumble that can roll the horizon).
+    void setOrbitStyle(std::string const & name);
+    std::string orbitStyle() const;
+
+    /// Set the orbit pivot, the point the orbit swings the eye around.
+    void setPivot(float x, float y, float z);
+
+    /// Recenter and frame the whole scene (the selection once picking lands).
+    void frameSelected();
+
     /// Show or hide the orientation-guide triad in the corner.
     void showAxis(bool show);
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -275,6 +275,35 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 "Projection: \"auto\" (orthographic 2D, perspective 3D), "
                 "\"parallel\", or \"perspective\".")
             .def_property(
+                "orbitStyle",
+                [](wrapped_type & self)
+                {
+                    return self.orbitStyle();
+                },
+                [](wrapped_type & self, std::string const & name)
+                {
+                    self.setOrbitStyle(name);
+                },
+                "Orbit style: \"turntable\" (up axis fixed) or \"trackball\" "
+                "(free tumble that can roll the horizon).")
+            .def(
+                "setOrbitStyle",
+                &wrapped_type::setOrbitStyle,
+                py::arg("name"),
+                "Select the orbit style: \"turntable\" or \"trackball\".")
+            .def(
+                "setPivot",
+                &wrapped_type::setPivot,
+                py::arg("x"),
+                py::arg("y"),
+                py::arg("z"),
+                "Set the orbit pivot, the point the orbit swings the eye "
+                "around.")
+            .def(
+                "frameSelected",
+                &wrapped_type::frameSelected,
+                "Recenter and frame the whole scene.")
+            .def_property(
                 "cameraMode",
                 [](wrapped_type & self)
                 {

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1077,6 +1077,75 @@ class RDomainWidgetViewPresetTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetTrackballTC(unittest.TestCase):
+    """Trackball orbit style and orbit pivot control."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_orbit_style_round_trip(self):
+        """The orbit style defaults to turntable and switches to trackball."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.orbitStyle, "turntable")
+        widget.orbitStyle = "trackball"
+        self.assertEqual(widget.orbitStyle, "trackball")
+        widget.setOrbitStyle("turntable")
+        self.assertEqual(widget.orbitStyle, "turntable")
+
+    def test_turntable_keeps_the_horizon_level(self):
+        """Turntable orbit holds the up axis fixed through a drag."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        widget.fitCameraToScene()
+        up0 = tuple(widget.cameraUp)
+        widget.rotateCamera(40.0, 30.0)
+        for a, b in zip(up0, tuple(widget.cameraUp)):
+            self.assertAlmostEqual(a, b, places=4)
+
+    def test_trackball_rolls_the_horizon(self):
+        """Trackball orbit rolls the up axis with the drag, so the horizon is
+        free to tilt (unlike the turntable)."""
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        widget.fitCameraToScene()
+        widget.orbitStyle = "trackball"
+        up0 = tuple(widget.cameraUp)
+        widget.rotateCamera(40.0, 30.0)
+        up1 = tuple(widget.cameraUp)
+        self.assertTrue(any(abs(a - b) > 1e-3 for a, b in zip(up0, up1)))
+
+    def test_set_pivot_moves_the_center_of_rotation(self):
+        """Setting the pivot moves the orbit target there, and orbiting then
+        keeps the eye's distance to that new pivot."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+        widget.setPivot(1.0, 2.0, 3.0)
+        self.assertEqual(tuple(widget.cameraTarget), (1.0, 2.0, 3.0))
+
+        def radius():
+            p = tuple(widget.cameraPosition)
+            t = tuple(widget.cameraTarget)
+            return math.sqrt(sum((a - b) ** 2 for a, b in zip(p, t)))
+
+        before = radius()
+        widget.rotateCamera(20.0, 10.0)
+        self.assertAlmostEqual(before, radius(), places=4)
+
+    def test_frame_selected_frames_the_scene(self):
+        """frameSelected recenters and frames the scene so it renders."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_3d_mesh())
+        widget.frameSelected()
+        self.assertGreater(_count_foreground(_grab_or_skip(widget)), 0)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneTC(unittest.TestCase):
     """Scene framing and the fit-to-scene camera (step 4)."""
 


### PR DESCRIPTION
## Summary

Add a free trackball orbit beside the turntable and let the orbit pivot move
off the scene center.

The turntable holds the up axis level; the trackball rolls the up axis with
the drag so the eye can tumble freely over the top. `setPivot` points the
orbit at an explicit center, keeping the eye put so the next drag swings
around the new point.

Python: the `orbitStyle` property, `setOrbitStyle`, `setPivot`,
`frameSelected`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; tests check the style round trip, that the turntable
  keeps the up axis level while the trackball rolls it, and that a set pivot
  becomes the center of rotation.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
