### PR TITLE
Map the mouse the Blender way and add orbit refinements

### DIFF
--- a/cpp/solvcon/pilot/RCameraController.cpp
+++ b/cpp/solvcon/pilot/RCameraController.cpp
@@ -122,54 +122,58 @@ QMatrix4x4 RCameraController::viewMatrix() const
     return view;
 }
 
-void RCameraController::rotate(float dx, float dy)
+void RCameraController::orbitBy(float yaw_deg, float pitch_deg)
 {
-    if (Mode::Orbit == m_mode && OrbitStyle::Trackball == m_orbit_style)
+    if (OrbitStyle::Trackball == m_orbit_style)
     {
         // Tumble freely: yaw about the current up axis and pitch about the
         // right axis, then roll the up axis with the same rotation so the
         // horizon is free to tilt. No pole guard, so the eye can pass over the
         // top and keep going, the way a virtual-trackball drag does.
         QVector3D const offset = m_position - m_target;
-        QQuaternion const yaw =
-            QQuaternion::fromAxisAndAngle(m_up, -dx * LOOK_DEGREES_PER_PIXEL);
+        QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, yaw_deg);
         QQuaternion const pitch =
-            QQuaternion::fromAxisAndAngle(rightAxis(), -dy * LOOK_DEGREES_PER_PIXEL);
+            QQuaternion::fromAxisAndAngle(rightAxis(), pitch_deg);
         QQuaternion const rot = yaw * pitch;
         m_position = m_target + rot.rotatedVector(offset);
         m_up = rot.rotatedVector(m_up).normalized();
+        return;
     }
-    else if (Mode::Orbit == m_mode)
+
+    // Turntable: swing the eye around the fixed target, up axis held so the
+    // horizon never rolls.
+    QVector3D const offset = m_position - m_target;
+    QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, yaw_deg);
+    QQuaternion const pitch = QQuaternion::fromAxisAndAngle(rightAxis(), pitch_deg);
+    QVector3D rotated = (yaw * pitch).rotatedVector(offset);
+    // Avoid gimbal lock: do not let the eye-to-target direction reach the up
+    // axis (which would degenerate the right axis and flip the view). Drop the
+    // pitch if it would push past the pole, but always ease away.
+    QVector3D const up = m_up.normalized();
+    float const limit = std::cos(qDegreesToRadians(1.0f));
+    float const aligned = std::abs(QVector3D::dotProduct(rotated.normalized(), up));
+    float const aligned0 = std::abs(QVector3D::dotProduct(offset.normalized(), up));
+    if (aligned > limit && aligned > aligned0)
     {
-        // Swing the eye around the fixed target (the pivot): yaw about the up
-        // axis and pitch about the right axis, applied to the eye offset with
-        // the target held put. The up axis stays fixed, so the horizon never
-        // rolls (a turntable orbit). This mirrors the FirstPerson rotation,
-        // which instead holds the eye and swings the target.
-        QVector3D const offset = m_position - m_target;
-        QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, -dx * LOOK_DEGREES_PER_PIXEL);
-        QQuaternion const pitch = QQuaternion::fromAxisAndAngle(rightAxis(), -dy * LOOK_DEGREES_PER_PIXEL);
-        QVector3D rotated = (yaw * pitch).rotatedVector(offset);
-        // Avoid gimbal lock: do not let the eye-to-target direction reach the
-        // up axis (which would degenerate the right axis and flip the view).
-        // Drop the pitch if it would push past the pole, but always ease away.
-        QVector3D const up = m_up.normalized();
-        float const limit = std::cos(qDegreesToRadians(1.0f));
-        float const aligned = std::abs(QVector3D::dotProduct(rotated.normalized(), up));
-        float const aligned0 = std::abs(QVector3D::dotProduct(offset.normalized(), up));
-        if (aligned > limit && aligned > aligned0)
-        {
-            rotated = yaw.rotatedVector(offset);
-        }
-        m_position = m_target + rotated;
+        rotated = yaw.rotatedVector(offset);
+    }
+    m_position = m_target + rotated;
+}
+
+void RCameraController::rotate(float dx, float dy)
+{
+    float const scale = LOOK_DEGREES_PER_PIXEL * m_orbit_sensitivity;
+    if (Mode::Orbit == m_mode)
+    {
+        orbitBy(-dx * scale, -dy * scale);
     }
     else if (Mode::FirstPerson == m_mode)
     {
         // Look around in place: yaw about the up axis, pitch about the right
         // axis, keeping the eye fixed and swinging the target.
         QVector3D const f0 = forward();
-        QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, -dx * LOOK_DEGREES_PER_PIXEL);
-        QQuaternion const pitch = QQuaternion::fromAxisAndAngle(rightAxis(), -dy * LOOK_DEGREES_PER_PIXEL);
+        QQuaternion const yaw = QQuaternion::fromAxisAndAngle(m_up, -dx * scale);
+        QQuaternion const pitch = QQuaternion::fromAxisAndAngle(rightAxis(), -dy * scale);
         QVector3D dir = (yaw * pitch).rotatedVector(f0).normalized();
         // Avoid gimbal lock: do not let the view direction reach the up axis
         // (which would degenerate the right axis and flip the view). Drop the

--- a/cpp/solvcon/pilot/RCameraController.hpp
+++ b/cpp/solvcon/pilot/RCameraController.hpp
@@ -85,6 +85,14 @@ public:
     /// The eye stays put, so the next drag rotates about the new center.
     void setPivot(QVector3D const & pivot) { m_target = pivot; }
 
+    /// Scale the rotate/look speed. A positive factor only; ignored otherwise.
+    void setOrbitSensitivity(float factor) { m_orbit_sensitivity = (factor > 0.0f) ? factor : m_orbit_sensitivity; }
+    float orbitSensitivity() const { return m_orbit_sensitivity; }
+
+    /// Orbit by a fixed number of degrees, a discrete step independent of the
+    /// per-pixel drag scaling (what a numpad-style fixed rotation drives).
+    void orbitStep(float yaw_deg, float pitch_deg) { orbitBy(yaw_deg, pitch_deg); }
+
     /// Frame the camera onto the bounding box [lo, hi] for an @p ndim domain
     /// at the given viewport @p aspect (width / height).
     void fitToBoundingBox(QVector3D const & lo, QVector3D const & hi, uint32_t ndim, float aspect);
@@ -128,9 +136,14 @@ private:
 
     QVector3D forward() const;
     QVector3D rightAxis() const;
+    /// Rotate the eye around the target by explicit degrees, honoring the
+    /// turntable/trackball style. Shared by the drag rotate and the discrete
+    /// step.
+    void orbitBy(float yaw_deg, float pitch_deg);
 
     Mode m_mode = Mode::Orbit; ///< Default; a 2D domain switches to PanZoom.
     OrbitStyle m_orbit_style = OrbitStyle::Turntable; ///< Default orbit style.
+    float m_orbit_sensitivity = 1.0f; ///< Rotate/look speed multiplier.
 
     QVector3D m_position{0.0f, 0.0f, 1.0f};
     QVector3D m_target{0.0f, 0.0f, 0.0f};

--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -859,6 +859,30 @@ void RDomainWidget::frameSelected()
     update();
 }
 
+void RDomainWidget::setNavigationMapping(std::string const & name)
+{
+    if ("default" == name || "blender" == name)
+    {
+        m_nav_mapping = name;
+    }
+}
+
+std::string RDomainWidget::navigationMapping() const
+{
+    return m_nav_mapping;
+}
+
+void RDomainWidget::setOrbitSensitivity(float factor)
+{
+    m_scene.camera().setOrbitSensitivity(factor);
+}
+
+void RDomainWidget::orbitStep(float yaw_deg, float pitch_deg)
+{
+    m_scene.camera().orbitStep(yaw_deg, pitch_deg);
+    update();
+}
+
 void RDomainWidget::setCameraMode(std::string const & name)
 {
     m_scene.camera().setMode(RCameraController::modeFromName(name));
@@ -930,7 +954,55 @@ void RDomainWidget::pinchCamera(float factor)
 void RDomainWidget::mousePressEvent(QMouseEvent * event)
 {
     m_last_mouse_pos = event->position().toPoint();
-    m_panning = (event->button() != Qt::LeftButton);
+
+    Qt::MouseButton const btn = event->button();
+    Qt::KeyboardModifiers const mods = event->modifiers();
+
+    if ("blender" == m_nav_mapping)
+    {
+        // Middle drives navigation; Alt+left aliases it for a trackpad with no
+        // middle button. Shift pans, Ctrl zooms, Alt recenters the pivot, and
+        // a plain middle drag orbits. Left alone still orbits (a convenience
+        // over Blender's select), right pans.
+        bool const navigate = (Qt::MiddleButton == btn) ||
+                              (Qt::LeftButton == btn && (mods & Qt::AltModifier));
+        if (navigate)
+        {
+            if (mods & Qt::ShiftModifier)
+            {
+                m_drag_action = DragAction::Pan;
+            }
+            else if (mods & Qt::ControlModifier)
+            {
+                m_drag_action = DragAction::Zoom;
+            }
+            else if ((mods & Qt::AltModifier) && Qt::MiddleButton == btn)
+            {
+                // Recenter the orbit pivot on the scene, then orbit about it.
+                m_scene.camera().setPivot(m_scene.boundingBoxCenter());
+                m_drag_action = DragAction::Rotate;
+            }
+            else
+            {
+                m_drag_action = DragAction::Rotate;
+            }
+        }
+        else if (Qt::LeftButton == btn)
+        {
+            m_drag_action = DragAction::Rotate;
+        }
+        else
+        {
+            m_drag_action = DragAction::Pan;
+        }
+    }
+    else
+    {
+        // Default mapping: left rotates, other buttons pan.
+        m_drag_action = (Qt::LeftButton == btn) ? DragAction::Rotate
+                                                : DragAction::Pan;
+    }
+    update();
 }
 
 void RDomainWidget::mouseMoveEvent(QMouseEvent * event)
@@ -943,20 +1015,25 @@ void RDomainWidget::mouseMoveEvent(QMouseEvent * event)
     float const dx = static_cast<float>(pos.x() - m_last_mouse_pos.x());
     float const dy = static_cast<float>(pos.y() - m_last_mouse_pos.y());
     m_last_mouse_pos = pos;
-    if (m_panning)
+    switch (m_drag_action)
     {
+    case DragAction::Pan:
         m_scene.camera().pan(dx, dy);
-    }
-    else
-    {
+        break;
+    case DragAction::Zoom:
+        // Dragging up zooms in; scale the pixel delta to wheel-notch units.
+        m_scene.camera().zoom(-dy * 0.05f);
+        break;
+    default:
         m_scene.camera().rotate(dx, dy);
+        break;
     }
     update();
 }
 
 void RDomainWidget::mouseReleaseEvent(QMouseEvent *)
 {
-    m_panning = false;
+    m_drag_action = DragAction::Rotate;
 }
 
 void RDomainWidget::wheelEvent(QWheelEvent * event)

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -170,6 +170,19 @@ public:
     /// Recenter and frame the whole scene (the selection once picking lands).
     void frameSelected();
 
+    /// Choose the mouse navigation mapping: "default" (left rotates, other
+    /// buttons pan) or "blender" (middle orbits; Shift+middle pans;
+    /// Ctrl+middle zooms; Alt+middle recenters the pivot; Alt+left aliases the
+    /// middle button for trackpads without one).
+    void setNavigationMapping(std::string const & name);
+    std::string navigationMapping() const;
+
+    /// Scale the orbit/look speed for drags.
+    void setOrbitSensitivity(float factor);
+
+    /// Orbit by a fixed number of degrees, a discrete step.
+    void orbitStep(float yaw_deg, float pitch_deg);
+
     /// Show or hide the orientation-guide triad in the corner.
     void showAxis(bool show);
 
@@ -284,7 +297,17 @@ private:
     std::shared_ptr<StaticMesh> m_mesh;
 
     QPoint m_last_mouse_pos; ///< Last cursor position during a drag.
-    bool m_panning = false; ///< A non-left-button drag pans in both modes.
+
+    /// What the current drag does, chosen at press time from the button and
+    /// modifiers through the active navigation mapping.
+    enum class DragAction
+    {
+        Rotate,
+        Pan,
+        Zoom,
+    };
+    DragAction m_drag_action = DragAction::Rotate;
+    std::string m_nav_mapping = "blender"; ///< "default" or "blender".
 
 }; /* end class RDomainWidget */
 

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -75,6 +75,9 @@ public:
     void extendBoundingBox(QVector3D const & lo, QVector3D const & hi);
 
     bool hasBoundingBox() const { return m_has_bbox; }
+    QVector3D boundingBoxLo() const { return m_bbox_lo; }
+    QVector3D boundingBoxHi() const { return m_bbox_hi; }
+    QVector3D boundingBoxCenter() const { return (m_bbox_lo + m_bbox_hi) * 0.5f; }
 
     void setDimension(uint32_t ndim) { m_ndim = ndim; }
     uint32_t dimension() const { return m_ndim; }

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -304,6 +304,34 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 &wrapped_type::frameSelected,
                 "Recenter and frame the whole scene.")
             .def_property(
+                "navigationMapping",
+                [](wrapped_type & self)
+                {
+                    return self.navigationMapping();
+                },
+                [](wrapped_type & self, std::string const & name)
+                {
+                    self.setNavigationMapping(name);
+                },
+                "Mouse navigation mapping: \"default\" (left rotates) or "
+                "\"blender\" (middle orbits; Shift/Ctrl/Alt+middle pan/zoom/"
+                "pivot; Alt+left aliases middle).")
+            .def(
+                "setNavigationMapping",
+                &wrapped_type::setNavigationMapping,
+                py::arg("name"))
+            .def(
+                "setOrbitSensitivity",
+                &wrapped_type::setOrbitSensitivity,
+                py::arg("factor"),
+                "Scale the orbit/look drag speed.")
+            .def(
+                "orbitStep",
+                &wrapped_type::orbitStep,
+                py::arg("yaw_deg"),
+                py::arg("pitch_deg"),
+                "Orbit by a fixed number of degrees (a discrete step).")
+            .def_property(
                 "cameraMode",
                 [](wrapped_type & self)
                 {

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1146,6 +1146,71 @@ class RDomainWidgetTrackballTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetNavMapTC(unittest.TestCase):
+    """Blender-style navigation mapping, discrete steps, and sensitivity.
+
+    The button-to-action routing lives in the C++ mouse handlers; a
+    pybind-created widget is not a PySide QObject that ``sendEvent`` accepts,
+    so the routing is exercised live, and the selectable mapping, the discrete
+    orbit step, and the sensitivity scaling are covered here through the
+    Python API.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_navigation_mapping_round_trip(self):
+        """The mapping defaults to blender and switches to default."""
+        widget = pilot.RDomainWidget()
+        self.assertEqual(widget.navigationMapping, "blender")
+        widget.navigationMapping = "default"
+        self.assertEqual(widget.navigationMapping, "default")
+        widget.setNavigationMapping("blender")
+        self.assertEqual(widget.navigationMapping, "blender")
+
+    def test_orbit_step_rotates_a_fixed_angle(self):
+        """A discrete orbit step swings the eye about the target by a fixed
+        angle, keeping the target and the eye-to-target distance."""
+        import math
+        widget = pilot.RDomainWidget()
+        widget.updateMesh(_make_3d_mesh())
+        widget.cameraMode = "orbit"
+
+        def radius():
+            p = tuple(widget.cameraPosition)
+            t = tuple(widget.cameraTarget)
+            return math.sqrt(sum((a - b) ** 2 for a, b in zip(p, t)))
+
+        t0 = tuple(widget.cameraTarget)
+        p0 = tuple(widget.cameraPosition)
+        r0 = radius()
+        widget.orbitStep(30.0, 0.0)
+        for a, b in zip(t0, tuple(widget.cameraTarget)):
+            self.assertAlmostEqual(a, b, places=4)
+        self.assertAlmostEqual(r0, radius(), places=4)
+        self.assertTrue(
+            any(abs(a - b) > 1e-3
+                for a, b in zip(p0, tuple(widget.cameraPosition))))
+
+    def test_orbit_sensitivity_scales_rotation(self):
+        """A higher sensitivity sweeps the eye further for the same drag."""
+        import math
+
+        def swept(factor):
+            widget = pilot.RDomainWidget()
+            widget.updateMesh(_make_3d_mesh())
+            widget.cameraMode = "orbit"
+            widget.setOrbitSensitivity(factor)
+            p0 = tuple(widget.cameraPosition)
+            widget.rotateCamera(20.0, 0.0)
+            p1 = tuple(widget.cameraPosition)
+            return math.sqrt(sum((a - b) ** 2 for a, b in zip(p0, p1)))
+
+        self.assertGreater(swept(2.0), swept(1.0))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneTC(unittest.TestCase):
     """Scene framing and the fit-to-scene camera (step 4)."""
 


### PR DESCRIPTION
## Summary

Add a Blender-style navigation mapping and the orbit refinements that go with
it. The mapping is selectable: "default" keeps left-rotate, other-buttons-pan,
while "blender" routes the middle button (middle orbits, Shift+middle pans,
Ctrl+middle zooms, Alt+middle recenters the pivot), with Alt+left aliasing the
middle button for a trackpad without one.

The camera gains a rotate/look sensitivity and a discrete fixed-angle orbit
step (the drag rotate and the step share one `orbitBy`).

Python: the `navigationMapping` property, `setNavigationMapping`,
`setOrbitSensitivity`, `orbitStep`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; tests cover the mapping selection, the discrete step,
  and the sensitivity scaling. The button routing lives in the C++ handlers
  and is exercised live (a pybind widget is not a PySide QObject `sendEvent`
  accepts).

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
