### PR TITLE
try/pilotmenu/step3

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -299,44 +299,51 @@ void RManager::setUpMenu()
     // NOTE: All menus need to be populated or Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
 
-    // The live menu model shares the same bar; consumers migrate onto it in
-    // later steps. Parent it to the main window so the widget tree owns it.
+    // Parent the model to the main window so the widget tree owns it.
     m_menuModel = new RMenuModel(m_mainWindow, m_mainWindow);
 
-    m_fileMenu = m_mainWindow->menuBar()->addMenu(QString("File"));
-    m_editMenu = m_mainWindow->menuBar()->addMenu(QString("Edit"));
+    // Seed the bar from one weighted table, the single source of truth for
+    // its order. The weight bands leave room to slot a menu between two
+    // others without renumbering. The members hold the model's menus until
+    // the getters become adapters over the model.
+    m_fileMenu = m_menuModel->menu("File", 0);
+    m_editMenu = m_menuModel->menu("Edit", 10);
+    m_viewMenu = m_menuModel->menu("View", 20);
+    m_oneMenu = m_menuModel->menu("One", 30);
+    m_meshMenu = m_menuModel->menu("Mesh", 40);
+    m_canvasMenu = m_menuModel->menu("Canvas", 50);
+    m_profilingMenu = m_menuModel->menu("Profiling", 60);
+    m_windowMenu = m_menuModel->menu("Window", 70);
+
     setUpEditMenuItems();
-    m_viewMenu = m_mainWindow->menuBar()->addMenu(QString("View"));
-    {
-        // Code for controlling camera is not exposed to Python yet
-        setUpCameraControllersMenuItems();
-        setUpCameraMovementMenuItems();
-    }
-    m_oneMenu = m_mainWindow->menuBar()->addMenu(QString("One"));
-    m_meshMenu = m_mainWindow->menuBar()->addMenu(QString("Mesh"));
-    m_canvasMenu = m_mainWindow->menuBar()->addMenu(QString("Canvas"));
-    m_profilingMenu = m_mainWindow->menuBar()->addMenu(QString("Profiling"));
-    m_windowMenu = m_mainWindow->menuBar()->addMenu(QString("Window"));
+    // Code for controlling camera is not exposed to Python yet.
+    setUpCameraControllersMenuItems();
+    setUpCameraMovementMenuItems();
 }
 
 void RManager::setUpEditMenuItems() const
 {
+    // Parent the actions to the model so they die with it instead of leaking.
     auto * undo_action = new RAction(
         QString("Undo"),
         QString("Undo the last change on the focused 2D canvas"),
         [this]()
-        { undoCanvas(); });
+        { undoCanvas(); },
+        m_menuModel);
+    undo_action->setObjectName("edit.undo");
     undo_action->setShortcut(QKeySequence::Undo);
 
     auto * redo_action = new RAction(
         QString("Redo"),
         QString("Redo the last undone change on the focused 2D canvas"),
         [this]()
-        { redoCanvas(); });
+        { redoCanvas(); },
+        m_menuModel);
+    redo_action->setObjectName("edit.redo");
     redo_action->setShortcut(QKeySequence::Redo);
 
-    m_editMenu->addAction(undo_action);
-    m_editMenu->addAction(redo_action);
+    m_menuModel->place("Edit", undo_action, 10);
+    m_menuModel->place("Edit", redo_action, 20);
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/tests/test_pilot_menu_model.py
+++ b/tests/test_pilot_menu_model.py
@@ -3,6 +3,7 @@
 
 
 import os
+import itertools
 import unittest
 
 import solvcon
@@ -15,6 +16,11 @@ except ImportError:
 
 GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
 
+# A fresh tag per test keeps each test's menus and ids from colliding on the
+# shared RManager singleton, whose menu model now owns the real bar; clearing
+# the model would delete the built-in menus other tests rely on.
+_TAG = itertools.count()
+
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
                  "GUI is not available in GitHub Actions")
@@ -22,9 +28,7 @@ class MenuModelTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
         self.model = self.mgr.menu_model
-        # The model persists on the singleton across tests; start each test
-        # from a bar holding only the built-in menus.
-        self.model.clear()
+        self.tag = "m%d_" % next(_TAG)
 
     def _top_level(self):
         return [a.text() for a in self.mgr.mainWindow.menuBar().actions()]
@@ -32,61 +36,60 @@ class MenuModelTC(unittest.TestCase):
     def _children(self, menu):
         return [a.text() for a in menu.actions()]
 
+    def _mine(self, *names):
+        wanted = {self.tag + n for n in names}
+        return [t for t in self._top_level() if t in wanted]
+
     def test_menu_creates_top_level_node(self):
-        menu = self.model.menu("Alpha")
-        self.assertEqual(menu.title(), "Alpha")
-        self.assertIn("Alpha", self._top_level())
+        menu = self.model.menu(self.tag + "Alpha")
+        self.assertEqual(menu.title(), self.tag + "Alpha")
+        self.assertIn(self.tag + "Alpha", self._top_level())
 
     def test_menu_is_idempotent(self):
-        first = self.model.menu("Alpha")
-        second = self.model.menu("Alpha")
+        first = self.model.menu(self.tag + "Alpha")
+        second = self.model.menu(self.tag + "Alpha")
         # The same path resolves to the same menu, not a duplicate on the bar.
         self.assertEqual(first, second)
-        self.assertEqual(self._top_level().count("Alpha"), 1)
+        self.assertEqual(self._top_level().count(self.tag + "Alpha"), 1)
 
     def test_menu_creates_ancestors_on_demand(self):
-        leaf = self.model.menu("Beta/Gamma")
+        leaf = self.model.menu(self.tag + "Beta/Gamma")
         self.assertEqual(leaf.title(), "Gamma")
-        self.assertIn("Beta", self._top_level())
-        parent = self.model.menu("Beta")
+        self.assertIn(self.tag + "Beta", self._top_level())
+        parent = self.model.menu(self.tag + "Beta")
         self.assertIn("Gamma", self._children(parent))
 
     def test_node_weight_orders_the_bar(self):
         # Declare out of order; the weights, not arrival, fix the bar order.
-        self.model.menu("Later", weight=40)
-        self.model.menu("Early", weight=10)
-        self.model.menu("Middle", weight=25)
-        top = [t for t in self._top_level() if t in ("Early", "Middle",
-                                                     "Later")]
-        self.assertEqual(top, ["Early", "Middle", "Later"])
+        self.model.menu(self.tag + "Later", weight=40)
+        self.model.menu(self.tag + "Early", weight=10)
+        self.model.menu(self.tag + "Middle", weight=25)
+        self.assertEqual(self._mine("Later", "Early", "Middle"),
+                         [self.tag + "Early", self.tag + "Middle",
+                          self.tag + "Later"])
 
     def test_equal_weight_keeps_arrival_order(self):
-        self.model.menu("Uno", weight=10)
-        self.model.menu("Dos", weight=10)
-        self.model.menu("Tres", weight=10)
-        top = [t for t in self._top_level() if t in ("Uno", "Dos", "Tres")]
-        self.assertEqual(top, ["Uno", "Dos", "Tres"])
+        self.model.menu(self.tag + "Uno", weight=10)
+        self.model.menu(self.tag + "Dos", weight=10)
+        self.model.menu(self.tag + "Tres", weight=10)
+        self.assertEqual(self._mine("Uno", "Dos", "Tres"),
+                         [self.tag + "Uno", self.tag + "Dos",
+                          self.tag + "Tres"])
 
     def test_submenu_weight_orders_children(self):
-        self.model.menu("Root", weight=90)
-        self.model.menu("Root/Second", weight=20)
-        self.model.menu("Root/First", weight=10)
-        parent = self.model.menu("Root")
+        self.model.menu(self.tag + "Root", weight=90)
+        self.model.menu(self.tag + "Root/Second", weight=20)
+        self.model.menu(self.tag + "Root/First", weight=10)
+        parent = self.model.menu(self.tag + "Root")
         self.assertEqual(self._children(parent), ["First", "Second"])
 
     def test_reweight_moves_an_existing_node(self):
-        self.model.menu("A", weight=10)
-        self.model.menu("B", weight=20)
+        self.model.menu(self.tag + "A", weight=10)
+        self.model.menu(self.tag + "B", weight=20)
         # Re-declaring with a larger weight repositions the same node.
-        self.model.menu("A", weight=30)
-        top = [t for t in self._top_level() if t in ("A", "B")]
-        self.assertEqual(top, ["B", "A"])
-
-    def test_clear_removes_model_menus(self):
-        self.model.menu("Temp")
-        self.assertIn("Temp", self._top_level())
-        self.model.clear()
-        self.assertNotIn("Temp", self._top_level())
+        self.model.menu(self.tag + "A", weight=30)
+        self.assertEqual(self._mine("A", "B"),
+                         [self.tag + "B", self.tag + "A"])
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
@@ -95,7 +98,8 @@ class MenuPlacementTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
         self.model = self.mgr.menu_model
-        self.model.clear()
+        self.tag = "p%d_" % next(_TAG)
+        self.box = self.tag + "Box"
 
     def _act(self, text, oid):
         act = QtGui.QAction(text, self.mgr.mainWindow)
@@ -106,53 +110,55 @@ class MenuPlacementTC(unittest.TestCase):
         return [a.text() for a in self.model.menu(path).actions()]
 
     def test_place_orders_items_by_weight(self):
-        self.model.place("Box", self._act("Later", "b.later"), weight=40)
-        self.model.place("Box", self._act("Early", "b.early"), weight=10)
-        self.model.place("Box", self._act("Middle", "b.middle"), weight=25)
-        self.assertEqual(self._items("Box"), ["Early", "Middle", "Later"])
+        self.model.place(self.box, self._act("Later", "b.later"), weight=40)
+        self.model.place(self.box, self._act("Early", "b.early"), weight=10)
+        self.model.place(self.box, self._act("Middle", "b.middle"), weight=25)
+        self.assertEqual(self._items(self.box), ["Early", "Middle", "Later"])
 
     def test_place_equal_weight_keeps_arrival_order(self):
-        self.model.place("Box", self._act("First", "b.1"), weight=10)
-        self.model.place("Box", self._act("Second", "b.2"), weight=10)
-        self.model.place("Box", self._act("Third", "b.3"), weight=10)
-        self.assertEqual(self._items("Box"), ["First", "Second", "Third"])
+        self.model.place(self.box, self._act("First", "b.1"), weight=10)
+        self.model.place(self.box, self._act("Second", "b.2"), weight=10)
+        self.model.place(self.box, self._act("Third", "b.3"), weight=10)
+        self.assertEqual(self._items(self.box), ["First", "Second", "Third"])
 
     def test_items_and_submenu_interleave_by_weight(self):
-        self.model.place("Box", self._act("Top", "b.top"), weight=5)
-        self.model.menu("Box/Sub", weight=10)
-        self.model.place("Box", self._act("Bottom", "b.bottom"), weight=20)
-        self.assertEqual(self._items("Box"), ["Top", "Sub", "Bottom"])
+        self.model.place(self.box, self._act("Top", "b.top"), weight=5)
+        self.model.menu(self.box + "/Sub", weight=10)
+        self.model.place(self.box, self._act("Bottom", "b.bottom"), weight=20)
+        self.assertEqual(self._items(self.box), ["Top", "Sub", "Bottom"])
 
     def test_action_id_round_trip(self):
-        act = self._act("Named", "box.named")
-        self.model.place("Box", act, weight=10)
-        self.assertEqual(self.model.action("box.named"), act)
-        self.assertIsNone(self.model.action("box.missing"))
+        act = self._act("Named", self.tag + "named")
+        self.model.place(self.box, act, weight=10)
+        self.assertEqual(self.model.action(self.tag + "named"), act)
+        self.assertIsNone(self.model.action(self.tag + "missing"))
 
     def test_remove_takes_item_out(self):
-        self.model.place("Box", self._act("Gone", "box.gone"), weight=10)
-        self.assertIn("Gone", self._items("Box"))
-        self.model.remove("box.gone")
-        self.assertIsNone(self.model.action("box.gone"))
-        self.assertNotIn("Gone", self._items("Box"))
+        self.model.place(self.box, self._act("Gone", self.tag + "gone"),
+                         weight=10)
+        self.assertIn("Gone", self._items(self.box))
+        self.model.remove(self.tag + "gone")
+        self.assertIsNone(self.model.action(self.tag + "gone"))
+        self.assertNotIn("Gone", self._items(self.box))
 
     def test_remove_finds_item_in_a_submenu(self):
-        self.model.place("Box/Sub", self._act("Deep", "box.deep"), weight=10)
-        self.assertIn("Deep", self._items("Box/Sub"))
-        self.model.remove("box.deep")
-        self.assertNotIn("Deep", self._items("Box/Sub"))
+        self.model.place(self.box + "/Sub",
+                         self._act("Deep", self.tag + "deep"), weight=10)
+        self.assertIn("Deep", self._items(self.box + "/Sub"))
+        self.model.remove(self.tag + "deep")
+        self.assertNotIn("Deep", self._items(self.box + "/Sub"))
 
     def test_place_separator(self):
-        self.model.place("Box", self._act("A", "box.a"), weight=10)
-        self.model.place_separator("Box", weight=15)
-        self.model.place("Box", self._act("B", "box.b"), weight=20)
-        actions = self.model.menu("Box").actions()
+        self.model.place(self.box, self._act("A", "box.a"), weight=10)
+        self.model.place_separator(self.box, weight=15)
+        self.model.place(self.box, self._act("B", "box.b"), weight=20)
+        actions = self.model.menu(self.box).actions()
         self.assertTrue(actions[1].isSeparator())
         self.assertEqual([actions[0].text(), actions[2].text()], ["A", "B"])
 
     def test_group_is_created_once(self):
-        first = self.model.group("modes")
-        second = self.model.group("modes")
+        first = self.model.group(self.tag + "modes")
+        second = self.model.group(self.tag + "modes")
         self.assertEqual(first, second)
 
 


### PR DESCRIPTION
Seed the pilot menu bar from the model, so its order is one declared table
rather than a run of imperative calls.

## What this changes

- `setUpMenu` builds the eight top-level menus through the model from one
  weighted table; the members hold the model's menus until the getters become
  adapters in a later step.
- The Edit items route through `place()` with stable ids ("edit.undo",
  "edit.redo") and a parent, which also stops the undo/redo actions from
  leaking.
- Behavior is preserved: the bar and each menu's items are byte-for-byte the
  same as before; only their source (weights, not call order) changed.

## Testing

The menu-model tests are made non-destructive: now that the model owns the
real bar, a shared `clear()` would delete the built-in menus, so each test
namespaces its own menus and ids instead. Local `make lint`, `make gtest`,
and `make run_pilot_pytest` pass.