### PR TITLE
Pick mesh cells, nodes, and faces from the viewer

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -17,6 +17,7 @@
 #include <QMouseEvent>
 #include <QNativeGestureEvent>
 #include <QPinchGesture>
+#include <QVector4D>
 #include <QWheelEvent>
 
 #include <algorithm>
@@ -808,6 +809,406 @@ void RDomainWidget::showNormals(bool show)
         }
     }
 
+    update();
+}
+
+namespace
+{
+
+/// Moeller-Trumbore ray/triangle intersection. On a hit, @p t is the ray
+/// parameter of the front-facing or back-facing intersection.
+bool ray_triangle(
+    QVector3D const & o,
+    QVector3D const & d,
+    QVector3D const & a,
+    QVector3D const & b,
+    QVector3D const & c,
+    float & t)
+{
+    QVector3D const e1 = b - a;
+    QVector3D const e2 = c - a;
+    QVector3D const pvec = QVector3D::crossProduct(d, e2);
+    float const det = QVector3D::dotProduct(e1, pvec);
+    if (std::abs(det) < 1.0e-12f)
+    {
+        return false;
+    }
+    float const inv = 1.0f / det;
+    QVector3D const tvec = o - a;
+    float const u = QVector3D::dotProduct(tvec, pvec) * inv;
+    if (u < 0.0f || u > 1.0f)
+    {
+        return false;
+    }
+    QVector3D const qvec = QVector3D::crossProduct(tvec, e1);
+    float const v = QVector3D::dotProduct(d, qvec) * inv;
+    if (v < 0.0f || u + v > 1.0f)
+    {
+        return false;
+    }
+    t = QVector3D::dotProduct(e2, qvec) * inv;
+    return t > 0.0f;
+}
+
+/// Even-odd point-in-polygon test in the xy plane.
+bool point_in_polygon(std::vector<QVector3D> const & poly, float px, float py)
+{
+    bool inside = false;
+    size_t const n = poly.size();
+    for (size_t i = 0, j = n - 1; i < n; j = i++)
+    {
+        float const yi = poly[i].y();
+        float const yj = poly[j].y();
+        if ((yi > py) != (yj > py))
+        {
+            float const xcross =
+                (poly[j].x() - poly[i].x()) * (py - yi) / (yj - yi) + poly[i].x();
+            if (px < xcross)
+            {
+                inside = !inside;
+            }
+        }
+    }
+    return inside;
+}
+
+} /* end namespace */
+
+bool RDomainWidget::computePickRay(int x, int y, QVector3D & origin, QVector3D & dir) const
+{
+    int const w = width();
+    int const h = height();
+    if (w <= 0 || h <= 0)
+    {
+        return false;
+    }
+    QMatrix4x4 const vp = m_scene.viewProjection(QSize(w, h), nullptr);
+    bool ok = false;
+    QMatrix4x4 const inv = vp.inverted(&ok);
+    if (!ok)
+    {
+        return false;
+    }
+    float const ndc_x = 2.0f * static_cast<float>(x) / static_cast<float>(w) - 1.0f;
+    float const ndc_y = 1.0f - 2.0f * static_cast<float>(y) / static_cast<float>(h);
+    QVector4D near_h = inv * QVector4D(ndc_x, ndc_y, -1.0f, 1.0f);
+    QVector4D far_h = inv * QVector4D(ndc_x, ndc_y, 1.0f, 1.0f);
+    if (qFuzzyIsNull(near_h.w()) || qFuzzyIsNull(far_h.w()))
+    {
+        return false;
+    }
+    origin = near_h.toVector3DAffine();
+    dir = (far_h.toVector3DAffine() - origin).normalized();
+    return true;
+}
+
+RDomainWidget::PickResult RDomainWidget::pickCell(int x, int y)
+{
+    PickResult result;
+    if (nullptr == m_mesh)
+    {
+        return result;
+    }
+    QVector3D origin;
+    QVector3D dir;
+    if (!computePickRay(x, y, origin, dir))
+    {
+        return result;
+    }
+    StaticMesh const & mh = *m_mesh;
+    uint32_t const ndim = mh.ndim();
+    auto coord = [&mh, ndim](int32_t ind, uint32_t dm) -> float
+    { return (dm < ndim) ? static_cast<float>(mh.ndcrd(ind, dm)) : 0.0f; };
+
+    int32_t hit_cell = -1;
+    if (3 == ndim)
+    {
+        SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+        float best = std::numeric_limits<float>::max();
+        for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+        {
+            int32_t const ifc = bndfcs(ibnd, 0);
+            int32_t const nnd = mh.fcnds(ifc, 0);
+            QVector3D const a(
+                coord(mh.fcnds(ifc, 1), 0), coord(mh.fcnds(ifc, 1), 1), coord(mh.fcnds(ifc, 1), 2));
+            for (int32_t k = 1; k + 1 < nnd; ++k)
+            {
+                int32_t const nb = mh.fcnds(ifc, k + 1);
+                int32_t const nc = mh.fcnds(ifc, k + 2);
+                QVector3D const b(coord(nb, 0), coord(nb, 1), coord(nb, 2));
+                QVector3D const c(coord(nc, 0), coord(nc, 1), coord(nc, 2));
+                float t = 0.0f;
+                if (ray_triangle(origin, dir, a, b, c, t) && t < best)
+                {
+                    best = t;
+                    hit_cell = mh.fcicl(ifc);
+                }
+            }
+        }
+    }
+    else
+    {
+        if (std::abs(dir.z()) > 1.0e-9f)
+        {
+            float const t = -origin.z() / dir.z();
+            if (t >= 0.0f)
+            {
+                QVector3D const hit = origin + dir * t;
+                for (uint32_t icl = 0; icl < mh.ncell() && hit_cell < 0; ++icl)
+                {
+                    int32_t const nnd = mh.clnds(icl, 0);
+                    std::vector<QVector3D> poly(static_cast<size_t>(nnd));
+                    for (int32_t k = 0; k < nnd; ++k)
+                    {
+                        int32_t const nd = mh.clnds(icl, k + 1);
+                        poly[k] = QVector3D(coord(nd, 0), coord(nd, 1), 0.0f);
+                    }
+                    if (point_in_polygon(poly, hit.x(), hit.y()))
+                    {
+                        hit_cell = static_cast<int32_t>(icl);
+                    }
+                }
+            }
+        }
+    }
+
+    if (hit_cell < 0)
+    {
+        return result;
+    }
+    result.kind = "cell";
+    result.id = hit_cell;
+    result.type = mh.cltpn(hit_cell);
+    result.measure = static_cast<double>(mh.clvol(hit_cell));
+    result.centroid = QVector3D(
+        static_cast<float>(mh.clcnd(hit_cell, 0)),
+        static_cast<float>(mh.clcnd(hit_cell, 1)),
+        (3 == ndim) ? static_cast<float>(mh.clcnd(hit_cell, 2)) : 0.0f);
+
+    // The picked cell's bounding box, for framing and the highlight.
+    QVector3D lo(result.centroid);
+    QVector3D hi(result.centroid);
+    int32_t const nnd = mh.clnds(hit_cell, 0);
+    for (int32_t k = 0; k < nnd; ++k)
+    {
+        int32_t const nd = mh.clnds(hit_cell, k + 1);
+        QVector3D const p(coord(nd, 0), coord(nd, 1), coord(nd, 2));
+        lo = QVector3D(std::min(lo.x(), p.x()), std::min(lo.y(), p.y()), std::min(lo.z(), p.z()));
+        hi = QVector3D(std::max(hi.x(), p.x()), std::max(hi.y(), p.y()), std::max(hi.z(), p.z()));
+    }
+    setSelection("cell", hit_cell, lo, hi);
+    return result;
+}
+
+RDomainWidget::PickResult RDomainWidget::pickNode(int x, int y)
+{
+    PickResult result;
+    if (nullptr == m_mesh)
+    {
+        return result;
+    }
+    QVector3D origin;
+    QVector3D dir;
+    if (!computePickRay(x, y, origin, dir))
+    {
+        return result;
+    }
+    StaticMesh const & mh = *m_mesh;
+    uint32_t const ndim = mh.ndim();
+
+    float best = std::numeric_limits<float>::max();
+    int32_t hit = -1;
+    QVector3D hit_pos;
+    for (uint32_t ind = 0; ind < mh.nnode(); ++ind)
+    {
+        QVector3D const p(
+            static_cast<float>(mh.ndcrd(ind, 0)),
+            static_cast<float>(mh.ndcrd(ind, 1)),
+            (3 == ndim) ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f);
+        // Perpendicular distance from the node to the pick ray.
+        QVector3D const w = p - origin;
+        QVector3D const closest = origin + dir * QVector3D::dotProduct(w, dir);
+        float const dist = (p - closest).length();
+        if (dist < best)
+        {
+            best = dist;
+            hit = static_cast<int32_t>(ind);
+            hit_pos = p;
+        }
+    }
+    if (hit < 0)
+    {
+        return result;
+    }
+    result.kind = "node";
+    result.id = hit;
+    result.centroid = hit_pos;
+    setSelection("node", hit, hit_pos, hit_pos);
+    return result;
+}
+
+RDomainWidget::PickResult RDomainWidget::pickFace(int x, int y)
+{
+    PickResult result;
+    if (nullptr == m_mesh)
+    {
+        return result;
+    }
+    QVector3D origin;
+    QVector3D dir;
+    if (!computePickRay(x, y, origin, dir))
+    {
+        return result;
+    }
+    StaticMesh const & mh = *m_mesh;
+    if (3 != mh.ndim())
+    {
+        // A 2D domain's faces are edges, not a ray-castable surface.
+        return result;
+    }
+    auto coord = [&mh](int32_t ind, uint32_t dm) -> float
+    { return static_cast<float>(mh.ndcrd(ind, dm)); };
+
+    SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+    float best = std::numeric_limits<float>::max();
+    int32_t hit_face = -1;
+    for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+    {
+        int32_t const ifc = bndfcs(ibnd, 0);
+        int32_t const nnd = mh.fcnds(ifc, 0);
+        QVector3D const a(
+            coord(mh.fcnds(ifc, 1), 0), coord(mh.fcnds(ifc, 1), 1), coord(mh.fcnds(ifc, 1), 2));
+        for (int32_t k = 1; k + 1 < nnd; ++k)
+        {
+            int32_t const nb = mh.fcnds(ifc, k + 1);
+            int32_t const nc = mh.fcnds(ifc, k + 2);
+            QVector3D const b(coord(nb, 0), coord(nb, 1), coord(nb, 2));
+            QVector3D const c(coord(nc, 0), coord(nc, 1), coord(nc, 2));
+            float t = 0.0f;
+            if (ray_triangle(origin, dir, a, b, c, t) && t < best)
+            {
+                best = t;
+                hit_face = ifc;
+            }
+        }
+    }
+    if (hit_face < 0)
+    {
+        return result;
+    }
+    result.kind = "face";
+    result.id = hit_face;
+    result.measure = static_cast<double>(mh.fcara(hit_face));
+    result.centroid = QVector3D(
+        static_cast<float>(mh.fccnd(hit_face, 0)),
+        static_cast<float>(mh.fccnd(hit_face, 1)),
+        static_cast<float>(mh.fccnd(hit_face, 2)));
+    setSelection("face", hit_face, result.centroid, result.centroid);
+    return result;
+}
+
+void RDomainWidget::setSelection(
+    std::string const & kind, int id, QVector3D const & lo, QVector3D const & hi)
+{
+    m_scene.removeDrawable(m_selection);
+    m_selection = nullptr;
+    m_selection_kind = kind;
+    m_selection_id = id;
+    m_selection_lo = lo;
+    m_selection_hi = hi;
+    m_has_selection = true;
+
+    // A picked cell gets a bright surface highlight; a node or face records the
+    // selection point without one.
+    if ("cell" == kind && nullptr != m_mesh)
+    {
+        StaticMesh const & mh = *m_mesh;
+        uint32_t const ndim = mh.ndim();
+        auto coord = [&mh, ndim](int32_t ind, uint32_t dm) -> float
+        { return (dm < ndim) ? static_cast<float>(mh.ndcrd(ind, dm)) : 0.0f; };
+
+        std::vector<float> verts;
+        std::vector<uint32_t> tris;
+        auto add_polygon = [&](auto node, int32_t nnd)
+        {
+            for (int32_t k = 1; k + 1 < nnd; ++k)
+            {
+                int32_t const tri[3] = {node(0), node(k), node(k + 1)};
+                uint32_t const base = static_cast<uint32_t>(verts.size() / 3);
+                for (int32_t const ind : tri)
+                {
+                    verts.push_back(coord(ind, 0));
+                    verts.push_back(coord(ind, 1));
+                    verts.push_back(coord(ind, 2));
+                }
+                tris.push_back(base + 0);
+                tris.push_back(base + 1);
+                tris.push_back(base + 2);
+            }
+        };
+        if (3 == ndim)
+        {
+            SimpleArray<int32_t> const & bndfcs = mh.bndfcs();
+            for (size_t ibnd = 0; ibnd < bndfcs.shape(0); ++ibnd)
+            {
+                int32_t const ifc = bndfcs(ibnd, 0);
+                if (mh.fcicl(ifc) == id)
+                {
+                    add_polygon(
+                        [&mh, ifc](int32_t k)
+                        { return mh.fcnds(ifc, k + 1); },
+                        mh.fcnds(ifc, 0));
+                }
+            }
+        }
+        else
+        {
+            add_polygon(
+                [&mh, id](int32_t k)
+                { return mh.clnds(id, k + 1); },
+                mh.clnds(id, 0));
+        }
+
+        if (!verts.empty())
+        {
+            size_t const nvert = verts.size() / 3;
+            size_t const ntri = tris.size() / 3;
+            SimpleArray<float> va(std::vector<size_t>{nvert, 3});
+            SimpleArray<float> ca(std::vector<size_t>{nvert, 3});
+            SimpleArray<uint32_t> ia(std::vector<size_t>{ntri, 3});
+            for (size_t i = 0; i < nvert; ++i)
+            {
+                va(i, 0) = verts[3 * i + 0];
+                va(i, 1) = verts[3 * i + 1];
+                va(i, 2) = verts[3 * i + 2];
+                ca(i, 0) = 1.0f;
+                ca(i, 1) = 0.9f;
+                ca(i, 2) = 0.1f;
+            }
+            for (size_t t = 0; t < ntri; ++t)
+            {
+                ia(t, 0) = tris[3 * t + 0];
+                ia(t, 1) = tris[3 * t + 1];
+                ia(t, 2) = tris[3 * t + 2];
+            }
+            auto highlight = std::make_unique<RField>(va, ca, ia);
+            if (highlight->hasGeometry())
+            {
+                m_selection = highlight.get();
+                m_scene.addDrawable(std::move(highlight));
+            }
+        }
+    }
+    update();
+}
+
+void RDomainWidget::clearSelection()
+{
+    m_scene.removeDrawable(m_selection);
+    m_selection = nullptr;
+    m_has_selection = false;
+    m_selection_kind = "none";
+    m_selection_id = -1;
     update();
 }
 

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -129,6 +129,31 @@ public:
     /// Show or hide a short arrow at every face center along its normal.
     void showNormals(bool show);
 
+    /// The result of a pick: the entity kind ("cell", "node", "face", or
+    /// "none" for a miss), its id, its element type (for a cell), a measure
+    /// (cell volume or face area), and its centroid.
+    struct PickResult
+    {
+        std::string kind = "none";
+        int id = -1;
+        int type = -1;
+        double measure = 0.0;
+        QVector3D centroid;
+
+        bool hit() const { return "none" != kind; }
+    };
+
+    // Pick the entity under the widget pixel (x, y): a cell (by ray-cast
+    // against the surface), the nearest node, or the nearest boundary face.
+    // The picked entity is highlighted and kept as the selection.
+    PickResult pickCell(int x, int y);
+    PickResult pickNode(int x, int y);
+    PickResult pickFace(int x, int y);
+
+    /// Drop the current selection and its highlight.
+    void clearSelection();
+    bool hasSelection() const { return m_has_selection; }
+
     // Color the mesh cells by a categorical attribute through the qualitative
     // colormap with a legend: element type, cell group, or boundary set. Each
     // replaces the field with a per-cell-colored surface; clearCellColoring
@@ -265,6 +290,15 @@ private:
         std::vector<float> & scals,
         std::vector<uint32_t> & tris) const;
 
+    /// Back-project the widget pixel (x, y) to a world-space ray. Returns
+    /// false when the viewport or the view-projection is degenerate.
+    bool computePickRay(int x, int y, QVector3D & origin, QVector3D & dir) const;
+
+    /// Highlight the picked cell (its surface triangles) and record it as the
+    /// selection with its bounding box; a kind other than "cell" records the
+    /// selection point without a surface highlight.
+    void setSelection(std::string const & kind, int id, QVector3D const & lo, QVector3D const & hi);
+
     QRhi * m_rhi = nullptr; ///< Tracked to detect device changes.
     QRhiRenderPassDescriptor * m_rpdesc = nullptr; ///< Tracked to detect target changes.
     int m_sample_count = 0; ///< Tracked to detect MSAA changes.
@@ -285,6 +319,13 @@ private:
     bool m_show_wireframe = true;
     bool m_show_points = false;
     bool m_mesh_shown = true; ///< The showMesh toggle, applied atop the styles.
+
+    RDrawable * m_selection = nullptr; ///< Highlight of the picked entity.
+    bool m_has_selection = false;
+    std::string m_selection_kind = "none";
+    int m_selection_id = -1;
+    QVector3D m_selection_lo;
+    QVector3D m_selection_hi;
 
     RColormap m_colormap = RColormap::named("viridis");
     bool m_range_pinned = false; ///< setScalarRange overrides auto-ranging.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -123,6 +123,23 @@ namespace solvcon
 namespace python
 {
 
+/// Convert a pick result to a Python dict, or None on a miss.
+static pybind11::object pick_to_py(RDomainWidget::PickResult const & r)
+{
+    namespace py = pybind11;
+    if (!r.hit())
+    {
+        return py::none();
+    }
+    py::dict d;
+    d["kind"] = r.kind;
+    d["id"] = r.id;
+    d["type"] = r.type;
+    d["measure"] = r.measure;
+    d["centroid"] = py::make_tuple(r.centroid.x(), r.centroid.y(), r.centroid.z());
+    return d;
+}
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
     : public WrapBase<WrapRDomainWidget, RDomainWidget, QPointer<RDomainWidget>>
 {
@@ -217,6 +234,37 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def("showBoundary", &wrapped_type::showBoundary, py::arg("ibc"), py::arg("show"))
             .def("showFeatureEdges", &wrapped_type::showFeatureEdges, py::arg("show"))
             .def("showNormals", &wrapped_type::showNormals, py::arg("show"))
+            .def(
+                "pickCell",
+                [](wrapped_type & self, int x, int y)
+                {
+                    return pick_to_py(self.pickCell(x, y));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                "Pick the cell under the pixel; a dict with id, type, measure, "
+                "and centroid, or None on a miss.")
+            .def(
+                "pickNode",
+                [](wrapped_type & self, int x, int y)
+                {
+                    return pick_to_py(self.pickNode(x, y));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                "Pick the nearest node to the pixel ray; a dict or None.")
+            .def(
+                "pickFace",
+                [](wrapped_type & self, int x, int y)
+                {
+                    return pick_to_py(self.pickFace(x, y));
+                },
+                py::arg("x"),
+                py::arg("y"),
+                "Pick the boundary face under the pixel (3D only); a dict or "
+                "None.")
+            .def("clearSelection", &wrapped_type::clearSelection)
+            .def_property_readonly("hasSelection", &wrapped_type::hasSelection)
             .def(
                 "colorByCellType",
                 &wrapped_type::colorByCellType,

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1145,6 +1145,110 @@ class RDomainWidgetTrackballTC(unittest.TestCase):
         self.assertGreater(_count_foreground(_grab_or_skip(widget)), 0)
 
 
+def _make_single_quad_2d():
+    """A single unit quad filling [0, 1] x [0, 1], so the framed view center
+    lands squarely inside cell 0."""
+    core = solvcon.core
+    Q = core.StaticMesh.QUADRILATERAL
+    mh = core.StaticMesh(ndim=2, nnode=4, nface=0, ncell=1)
+    mh.ndcrd.ndarray[:, :] = [(0, 0), (1, 0), (1, 1), (0, 1)]
+    mh.cltpn.ndarray[:] = [Q]
+    mh.clnds.ndarray[:, :5] = [(4, 0, 1, 2, 3)]
+    mh.build_interior()
+    mh.build_boundary()
+    mh.build_ghost()
+    return mh
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetPickTC(unittest.TestCase):
+    """Picking a cell, node, or face and reporting its geometry.
+
+    Picking back-projects the click through the same view-projection the
+    renderer uses, entirely on the CPU, so these tests are exact and need no
+    rendered frame.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_pick_cell_returns_id_and_geometry(self):
+        """Clicking the framed view center of a unit quad picks cell 0 and
+        reports its type, area, and centroid."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_single_quad_2d())
+        widget.fitCameraToScene()
+        r = widget.pickCell(100, 100)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["kind"], "cell")
+        self.assertEqual(r["id"], 0)
+        self.assertAlmostEqual(r["measure"], 1.0, places=4)
+        cx, cy, _cz = r["centroid"]
+        self.assertAlmostEqual(cx, 0.5, places=3)
+        self.assertAlmostEqual(cy, 0.5, places=3)
+        self.assertTrue(widget.hasSelection)
+
+    def test_pick_outside_returns_none(self):
+        """A click on the background (a corner, outside the framed quad) picks
+        nothing."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_single_quad_2d())
+        widget.fitCameraToScene()
+        self.assertIsNone(widget.pickCell(0, 0))
+
+    def test_pick_without_mesh_returns_none(self):
+        """Picking before a mesh loads returns None, not a crash."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        self.assertIsNone(widget.pickCell(100, 100))
+        self.assertIsNone(widget.pickNode(100, 100))
+        self.assertIsNone(widget.pickFace(100, 100))
+
+    def test_pick_node_returns_a_node(self):
+        """Picking near the view center returns the nearest node."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_single_quad_2d())
+        widget.fitCameraToScene()
+        r = widget.pickNode(100, 100)
+        self.assertIsNotNone(r)
+        self.assertEqual(r["kind"], "node")
+        self.assertIn(r["id"], (0, 1, 2, 3))
+
+    def test_pick_face_on_3d_mesh(self):
+        """A ray that meets the 3D shell picks a boundary face with an area."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_3d_mesh())
+        widget.fitCameraToScene()
+        hit = None
+        for yy in range(20, 200, 15):
+            for xx in range(20, 200, 15):
+                r = widget.pickFace(xx, yy)
+                if r is not None:
+                    hit = r
+                    break
+            if hit is not None:
+                break
+        self.assertIsNotNone(hit, "no boundary face was picked over the shell")
+        self.assertEqual(hit["kind"], "face")
+        self.assertGreater(hit["measure"], 0.0)
+
+    def test_clear_selection(self):
+        """clearSelection drops the pick and its highlight."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_single_quad_2d())
+        widget.fitCameraToScene()
+        widget.pickCell(100, 100)
+        self.assertTrue(widget.hasSelection)
+        widget.clearSelection()
+        self.assertFalse(widget.hasSelection)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetNavMapTC(unittest.TestCase):
     """Blender-style navigation mapping, discrete steps, and sensitivity.


### PR DESCRIPTION
## Summary

Add interactive picking: a click resolves to the cell, node, or face under the
cursor, reports its identity and geometry, and highlights it.

Picking back-projects the pixel through the same view-projection the renderer
uses and casts the ray on the CPU: a cell is the nearest surface hit (the
boundary shell in 3D, a point-in-cell test in 2D), a node is the nearest node
to the ray, a face is the nearest boundary face. Results carry the id, element
type, a measure (cell volume or face area), and the centroid, and record the
entity as the selection with its bounding box. A picked cell gets a bright
surface highlight.

Python: `pickCell`, `pickNode`, `pickFace`, `clearSelection`, `hasSelection`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; picking is pure CPU, so the tests are exact: they pick a
  known pixel of a unit quad and check the returned id and geometry, and cover
  the miss, no-mesh, node, and 3D-face cases.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
