### PR TITLE
try/pilotmenu/step2

### DIFF
--- a/cpp/solvcon/pilot/RMenuModel.cpp
+++ b/cpp/solvcon/pilot/RMenuModel.cpp
@@ -8,6 +8,7 @@
 #include <limits>
 
 #include <QAction>
+#include <QActionGroup>
 #include <QMainWindow>
 #include <QMenu>
 #include <QMenuBar>
@@ -20,7 +21,7 @@ namespace solvcon
 namespace
 {
 
-/// A negative weight sorts last, so a node declared without a weight lands
+/// A negative weight sorts last, so an entry declared without a weight lands
 /// after every explicitly weighted sibling.
 int effective_weight(int weight)
 {
@@ -43,6 +44,97 @@ RMenuModel::~RMenuModel()
 
 QMenu * RMenuModel::menu(std::string const & path, int weight)
 {
+    Node * node = resolve(path, weight);
+    return node ? node->menu.data() : nullptr;
+}
+
+void RMenuModel::place(std::string const & path, QAction * action, int weight)
+{
+    Node * node = resolve(path, -1);
+    if (node == nullptr || action == nullptr)
+    {
+        return;
+    }
+    placeAction(node, action, weight);
+
+    QString const id = action->objectName();
+    if (!id.isEmpty())
+    {
+        m_actions[id.toStdString()] = action;
+    }
+}
+
+void RMenuModel::placeSeparator(std::string const & path, int weight)
+{
+    Node * node = resolve(path, -1);
+    if (node == nullptr)
+    {
+        return;
+    }
+    // Parent the separator to its menu so it is deleted with the menu; a
+    // separator carries no id and stays out of the registry.
+    auto * separator = new QAction(node->menu);
+    separator->setSeparator(true);
+    placeAction(node, separator, weight);
+}
+
+QAction * RMenuModel::action(std::string const & id) const
+{
+    auto const it = m_actions.find(id);
+    return it != m_actions.end() ? it->second.data() : nullptr;
+}
+
+void RMenuModel::remove(std::string const & id)
+{
+    auto const it = m_actions.find(id);
+    if (it == m_actions.end())
+    {
+        return;
+    }
+    if (QAction * target = it->second.data())
+    {
+        removeAction(&m_root, target);
+    }
+    m_actions.erase(it);
+}
+
+QActionGroup * RMenuModel::group(std::string const & id)
+{
+    QPointer<QActionGroup> & slot = m_groups[id];
+    if (!slot)
+    {
+        slot = new QActionGroup(this);
+    }
+    return slot.data();
+}
+
+void RMenuModel::clear()
+{
+    for (auto const & entry : m_groups)
+    {
+        if (entry.second)
+        {
+            delete entry.second;
+        }
+    }
+    m_groups.clear();
+
+    // QPointer entries drop to null when Qt already deleted a menu (for
+    // example when the whole main window is torn down), so guard each delete.
+    for (QPointer<QMenu> const & menu : m_menus)
+    {
+        if (menu)
+        {
+            delete menu;
+        }
+    }
+    m_menus.clear();
+    m_actions.clear();
+    m_root.entries.clear();
+}
+
+RMenuModel::Node * RMenuModel::resolve(std::string const & path, int weight)
+{
     QStringList const parts =
         QString::fromStdString(path).split('/', Qt::SkipEmptyParts);
     if (parts.isEmpty())
@@ -56,89 +148,62 @@ QMenu * RMenuModel::menu(std::string const & path, int weight)
         bool const last = (i + 1 == parts.size());
         cur = ensureChild(cur, parts.at(i), last ? weight : -1);
     }
-    return cur->menu;
-}
-
-void RMenuModel::clear()
-{
-    // QPointer entries drop to null when Qt already deleted a menu (for
-    // example when the whole main window is torn down), so guard each delete.
-    for (QPointer<QMenu> const & menu : m_menus)
-    {
-        if (menu)
-        {
-            delete menu;
-        }
-    }
-    m_menus.clear();
-    m_root.children.clear();
+    return cur;
 }
 
 RMenuModel::Node * RMenuModel::ensureChild(Node * parent, QString const & name, int weight)
 {
-    for (std::unique_ptr<Node> const & child : parent->children)
+    for (int i = 0; i < static_cast<int>(parent->entries.size()); ++i)
     {
-        if (child->name == name)
+        Entry & entry = parent->entries.at(i);
+        if (entry.submenu && entry.submenu->name == name)
         {
-            if (weight >= 0 && weight != child->weight)
+            if (weight >= 0 && weight != entry.weight)
             {
-                reweight(parent, child.get(), weight);
+                reweightEntry(parent, i, weight);
             }
-            return child.get();
+            return entry.submenu.get();
         }
     }
 
-    auto node = std::make_unique<Node>();
-    node->name = name;
-    node->weight = weight;
-    node->parent = parent;
-    node->menu = new QMenu(name, m_mainWindow);
-    m_menus.emplace_back(node->menu);
+    auto * qmenu = new QMenu(name, m_mainWindow);
+    m_menus.emplace_back(qmenu);
 
     int const idx = insertionIndex(parent, weight);
-    QAction * before = idx < static_cast<int>(parent->children.size())
-                           ? parent->children.at(idx)->menu->menuAction()
-                           : nullptr;
-    containerInsert(parent, node->menu, before);
+    containerInsert(parent, qmenu->menuAction(), beforeAt(parent, idx));
 
-    Node * raw = node.get();
-    parent->children.insert(parent->children.begin() + idx, std::move(node));
+    Entry entry;
+    entry.weight = weight;
+    entry.action = qmenu->menuAction();
+    entry.submenu = std::make_unique<Node>();
+    entry.submenu->name = name;
+    entry.submenu->weight = weight;
+    entry.submenu->menu = qmenu;
+    entry.submenu->parent = parent;
+
+    Node * raw = entry.submenu.get();
+    parent->entries.insert(parent->entries.begin() + idx, std::move(entry));
     return raw;
 }
 
-void RMenuModel::reweight(Node * parent, Node * node, int weight)
+void RMenuModel::placeAction(Node * node, QAction * action, int weight)
 {
-    // Detach from the Qt container and the sibling vector, then re-insert
-    // where the new weight places the node.
-    containerRemove(parent, node->menu);
+    int const idx = insertionIndex(node, weight);
+    containerInsert(node, action, beforeAt(node, idx));
 
-    int old = 0;
-    for (; old < static_cast<int>(parent->children.size()); ++old)
-    {
-        if (parent->children.at(old).get() == node)
-        {
-            break;
-        }
-    }
-    std::unique_ptr<Node> held = std::move(parent->children.at(old));
-    parent->children.erase(parent->children.begin() + old);
-
-    node->weight = weight;
-    int const idx = insertionIndex(parent, weight);
-    QAction * before = idx < static_cast<int>(parent->children.size())
-                           ? parent->children.at(idx)->menu->menuAction()
-                           : nullptr;
-    containerInsert(parent, node->menu, before);
-    parent->children.insert(parent->children.begin() + idx, std::move(held));
+    Entry entry;
+    entry.weight = weight;
+    entry.action = action;
+    node->entries.insert(node->entries.begin() + idx, std::move(entry));
 }
 
-int RMenuModel::insertionIndex(Node * parent, int weight) const
+int RMenuModel::insertionIndex(Node * node, int weight) const
 {
     int const ew = effective_weight(weight);
     int idx = 0;
-    for (; idx < static_cast<int>(parent->children.size()); ++idx)
+    for (; idx < static_cast<int>(node->entries.size()); ++idx)
     {
-        if (effective_weight(parent->children.at(idx)->weight) > ew)
+        if (effective_weight(node->entries.at(idx).weight) > ew)
         {
             break;
         }
@@ -146,24 +211,75 @@ int RMenuModel::insertionIndex(Node * parent, int weight) const
     return idx;
 }
 
-void RMenuModel::containerInsert(Node * parent, QMenu * menu, QAction * before)
+void RMenuModel::reweightEntry(Node * node, int index, int weight)
 {
-    if (parent == &m_root)
+    // Detach the entry from the Qt container and the sibling vector, then
+    // re-insert it where the new weight places it.
+    QAction * act = node->entries.at(index).action;
+    containerRemove(node, act);
+    Entry held = std::move(node->entries.at(index));
+    node->entries.erase(node->entries.begin() + index);
+
+    held.weight = weight;
+    if (held.submenu)
     {
-        before ? m_bar->insertMenu(before, menu) : m_bar->addMenu(menu);
+        held.submenu->weight = weight;
+    }
+    int const idx = insertionIndex(node, weight);
+    containerInsert(node, act, beforeAt(node, idx));
+    node->entries.insert(node->entries.begin() + idx, std::move(held));
+}
+
+QAction * RMenuModel::beforeAt(Node * node, int index) const
+{
+    return index < static_cast<int>(node->entries.size())
+               ? node->entries.at(index).action.data()
+               : nullptr;
+}
+
+void RMenuModel::containerInsert(Node * node, QAction * action, QAction * before)
+{
+    // QMenuBar and QMenu are both QWidgets, and QWidget::insertAction renders
+    // an action that carries a submenu as that submenu, so one path serves
+    // items, separators, and submenus alike.
+    QWidget * container = node == &m_root
+                              ? static_cast<QWidget *>(m_bar)
+                              : static_cast<QWidget *>(node->menu);
+    if (before)
+    {
+        container->insertAction(before, action);
     }
     else
     {
-        before ? parent->menu->insertMenu(before, menu) : parent->menu->addMenu(menu);
+        container->addAction(action);
     }
 }
 
-void RMenuModel::containerRemove(Node * parent, QMenu * menu)
+void RMenuModel::containerRemove(Node * node, QAction * action)
 {
-    QWidget * container = parent == &m_root
+    QWidget * container = node == &m_root
                               ? static_cast<QWidget *>(m_bar)
-                              : static_cast<QWidget *>(parent->menu);
-    container->removeAction(menu->menuAction());
+                              : static_cast<QWidget *>(node->menu);
+    container->removeAction(action);
+}
+
+bool RMenuModel::removeAction(Node * node, QAction * target)
+{
+    for (int i = 0; i < static_cast<int>(node->entries.size()); ++i)
+    {
+        Entry & entry = node->entries.at(i);
+        if (!entry.submenu && entry.action == target)
+        {
+            containerRemove(node, target);
+            node->entries.erase(node->entries.begin() + i);
+            return true;
+        }
+        if (entry.submenu && removeAction(entry.submenu.get(), target))
+        {
+            return true;
+        }
+    }
+    return false;
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RMenuModel.hpp
+++ b/cpp/solvcon/pilot/RMenuModel.hpp
@@ -7,13 +7,14 @@
 
 /**
  * @file
- * Live model of the pilot menu bar: menus addressed by path and weight.
+ * Live model of the pilot menu bar: menus by path, actions by id and weight.
  *
  * @ingroup group_domain
  */
 
 #include <solvcon/pilot/common_detail.hpp> // Must be the first include.
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -23,6 +24,7 @@
 #include <QString>
 
 class QAction;
+class QActionGroup;
 class QMainWindow;
 class QMenu;
 class QMenuBar;
@@ -36,12 +38,15 @@ namespace solvcon
  * @ingroup group_domain
  *
  * Menus are addressed by a slash-separated path ("View/Panels"). menu()
- * resolves a path, creating any missing ancestor on demand, and orders each
- * node among its siblings (and on the bar for a top-level path) by a weight
- * declared once. A smaller weight sits earlier; equal weights keep arrival
- * order; a negative weight leaves an existing node untouched and appends a new
- * one. The model owns the menus it creates, so clear() empties the bar and
- * lets a fresh setUp rebuild it.
+ * resolves a path, creating any missing ancestor on demand, and place() drops
+ * an action (or a separator) into the menu at a path. Every entry in a menu,
+ * whether a submenu or an item, is ordered by a weight: a smaller weight sits
+ * earlier, equal weights keep arrival order, and a negative weight appends.
+ *
+ * Placed actions are registered under their objectName, so action(id) looks
+ * one up and remove(id) takes it out. group(id) returns a named QActionGroup
+ * for exclusive selections. The model owns the menus and groups it creates, so
+ * clear() empties the bar and lets a fresh setUp rebuild it.
  */
 class RMenuModel
     : public QObject
@@ -59,10 +64,37 @@ public:
     /// leaves an existing node's order untouched and appends a new one.
     QMenu * menu(std::string const & path, int weight = -1);
 
-    /// Delete every menu the model created and empty the bar.
+    /// Place @p action in the menu at @p path, ordered by @p weight among the
+    /// menu's current entries. The action is registered under its objectName
+    /// when that name is set.
+    void place(std::string const & path, QAction * action, int weight = 50);
+
+    /// Place a separator in the menu at @p path, ordered by @p weight.
+    void placeSeparator(std::string const & path, int weight = 50);
+
+    /// The action registered under @p id, or nullptr when none is.
+    QAction * action(std::string const & id) const;
+
+    /// Remove and unregister the action registered under @p id, if any.
+    void remove(std::string const & id);
+
+    /// The named action group, created on first use.
+    QActionGroup * group(std::string const & id);
+
+    /// Delete every menu and group the model created and empty the bar.
     void clear();
 
 private:
+
+    struct Node;
+
+    struct Entry
+    {
+        int weight = -1;
+        QPointer<QAction> action; // the entry's QAction (item, separator, or
+                                  // a submenu's menuAction)
+        std::unique_ptr<Node> submenu; // non-null only for a submenu entry
+    };
 
     struct Node
     {
@@ -70,19 +102,25 @@ private:
         int weight = -1;
         QPointer<QMenu> menu; // nullptr for the root, which stands for the bar
         Node * parent = nullptr;
-        std::vector<std::unique_ptr<Node>> children;
+        std::vector<Entry> entries;
     };
 
+    Node * resolve(std::string const & path, int weight);
     Node * ensureChild(Node * parent, QString const & name, int weight);
-    void reweight(Node * parent, Node * node, int weight);
-    int insertionIndex(Node * parent, int weight) const;
-    void containerInsert(Node * parent, QMenu * menu, QAction * before);
-    void containerRemove(Node * parent, QMenu * menu);
+    void placeAction(Node * node, QAction * action, int weight);
+    int insertionIndex(Node * node, int weight) const;
+    void reweightEntry(Node * node, int index, int weight);
+    QAction * beforeAt(Node * node, int index) const;
+    void containerInsert(Node * node, QAction * action, QAction * before);
+    void containerRemove(Node * node, QAction * action);
+    bool removeAction(Node * node, QAction * target);
 
     QMainWindow * m_mainWindow = nullptr;
     QMenuBar * m_bar = nullptr;
     Node m_root;
     std::vector<QPointer<QMenu>> m_menus;
+    std::map<std::string, QPointer<QAction>> m_actions;
+    std::map<std::string, QPointer<QActionGroup>> m_groups;
 }; /* end class RMenuModel */
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -12,6 +12,8 @@
 #include <solvcon/pilot/RMenuModel.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
+#include <QAction>
+#include <QActionGroup>
 #include <QClipboard>
 #include <QMenu>
 #include <QPixmap>
@@ -105,6 +107,8 @@ public:
     }
 
 QT_TYPE_CASTER(QWidget, _("QWidget"));
+QT_TYPE_CASTER(QAction, _("QAction"));
+QT_TYPE_CASTER(QActionGroup, _("QActionGroup"));
 QT_TYPE_CASTER(QMenu, _("QMenu"));
 QT_TYPE_CASTER(QCoreApplication, _("QCoreApplication"));
 QT_TYPE_CASTER(QApplication, _("QApplication"));
@@ -366,6 +370,51 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRMenuModel
                 "Resolve or create the menu at a slash-separated path, "
                 "creating ancestors on demand; weight orders the node among "
                 "its siblings.")
+            .def(
+                "place",
+                [](wrapped_type & self, std::string const & path, QAction * action, int weight)
+                {
+                    self.place(path, action, weight);
+                },
+                py::arg("path"),
+                py::arg("action"),
+                py::arg("weight") = 50,
+                "Place an action in the menu at a path, ordered by weight; the "
+                "action is registered under its objectName when set.")
+            .def(
+                "place_separator",
+                [](wrapped_type & self, std::string const & path, int weight)
+                {
+                    self.placeSeparator(path, weight);
+                },
+                py::arg("path"),
+                py::arg("weight") = 50)
+            .def(
+                "action",
+                [](wrapped_type & self, std::string const & id) -> py::object
+                {
+                    // The Qt caster dereferences the pointer to find its
+                    // PySide type, so an unknown id must return None here.
+                    QAction * found = self.action(id);
+                    return found ? py::cast(found) : py::none();
+                },
+                py::arg("id"),
+                "The action registered under an id, or None.")
+            .def(
+                "remove",
+                [](wrapped_type & self, std::string const & id)
+                {
+                    self.remove(id);
+                },
+                py::arg("id"))
+            .def(
+                "group",
+                [](wrapped_type & self, std::string const & id)
+                {
+                    return self.group(id);
+                },
+                py::arg("id"),
+                "The named QActionGroup, created on first use.")
             .def(
                 "clear",
                 [](wrapped_type & self)

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -9,6 +9,7 @@ import solvcon
 
 try:
     from solvcon import pilot
+    from PySide6 import QtGui
 except ImportError:
     pilot = None
 
@@ -86,6 +87,73 @@ class MenuModelTC(unittest.TestCase):
         self.assertIn("Temp", self._top_level())
         self.model.clear()
         self.assertNotIn("Temp", self._top_level())
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class MenuPlacementTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+        self.model.clear()
+
+    def _act(self, text, oid):
+        act = QtGui.QAction(text, self.mgr.mainWindow)
+        act.setObjectName(oid)
+        return act
+
+    def _items(self, path):
+        return [a.text() for a in self.model.menu(path).actions()]
+
+    def test_place_orders_items_by_weight(self):
+        self.model.place("Box", self._act("Later", "b.later"), weight=40)
+        self.model.place("Box", self._act("Early", "b.early"), weight=10)
+        self.model.place("Box", self._act("Middle", "b.middle"), weight=25)
+        self.assertEqual(self._items("Box"), ["Early", "Middle", "Later"])
+
+    def test_place_equal_weight_keeps_arrival_order(self):
+        self.model.place("Box", self._act("First", "b.1"), weight=10)
+        self.model.place("Box", self._act("Second", "b.2"), weight=10)
+        self.model.place("Box", self._act("Third", "b.3"), weight=10)
+        self.assertEqual(self._items("Box"), ["First", "Second", "Third"])
+
+    def test_items_and_submenu_interleave_by_weight(self):
+        self.model.place("Box", self._act("Top", "b.top"), weight=5)
+        self.model.menu("Box/Sub", weight=10)
+        self.model.place("Box", self._act("Bottom", "b.bottom"), weight=20)
+        self.assertEqual(self._items("Box"), ["Top", "Sub", "Bottom"])
+
+    def test_action_id_round_trip(self):
+        act = self._act("Named", "box.named")
+        self.model.place("Box", act, weight=10)
+        self.assertEqual(self.model.action("box.named"), act)
+        self.assertIsNone(self.model.action("box.missing"))
+
+    def test_remove_takes_item_out(self):
+        self.model.place("Box", self._act("Gone", "box.gone"), weight=10)
+        self.assertIn("Gone", self._items("Box"))
+        self.model.remove("box.gone")
+        self.assertIsNone(self.model.action("box.gone"))
+        self.assertNotIn("Gone", self._items("Box"))
+
+    def test_remove_finds_item_in_a_submenu(self):
+        self.model.place("Box/Sub", self._act("Deep", "box.deep"), weight=10)
+        self.assertIn("Deep", self._items("Box/Sub"))
+        self.model.remove("box.deep")
+        self.assertNotIn("Deep", self._items("Box/Sub"))
+
+    def test_place_separator(self):
+        self.model.place("Box", self._act("A", "box.a"), weight=10)
+        self.model.place_separator("Box", weight=15)
+        self.model.place("Box", self._act("B", "box.b"), weight=20)
+        actions = self.model.menu("Box").actions()
+        self.assertTrue(actions[1].isSeparator())
+        self.assertEqual([actions[0].text(), actions[2].text()], ["A", "B"])
+
+    def test_group_is_created_once(self):
+        first = self.model.group("modes")
+        second = self.model.group("modes")
+        self.assertEqual(first, second)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Give the menu model action placement and identity, the second load-bearing
piece.

## What this adds

- A menu's entries become one weight-ordered list, so submenus and items
  interleave by weight rather than living in separate lanes.
- `place(path, action, weight)` and `place_separator(path, weight)` drop an
  action or a separator into a menu. Placed actions register under their
  `objectName`, so `action(id)` looks one up and `remove(id)` takes it out,
  from either language.
- `group(id)` returns a named `QActionGroup`, created on first use, for
  exclusive selections.
- The `QAction` and `QActionGroup` type casters, so PySide actions and groups
  cross the boundary. `action()` returns `None` for an unknown id rather than
  dereferencing a null pointer through the caster.

No consumers change yet.

## Testing

`tests/test_pilot_menu_model.py` adds weight-ordered placement, equal-weight
stability, item/submenu interleaving, id round-trip, removal from a menu and
from a submenu, separators, and named groups. GUI tests skip on CI runners
without a display.

Local `make lint`, `make gtest`, and `make run_pilot_pytest` all pass.