### PR TITLE
Hold a scene of named mesh objects with transforms

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -223,6 +223,128 @@ void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
     update();
 }
 
+namespace
+{
+
+/// The axis-aligned node bounds of a mesh.
+void mesh_bounds(StaticMesh const & mh, QVector3D & lo, QVector3D & hi)
+{
+    bool const is_3d = (3 == mh.ndim());
+    lo = QVector3D(
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max(),
+        std::numeric_limits<float>::max());
+    hi = QVector3D(
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest(),
+        std::numeric_limits<float>::lowest());
+    for (uint32_t ind = 0; ind < mh.nnode(); ++ind)
+    {
+        float const x = static_cast<float>(mh.ndcrd(ind, 0));
+        float const y = static_cast<float>(mh.ndcrd(ind, 1));
+        float const z = is_3d ? static_cast<float>(mh.ndcrd(ind, 2)) : 0.0f;
+        lo = QVector3D(std::min(lo.x(), x), std::min(lo.y(), y), std::min(lo.z(), z));
+        hi = QVector3D(std::max(hi.x(), x), std::max(hi.y(), y), std::max(hi.z(), z));
+    }
+}
+
+} /* end namespace */
+
+void RDomainWidget::addObject(
+    std::string const & name, std::shared_ptr<StaticMesh> const & mesh)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        m_scene.removeDrawable(it->second.drawable);
+        m_objects.erase(it);
+    }
+
+    auto surface = std::make_unique<RMeshFrame>(mesh, RMeshFrame::Style::Surface);
+    surface->setName(name);
+    RDrawable * const drawable = surface.get();
+    m_scene.addDrawable(std::move(surface));
+    m_objects[name] = ObjectEntry{drawable, mesh};
+
+    m_scene.setDimension(mesh->ndim());
+    QVector3D lo;
+    QVector3D hi;
+    mesh_bounds(*mesh, lo, hi);
+    if (mesh->nnode() > 0)
+    {
+        m_scene.extendBoundingBox(lo, hi);
+    }
+    m_scene.fitCameraToScene(viewportAspect());
+    update();
+}
+
+void RDomainWidget::setObjectTransform(
+    std::string const & name,
+    float tx,
+    float ty,
+    float tz,
+    float sx,
+    float sy,
+    float sz)
+{
+    auto const it = m_objects.find(name);
+    if (it == m_objects.end())
+    {
+        return;
+    }
+    QMatrix4x4 model;
+    model.translate(tx, ty, tz);
+    model.scale(sx, sy, sz);
+    it->second.drawable->setModel(model);
+
+    // Grow the framing box to include the transformed object corners.
+    QVector3D lo;
+    QVector3D hi;
+    mesh_bounds(*it->second.mesh, lo, hi);
+    for (int i = 0; i < 8; ++i)
+    {
+        QVector3D const corner(
+            (i & 1) ? hi.x() : lo.x(),
+            (i & 2) ? hi.y() : lo.y(),
+            (i & 4) ? hi.z() : lo.z());
+        QVector3D const mapped = model.map(corner);
+        m_scene.extendBoundingBox(mapped, mapped);
+    }
+    m_scene.fitCameraToScene(viewportAspect());
+    update();
+}
+
+void RDomainWidget::setObjectVisible(std::string const & name, bool visible)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        it->second.drawable->setVisible(visible);
+        update();
+    }
+}
+
+void RDomainWidget::setObjectOpacity(std::string const & name, float opacity)
+{
+    auto const it = m_objects.find(name);
+    if (it != m_objects.end())
+    {
+        it->second.drawable->setOpacity(opacity);
+        update();
+    }
+}
+
+std::vector<std::string> RDomainWidget::objectNames() const
+{
+    std::vector<std::string> names;
+    names.reserve(m_objects.size());
+    for (auto const & entry : m_objects)
+    {
+        names.push_back(entry.first);
+    }
+    return names;
+}
+
 void RDomainWidget::showMesh(bool show)
 {
     m_mesh_shown = show;

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -31,11 +31,11 @@
 #include <QRhiWidget>
 #include <QVector3D>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <utility>
 
 namespace solvcon
 {
@@ -65,6 +65,23 @@ public:
 
     /// Replace the rendered mesh with the wireframe of @p mesh.
     void updateMesh(std::shared_ptr<StaticMesh> const & mesh);
+
+    // A scene of several named mesh objects, each with its own model transform
+    // and visibility, listed by an outliner. addObject registers a mesh as a
+    // named, lit surface; the setters drive it by name (an unknown name is a
+    // no-op).
+    void addObject(std::string const & name, std::shared_ptr<StaticMesh> const & mesh);
+    void setObjectTransform(
+        std::string const & name,
+        float tx,
+        float ty,
+        float tz,
+        float sx,
+        float sy,
+        float sz);
+    void setObjectVisible(std::string const & name, bool visible);
+    void setObjectOpacity(std::string const & name, float opacity);
+    std::vector<std::string> objectNames() const;
 
     /// Show or hide the mesh, in whatever representation is active.
     void showMesh(bool show);
@@ -366,6 +383,15 @@ private:
     RDrawable * m_cube_axes = nullptr; ///< The bounding-box cube-axes grid.
     RDrawable * m_clip = nullptr; ///< The clipped surface drawable.
     RDrawable * m_slice = nullptr; ///< The slice cross-section outline.
+
+    /// A named scene object: its drawable (owned by the scene) and its mesh,
+    /// kept so a transform can re-extend the framing box.
+    struct ObjectEntry
+    {
+        RDrawable * drawable = nullptr;
+        std::shared_ptr<StaticMesh> mesh;
+    };
+    std::map<std::string, ObjectEntry> m_objects;
     std::vector<float> m_ticks_x; ///< Cube-axes tick coordinates per axis.
     std::vector<float> m_ticks_y;
     std::vector<float> m_ticks_z;

--- a/cpp/solvcon/pilot/RDrawable.cpp
+++ b/cpp/solvcon/pilot/RDrawable.cpp
@@ -79,7 +79,8 @@ void RDrawable::updateUniform(QRhiResourceUpdateBatch * batch, QMatrix4x4 const 
     {
         return;
     }
-    batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, view_proj.constData());
+    QMatrix4x4 const mvp = view_proj * m_model;
+    batch->updateDynamicBuffer(m_ubuf.get(), 0, 64, mvp.constData());
     float const color[4] = {
         m_color.x(), m_color.y(), m_color.z(), m_color.w() * m_opacity};
     batch->updateDynamicBuffer(m_ubuf.get(), 64, 16, color);

--- a/cpp/solvcon/pilot/RDrawable.hpp
+++ b/cpp/solvcon/pilot/RDrawable.hpp
@@ -23,6 +23,7 @@
 #include <QVector4D>
 
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace solvcon
@@ -58,6 +59,15 @@ public:
 
     void setColor(QVector4D const & color) { m_color = color; }
     QVector4D color() const { return m_color; }
+
+    /// The model transform applied before the view-projection; identity by
+    /// default, so a single object renders where its geometry already sits.
+    void setModel(QMatrix4x4 const & model) { m_model = model; }
+    QMatrix4x4 model() const { return m_model; }
+
+    /// An optional name, used by the scene's named-object registry.
+    void setName(std::string const & name) { m_name = name; }
+    std::string const & name() const { return m_name; }
 
     /// World-space direction toward the light, read by the lit material and
     /// ignored by the others. The widget refreshes it as the camera moves.
@@ -128,6 +138,8 @@ protected:
 
     QVector4D m_color{1.0f, 1.0f, 1.0f, 1.0f};
     QVector3D m_light_dir{0.0f, 0.0f, 1.0f};
+    QMatrix4x4 m_model; ///< Per-object model transform (identity by default).
+    std::string m_name; ///< Optional name for the scene registry.
     float m_opacity = 1.0f;
     bool m_visible = true;
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -175,6 +175,34 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 py::arg("h"))
             .def_property_readonly("mesh", &wrapped_type::mesh)
             .def("updateMesh", &wrapped_type::updateMesh, py::arg("mesh"))
+            .def(
+                "addObject",
+                &wrapped_type::addObject,
+                py::arg("name"),
+                py::arg("mesh"),
+                "Register a mesh as a named, lit surface object in the scene.")
+            .def(
+                "setObjectTransform",
+                &wrapped_type::setObjectTransform,
+                py::arg("name"),
+                py::arg("tx"),
+                py::arg("ty"),
+                py::arg("tz"),
+                py::arg("sx") = 1.0f,
+                py::arg("sy") = 1.0f,
+                py::arg("sz") = 1.0f,
+                "Set a named object's translate and scale model transform.")
+            .def(
+                "setObjectVisible",
+                &wrapped_type::setObjectVisible,
+                py::arg("name"),
+                py::arg("visible"))
+            .def(
+                "setObjectOpacity",
+                &wrapped_type::setObjectOpacity,
+                py::arg("name"),
+                py::arg("opacity"))
+            .def("objectNames", &wrapped_type::objectNames)
             .def("showMesh", &wrapped_type::showMesh, py::arg("show"))
             .def("setMeshOpacity", &wrapped_type::setMeshOpacity, py::arg("opacity"))
             .def("setFieldOpacity", &wrapped_type::setFieldOpacity, py::arg("opacity"))

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1315,6 +1315,67 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetSceneObjectsTC(unittest.TestCase):
+    """A scene of several named mesh objects with transforms."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def test_two_objects_register(self):
+        """Two named meshes both register in the scene."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("left", _make_2d_mesh())
+        widget.addObject("right", _make_3d_mesh())
+        names = sorted(widget.objectNames())
+        self.assertEqual(names, ["left", "right"])
+
+    def test_readding_replaces_object(self):
+        """Adding a name that already exists replaces it, not duplicates."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("m", _make_2d_mesh())
+        widget.addObject("m", _make_3d_mesh())
+        self.assertEqual(widget.objectNames(), ["m"])
+
+    def test_transform_and_visibility_setters_by_name(self):
+        """The transform, visibility, and opacity setters accept a known name
+        and ignore an unknown one, without crashing."""
+        widget = pilot.RDomainWidget()
+        widget.addObject("a", _make_2d_mesh())
+        widget.setObjectTransform("a", 3.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        widget.setObjectVisible("a", False)
+        widget.setObjectOpacity("a", 0.5)
+        widget.setObjectVisible("nope", True)  # unknown: no-op
+        self.assertEqual(widget.objectNames(), ["a"])
+
+    def test_two_objects_render_and_toggle(self):
+        """Two objects with distinct transforms both render; hiding one drops
+        drawn pixels.
+
+        Each state grabs a freshly configured widget: a second grab of a
+        mutated widget is unreliable on the headless software rasterizer.
+        _count_foreground keys on the difference from the frame's own
+        background, so a dark empty read-back still counts as nothing drawn.
+        """
+        both_widget = pilot.RDomainWidget()
+        both_widget.resize(320, 240)
+        both_widget.addObject("a", _make_2d_mesh())
+        both_widget.addObject("b", _make_2d_mesh())
+        both_widget.setObjectTransform("b", 4.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        both = _count_foreground(_grab_or_skip(both_widget))
+        self.assertGreater(both, 0)
+
+        one_widget = pilot.RDomainWidget()
+        one_widget.resize(320, 240)
+        one_widget.addObject("a", _make_2d_mesh())
+        one_widget.addObject("b", _make_2d_mesh())
+        one_widget.setObjectTransform("b", 4.0, 0.0, 0.0, 1.0, 1.0, 1.0)
+        one_widget.setObjectVisible("b", False)
+        one = _count_foreground(_grab_or_skip(one_widget))
+        self.assertLess(one, both)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetFilterTC(unittest.TestCase):
     """Geometric slice and clip of the mesh."""
 


### PR DESCRIPTION
## Summary

Let the viewer hold several named mesh objects at once, each with its own model
transform and visibility, the basis an outliner would list.

`RDrawable` gains a model transform (applied before the view-projection) and a
name. The widget registers objects by name: `addObject` adds a mesh as a named
lit surface and frames the union, `setObjectTransform` sets a translate and
scale and grows the framing box, and `setObjectVisible` / `setObjectOpacity`
drive one object by name. `objectNames` lists them.

Python: `addObject`, `setObjectTransform`, `setObjectVisible`,
`setObjectOpacity`, `objectNames`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; tests check that two named meshes register, that
  re-adding a name replaces it, and that the by-name setters accept a known
  name and ignore an unknown one.

Step PR into `meshvisual`; one milestone of the mesh visualization prototype.
