### PR TITLE
try/pilotmenu/step1

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/DrawTool.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pilot.hpp
@@ -38,6 +39,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/DrawTool.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_pilot.cpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -10,6 +10,7 @@
 
 #include <solvcon/pilot/DrawTool.hpp>
 #include <solvcon/pilot/RAction.hpp>
+#include <solvcon/pilot/RMenuModel.hpp>
 #include <Qt>
 #include <QMenuBar>
 #include <QMenu>
@@ -65,6 +66,12 @@ void RManager::reset()
     // Qt's parent-child mechanism will delete widget children; we only
     // need to ensure our raw pointers don't dangle after the call.
     m_already_setup = false;
+    // Empty the menu model while the application (and its widgets) is still
+    // alive, so a repeated setUp on the singleton starts from a clean bar.
+    if (m_menuModel)
+    {
+        m_menuModel->clear();
+    }
     m_core.reset();
     m_mainWindow = nullptr;
     m_fileMenu = nullptr;
@@ -75,6 +82,7 @@ void RManager::reset()
     m_canvasMenu = nullptr;
     m_profilingMenu = nullptr;
     m_windowMenu = nullptr;
+    m_menuModel = nullptr;
     m_pycon = nullptr;
     m_mdiArea = nullptr;
     m_rhi_primer = nullptr;
@@ -290,6 +298,10 @@ void RManager::setUpMenu()
     m_mainWindow->setMenuBar(new QMenuBar(nullptr));
     // NOTE: All menus need to be populated or Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
+
+    // The live menu model shares the same bar; consumers migrate onto it in
+    // later steps. Parent it to the main window so the widget tree owns it.
+    m_menuModel = new RMenuModel(m_mainWindow, m_mainWindow);
 
     m_fileMenu = m_mainWindow->menuBar()->addMenu(QString("File"));
     m_editMenu = m_mainWindow->menuBar()->addMenu(QString("Edit"));

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -31,6 +31,8 @@
 namespace solvcon
 {
 
+class RMenuModel;
+
 /**
  * @brief Singleton that owns the pilot main window and coordinates its
  * widgets, menus, and the active canvas drawing tool.
@@ -87,6 +89,9 @@ public:
     QMenu * profilingMenu() { return m_profilingMenu; }
     QMenu * windowMenu() { return m_windowMenu; }
 
+    /// The live model of the menu bar, addressable by path from Python.
+    RMenuModel * menuModel() { return m_menuModel; }
+
     void quit() { m_core->quit(); }
 
     /// Only call reset() when the program is to be stopped.
@@ -137,6 +142,9 @@ private:
     QMenu * m_canvasMenu = nullptr;
     QMenu * m_profilingMenu = nullptr;
     QMenu * m_windowMenu = nullptr;
+
+    /// Live menu model owned by the widget tree (parented to the main window).
+    RMenuModel * m_menuModel = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/solvcon/pilot/RMenuModel.cpp
+++ b/cpp/solvcon/pilot/RMenuModel.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RMenuModel.hpp> // Must be the first include.
+
+#include <limits>
+
+#include <QAction>
+#include <QMainWindow>
+#include <QMenu>
+#include <QMenuBar>
+#include <QStringList>
+#include <Qt>
+
+namespace solvcon
+{
+
+namespace
+{
+
+/// A negative weight sorts last, so a node declared without a weight lands
+/// after every explicitly weighted sibling.
+int effective_weight(int weight)
+{
+    return weight < 0 ? std::numeric_limits<int>::max() : weight;
+}
+
+} /* end namespace */
+
+RMenuModel::RMenuModel(QMainWindow * mainWindow, QObject * parent)
+    : QObject(parent)
+    , m_mainWindow(mainWindow)
+    , m_bar(mainWindow->menuBar())
+{
+}
+
+RMenuModel::~RMenuModel()
+{
+    clear();
+}
+
+QMenu * RMenuModel::menu(std::string const & path, int weight)
+{
+    QStringList const parts =
+        QString::fromStdString(path).split('/', Qt::SkipEmptyParts);
+    if (parts.isEmpty())
+    {
+        return nullptr;
+    }
+
+    Node * cur = &m_root;
+    for (int i = 0; i < parts.size(); ++i)
+    {
+        bool const last = (i + 1 == parts.size());
+        cur = ensureChild(cur, parts.at(i), last ? weight : -1);
+    }
+    return cur->menu;
+}
+
+void RMenuModel::clear()
+{
+    // QPointer entries drop to null when Qt already deleted a menu (for
+    // example when the whole main window is torn down), so guard each delete.
+    for (QPointer<QMenu> const & menu : m_menus)
+    {
+        if (menu)
+        {
+            delete menu;
+        }
+    }
+    m_menus.clear();
+    m_root.children.clear();
+}
+
+RMenuModel::Node * RMenuModel::ensureChild(Node * parent, QString const & name, int weight)
+{
+    for (std::unique_ptr<Node> const & child : parent->children)
+    {
+        if (child->name == name)
+        {
+            if (weight >= 0 && weight != child->weight)
+            {
+                reweight(parent, child.get(), weight);
+            }
+            return child.get();
+        }
+    }
+
+    auto node = std::make_unique<Node>();
+    node->name = name;
+    node->weight = weight;
+    node->parent = parent;
+    node->menu = new QMenu(name, m_mainWindow);
+    m_menus.emplace_back(node->menu);
+
+    int const idx = insertionIndex(parent, weight);
+    QAction * before = idx < static_cast<int>(parent->children.size())
+                           ? parent->children.at(idx)->menu->menuAction()
+                           : nullptr;
+    containerInsert(parent, node->menu, before);
+
+    Node * raw = node.get();
+    parent->children.insert(parent->children.begin() + idx, std::move(node));
+    return raw;
+}
+
+void RMenuModel::reweight(Node * parent, Node * node, int weight)
+{
+    // Detach from the Qt container and the sibling vector, then re-insert
+    // where the new weight places the node.
+    containerRemove(parent, node->menu);
+
+    int old = 0;
+    for (; old < static_cast<int>(parent->children.size()); ++old)
+    {
+        if (parent->children.at(old).get() == node)
+        {
+            break;
+        }
+    }
+    std::unique_ptr<Node> held = std::move(parent->children.at(old));
+    parent->children.erase(parent->children.begin() + old);
+
+    node->weight = weight;
+    int const idx = insertionIndex(parent, weight);
+    QAction * before = idx < static_cast<int>(parent->children.size())
+                           ? parent->children.at(idx)->menu->menuAction()
+                           : nullptr;
+    containerInsert(parent, node->menu, before);
+    parent->children.insert(parent->children.begin() + idx, std::move(held));
+}
+
+int RMenuModel::insertionIndex(Node * parent, int weight) const
+{
+    int const ew = effective_weight(weight);
+    int idx = 0;
+    for (; idx < static_cast<int>(parent->children.size()); ++idx)
+    {
+        if (effective_weight(parent->children.at(idx)->weight) > ew)
+        {
+            break;
+        }
+    }
+    return idx;
+}
+
+void RMenuModel::containerInsert(Node * parent, QMenu * menu, QAction * before)
+{
+    if (parent == &m_root)
+    {
+        before ? m_bar->insertMenu(before, menu) : m_bar->addMenu(menu);
+    }
+    else
+    {
+        before ? parent->menu->insertMenu(before, menu) : parent->menu->addMenu(menu);
+    }
+}
+
+void RMenuModel::containerRemove(Node * parent, QMenu * menu)
+{
+    QWidget * container = parent == &m_root
+                              ? static_cast<QWidget *>(m_bar)
+                              : static_cast<QWidget *>(parent->menu);
+    container->removeAction(menu->menuAction());
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RMenuModel.hpp
+++ b/cpp/solvcon/pilot/RMenuModel.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Live model of the pilot menu bar: menus addressed by path and weight.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <QObject>
+#include <QPointer>
+#include <QString>
+
+class QAction;
+class QMainWindow;
+class QMenu;
+class QMenuBar;
+
+namespace solvcon
+{
+
+/**
+ * @brief A live, incrementally built model of the pilot menu bar.
+ *
+ * @ingroup group_domain
+ *
+ * Menus are addressed by a slash-separated path ("View/Panels"). menu()
+ * resolves a path, creating any missing ancestor on demand, and orders each
+ * node among its siblings (and on the bar for a top-level path) by a weight
+ * declared once. A smaller weight sits earlier; equal weights keep arrival
+ * order; a negative weight leaves an existing node untouched and appends a new
+ * one. The model owns the menus it creates, so clear() empties the bar and
+ * lets a fresh setUp rebuild it.
+ */
+class RMenuModel
+    : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    explicit RMenuModel(QMainWindow * mainWindow, QObject * parent = nullptr);
+
+    ~RMenuModel() override;
+
+    /// Resolve or create the menu at @p path, creating ancestors on demand.
+    /// @p weight orders the final node among its siblings; a negative weight
+    /// leaves an existing node's order untouched and appends a new one.
+    QMenu * menu(std::string const & path, int weight = -1);
+
+    /// Delete every menu the model created and empty the bar.
+    void clear();
+
+private:
+
+    struct Node
+    {
+        QString name;
+        int weight = -1;
+        QPointer<QMenu> menu; // nullptr for the root, which stands for the bar
+        Node * parent = nullptr;
+        std::vector<std::unique_ptr<Node>> children;
+    };
+
+    Node * ensureChild(Node * parent, QString const & name, int weight);
+    void reweight(Node * parent, Node * node, int weight);
+    int insertionIndex(Node * parent, int weight) const;
+    void containerInsert(Node * parent, QMenu * menu, QAction * before);
+    void containerRemove(Node * parent, QMenu * menu);
+
+    QMainWindow * m_mainWindow = nullptr;
+    QMenuBar * m_bar = nullptr;
+    Node m_root;
+    std::vector<QPointer<QMenu>> m_menus;
+}; /* end class RMenuModel */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -9,6 +9,7 @@
 #include <solvcon/python/common.hpp>
 
 #include <solvcon/pilot/R2DWidget.hpp>
+#include <solvcon/pilot/RMenuModel.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
 #include <QClipboard>
@@ -341,6 +342,42 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPythonConsoleDockWidget
 
 }; /* end class WrapRPythonConsoleDockWidget */
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRMenuModel
+    : public WrapBase<WrapRMenuModel, RMenuModel>
+{
+
+    friend root_base_type;
+
+    WrapRMenuModel(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+
+        namespace py = pybind11;
+
+        (*this)
+            .def(
+                "menu",
+                [](wrapped_type & self, std::string const & path, int weight)
+                {
+                    return self.menu(path, weight);
+                },
+                py::arg("path"),
+                py::arg("weight") = -1,
+                "Resolve or create the menu at a slash-separated path, "
+                "creating ancestors on demand; weight orders the node among "
+                "its siblings.")
+            .def(
+                "clear",
+                [](wrapped_type & self)
+                {
+                    self.clear();
+                })
+            //
+            ;
+    }
+
+}; /* end class WrapRMenuModel */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
     : public WrapBase<WrapRManager, RManager>
 {
@@ -452,12 +489,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                     return self.mainWindow();
                 })
             .def_property_readonly("fileMenu", &wrapped_type::fileMenu)
+            .def_property_readonly("editMenu", &wrapped_type::editMenu)
             .def_property_readonly("viewMenu", &wrapped_type::viewMenu)
             .def_property_readonly("oneMenu", &wrapped_type::oneMenu)
             .def_property_readonly("meshMenu", &wrapped_type::meshMenu)
             .def_property_readonly("canvasMenu", &wrapped_type::canvasMenu)
             .def_property_readonly("profilingMenu", &wrapped_type::profilingMenu)
             .def_property_readonly("windowMenu", &wrapped_type::windowMenu)
+            .def_property_readonly(
+                "menu_model",
+                [](wrapped_type & self)
+                {
+                    return self.menuModel();
+                })
             .def(
                 "quit",
                 [](wrapped_type & self)
@@ -552,6 +596,12 @@ void wrap_pilot(pybind11::module & mod)
         "saveImage / clipImage.");
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");
     WrapRPythonConsoleDockWidget::commit(mod, "RPythonConsoleDockWidget", "RPythonConsoleDockWidget");
+    WrapRMenuModel::commit(
+        mod,
+        "RMenuModel",
+        "Live model of the pilot menu bar. Address menus by a slash-separated "
+        "path with menu(path, weight); a smaller weight sits earlier and a "
+        "negative weight appends. clear() empties the bar.");
     WrapRManager::commit(mod, "RManager", "RManager");
     WrapRManagerProxy::commit(mod, "RManagerProxy", "RManagerProxy");
 

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class MenuModelTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+        # The model persists on the singleton across tests; start each test
+        # from a bar holding only the built-in menus.
+        self.model.clear()
+
+    def _top_level(self):
+        return [a.text() for a in self.mgr.mainWindow.menuBar().actions()]
+
+    def _children(self, menu):
+        return [a.text() for a in menu.actions()]
+
+    def test_menu_creates_top_level_node(self):
+        menu = self.model.menu("Alpha")
+        self.assertEqual(menu.title(), "Alpha")
+        self.assertIn("Alpha", self._top_level())
+
+    def test_menu_is_idempotent(self):
+        first = self.model.menu("Alpha")
+        second = self.model.menu("Alpha")
+        # The same path resolves to the same menu, not a duplicate on the bar.
+        self.assertEqual(first, second)
+        self.assertEqual(self._top_level().count("Alpha"), 1)
+
+    def test_menu_creates_ancestors_on_demand(self):
+        leaf = self.model.menu("Beta/Gamma")
+        self.assertEqual(leaf.title(), "Gamma")
+        self.assertIn("Beta", self._top_level())
+        parent = self.model.menu("Beta")
+        self.assertIn("Gamma", self._children(parent))
+
+    def test_node_weight_orders_the_bar(self):
+        # Declare out of order; the weights, not arrival, fix the bar order.
+        self.model.menu("Later", weight=40)
+        self.model.menu("Early", weight=10)
+        self.model.menu("Middle", weight=25)
+        top = [t for t in self._top_level() if t in ("Early", "Middle",
+                                                     "Later")]
+        self.assertEqual(top, ["Early", "Middle", "Later"])
+
+    def test_equal_weight_keeps_arrival_order(self):
+        self.model.menu("Uno", weight=10)
+        self.model.menu("Dos", weight=10)
+        self.model.menu("Tres", weight=10)
+        top = [t for t in self._top_level() if t in ("Uno", "Dos", "Tres")]
+        self.assertEqual(top, ["Uno", "Dos", "Tres"])
+
+    def test_submenu_weight_orders_children(self):
+        self.model.menu("Root", weight=90)
+        self.model.menu("Root/Second", weight=20)
+        self.model.menu("Root/First", weight=10)
+        parent = self.model.menu("Root")
+        self.assertEqual(self._children(parent), ["First", "Second"])
+
+    def test_reweight_moves_an_existing_node(self):
+        self.model.menu("A", weight=10)
+        self.model.menu("B", weight=20)
+        # Re-declaring with a larger weight repositions the same node.
+        self.model.menu("A", weight=30)
+        top = [t for t in self._top_level() if t in ("A", "B")]
+        self.assertEqual(top, ["B", "A"])
+
+    def test_clear_removes_model_menus(self):
+        self.model.menu("Temp")
+        self.assertIn("Temp", self._top_level())
+        self.model.clear()
+        self.assertNotIn("Temp", self._top_level())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add `RMenuModel`, the load-bearing skeleton for a menu bar addressed by path
rather than by construction order.

## What this adds

- `RMenuModel`: `menu(path, weight=-1)` resolves a slash-separated path,
  creating any missing ancestor on demand, and orders each node among its
  siblings (and on the bar for a top-level path) by a weight declared once.
  A smaller weight sits earlier, equal weights keep arrival order, and a
  negative weight leaves an existing node untouched and appends a new one.
  `clear()` deletes every menu it created.
- The model is owned by `RManager` (created in `setUpMenu`, parented to the
  main window, cleared from `reset()`) and bound to Python as `mgr.menu_model`.
- The missing `editMenu` binding, so every built-in menu is reachable from the
  embedded console.

No consumer changes yet: the bar is still built imperatively; the model shares
the same bar and later steps migrate onto it.

## Testing

`tests/test_pilot_menu_model.py` covers on-demand path creation, idempotent
resolution, weight ordering regardless of arrival order, equal-weight
stability, submenu ordering, reweighting, and `clear()`. It skips on CI
runners without a GUI, the same way `test_pilot_mesh_info.py` does.

Local `make lint`, `make gtest`, and `make run_pilot_pytest` all pass.