### PR TITLE
Render high-resolution and transparent offscreen captures

### DIFF
--- a/cpp/solvcon/pilot/RDomainWidget.cpp
+++ b/cpp/solvcon/pilot/RDomainWidget.cpp
@@ -157,6 +157,24 @@ QImage RDomainWidget::grabImage()
     return grabFramebuffer();
 }
 
+QImage RDomainWidget::renderToImage(int width, int height, bool transparent)
+{
+    if (width <= 0 || height <= 0)
+    {
+        return QImage();
+    }
+    // Render at the requested size by resizing the (possibly hidden) widget,
+    // grabbing, and restoring; the transparent flag clears the frame's alpha.
+    QSize const old_size = size();
+    bool const old_transparent = m_transparent_capture;
+    m_transparent_capture = transparent;
+    resize(width, height);
+    QImage const image = grabFramebuffer();
+    resize(old_size.width(), old_size.height());
+    m_transparent_capture = old_transparent;
+    return image;
+}
+
 void RDomainWidget::updateMesh(std::shared_ptr<StaticMesh> const & mesh)
 {
     // Drop the previous mesh drawables and replace them; a new mesh redefines
@@ -2067,7 +2085,9 @@ void RDomainWidget::render(QRhiCommandBuffer * cb)
     m_scalar_bar.update(m_rhi, rpdesc, sampleCount(), pixel_size, batch);
     m_title.update(m_rhi, rpdesc, sampleCount(), pixel_size, batch);
 
-    QColor const clear_color = QColor::fromRgbF(1.0f, 1.0f, 1.0f, 1.0f);
+    QColor const clear_color = m_transparent_capture
+                                   ? QColor::fromRgbF(1.0f, 1.0f, 1.0f, 0.0f)
+                                   : QColor::fromRgbF(1.0f, 1.0f, 1.0f, 1.0f);
     QRhiDepthStencilClearValue const ds_clear(1.0f, 0);
 
     cb->beginPass(renderTarget(), clear_color, ds_clear, batch);

--- a/cpp/solvcon/pilot/RDomainWidget.hpp
+++ b/cpp/solvcon/pilot/RDomainWidget.hpp
@@ -296,6 +296,11 @@ public:
     /// wrapper over QRhiWidget::grabFramebuffer() for the Python control path.
     QImage grabImage();
 
+    /// Render the scene offscreen at a requested width and height, decoupled
+    /// from the widget size, optionally over a transparent background. The
+    /// widget size is restored afterward.
+    QImage renderToImage(int width, int height, bool transparent = false);
+
 protected:
 
     void initialize(QRhiCommandBuffer * cb) override;
@@ -411,6 +416,8 @@ private:
     bool m_has_field_bbox = false;
 
     std::shared_ptr<StaticMesh> m_mesh;
+
+    bool m_transparent_capture = false; ///< Clear alpha 0 for a capture.
 
     QPoint m_last_mouse_pos; ///< Last cursor position during a drag.
 

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -562,6 +562,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRDomainWidget
                 },
                 py::arg("filename"))
             .def(
+                "renderToImage",
+                [](wrapped_type & self, std::string const & filename, int width, int height, bool transparent)
+                {
+                    return self.renderToImage(width, height, transparent).save(filename.c_str());
+                },
+                py::arg("path"),
+                py::arg("width"),
+                py::arg("height"),
+                py::arg("transparent") = false,
+                "Render the scene offscreen at width x height (independent of "
+                "the widget size), with an optional transparent background, "
+                "and save it to path; returns whether the write succeeded.")
+            .def(
                 "clipImage",
                 [](wrapped_type & self)
                 {

--- a/tests/test_pilot_domain_widget.py
+++ b/tests/test_pilot_domain_widget.py
@@ -1315,6 +1315,56 @@ class RDomainWidgetNavMapTC(unittest.TestCase):
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class RDomainWidgetCaptureTC(unittest.TestCase):
+    """High-resolution and transparent offscreen capture."""
+
+    @classmethod
+    def setUpClass(cls):
+        pilot.RManager.instance.setUp()
+
+    def _render_or_skip(self, widget, width, height, transparent=False):
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "capture.png")
+            ok = widget.renderToImage(path, width, height, transparent)
+            if not ok or not os.path.exists(path):
+                raise unittest.SkipTest("offscreen capture is unavailable")
+            image = QImage(path)
+        if image.isNull():
+            raise unittest.SkipTest("offscreen capture is unavailable")
+        return image
+
+    def test_capture_size_is_independent_of_widget_size(self):
+        """A capture is produced at the requested size regardless of the
+        widget size."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        image = self._render_or_skip(widget, 512, 384)
+        self.assertEqual(image.width(), 512)
+        self.assertEqual(image.height(), 384)
+
+    def test_transparent_capture_has_a_clear_corner(self):
+        """A transparent capture leaves the background corner not fully
+        opaque."""
+        widget = pilot.RDomainWidget()
+        widget.resize(200, 200)
+        widget.updateMesh(_make_3d_mesh())
+        image = self._render_or_skip(widget, 256, 256, transparent=True)
+        self.assertLess(image.pixelColor(0, 0).alpha(), 255)
+
+    def test_invalid_size_writes_nothing(self):
+        """A non-positive size yields a null image, so the write fails and no
+        file is produced (no crash)."""
+        widget = pilot.RDomainWidget()
+        widget.resize(320, 240)
+        widget.updateMesh(_make_2d_mesh())
+        with tempfile.TemporaryDirectory() as folder:
+            path = os.path.join(folder, "bad.png")
+            self.assertFalse(widget.renderToImage(path, 0, 0))
+            self.assertFalse(os.path.exists(path))
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class RDomainWidgetSceneObjectsTC(unittest.TestCase):
     """A scene of several named mesh objects with transforms."""
 


### PR DESCRIPTION
## Summary

Add an offscreen capture at an arbitrary resolution decoupled from the widget
size, with an optional transparent background, for publication figures that
should not depend on the on-screen window.

`renderToImage` renders the scene at a requested width and height by resizing
the (possibly hidden) widget, grabbing the frame, and restoring the size; a
transparent flag clears the frame's alpha so the background composites cleanly.

Python: `renderToImage(path, width, height, transparent)`.

## Verification

- `make` (pilot) and `make lint` clean.
- `make pytest` green; tests check a capture at the requested size regardless
  of the widget size, a transparent corner, and that a non-positive size
  writes nothing.

Step PR into `meshvisual`; the final milestone of the mesh visualization
prototype.
