### PR TITLE
Add zoom-to-selection and camera reset

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -1303,8 +1303,26 @@ void RDomainWidget::setPivot(float x, float y, float z)
 
 void RDomainWidget::frameSelected()
 {
-    // No selection exists yet (it arrives with picking), so frame the whole
-    // scene.
+    zoomToSelection();
+}
+
+void RDomainWidget::zoomToSelection()
+{
+    if (m_has_selection)
+    {
+        m_scene.frameBox(m_selection_lo, m_selection_hi, viewportAspect());
+    }
+    else
+    {
+        m_scene.fitCameraToScene(viewportAspect());
+    }
+    update();
+}
+
+void RDomainWidget::resetCamera()
+{
+    m_scene.setProjection("auto");
+    m_scene.camera().setOrbitStyle(RCameraController::OrbitStyle::Turntable);
     m_scene.fitCameraToScene(viewportAspect());
     update();
 }

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -206,6 +206,14 @@ public:
     /// Recenter and frame the whole scene (the selection once picking lands).
     void frameSelected();
 
+    /// Frame the current selection (from a pick), or the whole scene when
+    /// nothing is selected.
+    void zoomToSelection();
+
+    /// Reset the camera to the fit-to-scene default: auto projection,
+    /// turntable orbit, the whole scene framed.
+    void resetCamera();
+
     /// Choose the mouse navigation mapping: "default" (left rotates, other
     /// buttons pan) or "blender" (middle orbits; Shift+middle pans;
     /// Ctrl+middle zooms; Alt+middle recenters the pivot; Alt+left aliases the

--- a/cpp/solvcon/pilot/RScene.cpp
+++ b/cpp/solvcon/pilot/RScene.cpp
@@ -82,6 +82,16 @@ float RScene::boundingRadius() const
     return (radius > 0.0f) ? radius : 1.0f;
 }
 
+float RScene::framingRadius() const
+{
+    if (m_has_frame_box)
+    {
+        float const radius = (m_frame_hi - m_frame_lo).length() * 0.5f;
+        return (radius > 0.0f) ? radius : 1.0f;
+    }
+    return boundingRadius();
+}
+
 void RScene::fitCameraToScene(float aspect)
 {
     if (!m_has_bbox)
@@ -91,7 +101,16 @@ void RScene::fitCameraToScene(float aspect)
         m_camera.setUp(QVector3D(0.0f, 1.0f, 0.0f));
         return;
     }
+    m_has_frame_box = false;
     m_camera.fitToBoundingBox(m_bbox_lo, m_bbox_hi, m_ndim, aspect);
+}
+
+void RScene::frameBox(QVector3D const & lo, QVector3D const & hi, float aspect)
+{
+    m_frame_lo = lo;
+    m_frame_hi = hi;
+    m_has_frame_box = true;
+    m_camera.fitToBoundingBox(lo, hi, m_ndim, aspect);
 }
 
 void RScene::setProjection(std::string const & name)
@@ -195,7 +214,7 @@ QMatrix4x4 RScene::viewProjection(QSize pixel_size, QRhi * rhi) const
     }
 
     float const aspect = static_cast<float>(pixel_size.width()) / static_cast<float>(pixel_size.height());
-    float const radius = boundingRadius();
+    float const radius = framingRadius();
 
     QMatrix4x4 const view = m_camera.viewMatrix();
     float distance = (m_camera.position() - m_camera.target()).length();

--- a/cpp/solvcon/pilot/RScene.hpp
+++ b/cpp/solvcon/pilot/RScene.hpp
@@ -105,8 +105,12 @@ public:
     RCameraController const & camera() const { return m_camera; }
 
     /// Frame the camera so the whole bounding box is in view at the given
-    /// viewport @p aspect (width / height).
+    /// viewport @p aspect (width / height). Resets any zoomed-in framing.
     void fitCameraToScene(float aspect);
+
+    /// Frame the camera on an arbitrary box [lo, hi] (a picked selection, say)
+    /// so the projection sizes to that box, not the whole scene.
+    void frameBox(QVector3D const & lo, QVector3D const & hi, float aspect);
 
     /// The model-view-projection for the framed scene at the given viewport.
     /// 2D domains use an orthographic projection, 3D domains a perspective
@@ -116,6 +120,9 @@ public:
 private:
 
     float boundingRadius() const;
+    /// Radius the projection sizes to: the zoomed framing box when one is set,
+    /// otherwise the whole-scene bounding box.
+    float framingRadius() const;
 
     std::vector<std::unique_ptr<RDrawable>> m_drawables;
 
@@ -124,6 +131,12 @@ private:
     bool m_has_bbox = false;
     uint32_t m_ndim = 0;
     Projection m_projection = Projection::Auto;
+
+    // A zoomed-in framing box (e.g. a picked selection); when set, the
+    // projection sizes to it instead of the whole scene.
+    QVector3D m_frame_lo;
+    QVector3D m_frame_hi;
+    bool m_has_frame_box = false;
 
     RCameraController m_camera;
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -379,7 +379,17 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
             .def(
                 "frameSelected",
                 &wrapped_type::frameSelected,
-                "Recenter and frame the whole scene.")
+                "Frame the current selection, or the whole scene when nothing "
+                "is selected.")
+            .def(
+                "zoomToSelection",
+                &wrapped_type::zoomToSelection,
+                "Frame the current selection (from a pick), or the whole scene "
+                "when nothing is selected.")
+            .def(
+                "resetCamera",
+                &wrapped_type::resetCamera,
+                "Reset the camera to the fit-to-scene default.")
             .def_property(
                 "navigationMapping",
                 [](wrapped_type & self)

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1315,6 +1315,56 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetZoomTC(unittest.TestCase):
+    """Zoom to the selection and reset the camera."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_zoom_to_selection_frames_the_picked_cell(self):
+        """Picking the right-hand quad then zooming frames it: the camera
+        target moves to the picked cell centroid, off the scene center."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.fitCameraToScene()
+        r = widget.pickCell(240, 120)
+        self.assertIsNotNone(r)
+        widget.zoomToSelection()
+        zoom_target = tuple(widget.cameraTarget)
+        self.assertAlmostEqual(zoom_target[0], r["centroid"][0], places=3)
+        widget.resetCamera()
+        reset_target = tuple(widget.cameraTarget)
+        self.assertNotAlmostEqual(zoom_target[0], reset_target[0], places=2)
+
+    def test_zoom_without_selection_frames_the_scene(self):
+        """With nothing selected, zoom-to-selection frames the whole scene
+        (its bounding-box center)."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.fitCameraToScene()
+        widget.zoomToSelection()
+        target = tuple(widget.cameraTarget)
+        self.assertAlmostEqual(target[0], 1.0, places=3)
+        self.assertAlmostEqual(target[1], 0.5, places=3)
+
+    def test_reset_camera_restores_scene_framing(self):
+        """After a zoom, reset returns the camera to the whole-scene center."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        widget.fitCameraToScene()
+        widget.pickCell(240, 120)
+        widget.zoomToSelection()
+        widget.resetCamera()
+        target = tuple(widget.cameraTarget)
+        self.assertAlmostEqual(target[0], 1.0, places=3)
+        self.assertAlmostEqual(target[1], 0.5, places=3)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetMeasureTC(unittest.TestCase):
     """Distance and angle measurement between world points."""
 


### PR DESCRIPTION
## Summary

Add the two most-used camera shortcuts: frame the current selection, and
return to a known view.

`RScene` gains a framing box so the projection sizes to the framed selection,
not the whole scene, so the view actually zooms in rather than only
recentering. `zoomToSelection` frames the picked entity's bounding box (or the
whole scene when nothing is selected), and `resetCamera` restores the
fit-to-scene default.

Python: `zoomToSelection`, `resetCamera`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; tests pick the right-hand quad and check that zooming
  moves the camera target to the cell centroid while reset returns it to the
  scene center.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
