### PR TITLE
try/pilotmenu/step5

### DIFF
--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -9,15 +9,13 @@ Graphical-user interface code
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
-import sys
-import importlib
-
 from . import _pilot_core as _pcore
 from . import airfoil
 
 if _pcore.enable:
     from PySide6.QtGui import QAction
     from PySide6.QtWidgets import QMenu
+    from . import _gui_common
     from . import _mesh
     from . import _mesh_info
     from . import _oblique
@@ -125,21 +123,6 @@ class _Controller(metaclass=_Singleton):
     def populate_menu(self):
         wm = self._rmgr
 
-        def _addAction(menu, text, tip, func, checkable=False, checked=False):
-            act = QAction(text, wm.mainWindow)
-            act.setStatusTip(tip)
-            act.setCheckable(checkable)
-            if checkable:
-                act.setChecked(checked)
-            if callable(func):
-                act.triggered.connect(lambda *a: func())
-            elif func:
-                modname, funcname = func.rsplit('.', maxsplit=1)
-                mod = importlib.import_module(modname)
-                func = getattr(mod, funcname)
-                act.triggered.connect(lambda *a: func())
-            menu.addAction(act)
-
         self.gmsh_dialog.populate_menu()
         self.svg_dialog.populate_menu()
         self.mesh_info.populate_menu()
@@ -154,22 +137,22 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata.populate_menu()
         self.runprofiling.populate_menu()
 
-        if sys.platform != 'darwin':
-            _addAction(
-                menu=wm.fileMenu,
-                text="Exit",
-                tip="Exit the application",
-                func=lambda: wm.quit(),
-            )
-
-        _addAction(
-            menu=wm.windowMenu,
-            text="Console",
-            tip="Open / Close Console",
-            func=wm.toggleConsole,
-            checkable=True,
-            checked=True,
-        )
+        # An explicit QuitRole lets macOS relocate Exit into the application
+        # menu, so no platform special case is needed.
+        wm.menu_model.place(
+            "File",
+            _gui_common.build_action(
+                wm.mainWindow, "Exit", "Exit the application",
+                lambda: wm.quit(), id="file.exit",
+                menu_role=QAction.MenuRole.QuitRole),
+            100)
+        wm.menu_model.place(
+            "Window",
+            _gui_common.build_action(
+                wm.mainWindow, "Console", "Open / Close Console",
+                wm.toggleConsole, id="window.console",
+                checkable=True, checked=True),
+            50)
 
 
 controller = _Controller()

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -6,6 +6,31 @@ from . import _pilot_core as _pcore
 from PySide6 import QtCore, QtGui
 
 
+def build_action(parent, text, tip, func, *, id=None, checkable=False,
+                 checked=False, shortcut=None, menu_role=None):
+    """Build a QAction from one description, the single item builder.
+
+    The id becomes the action's objectName (its handle in the menu model and
+    in tests). A checkable action carries its initial check state; ``func``,
+    when given, runs on trigger. A checkable feature that needs the toggled
+    state wires ``toggled`` on the returned action itself.
+    """
+    act = QtGui.QAction(text, parent)
+    if id:
+        act.setObjectName(id)
+    act.setStatusTip(tip)
+    if shortcut is not None:
+        act.setShortcut(shortcut)
+    if menu_role is not None:
+        act.setMenuRole(menu_role)
+    if checkable:
+        act.setCheckable(True)
+        act.setChecked(checked)
+    if func is not None:
+        act.triggered.connect(lambda *a: func())
+    return act
+
+
 class PilotFeature(QtCore.QObject):
     """
     Base class to house common GUI code for prototyping pilot features.
@@ -41,6 +66,21 @@ class PilotFeature(QtCore.QObject):
         """
         return self._mgr.mainWindow
 
+    def add_action(self, path, text, tip, func, *, id, weight=50,
+                   checkable=False, checked=False, shortcut=None,
+                   menu_role=None):
+        """Build an action and place it in the menu at ``path`` by ``weight``.
+
+        This is the one Python item builder over the shared placement: it
+        returns the live action so a toggle feature can wire its own reverse
+        connections.
+        """
+        act = build_action(self._mainWindow, text, tip, func, id=id,
+                           checkable=checkable, checked=checked,
+                           shortcut=shortcut, menu_role=menu_role)
+        self._mgr.menu_model.place(path, act, weight)
+        return act
+
     def _add_menu_item(self, menu, text, tip, func):
         """
         Add an item to the corresponding menu.
@@ -53,10 +93,7 @@ class PilotFeature(QtCore.QObject):
 
         :return: None
         """
-        act = QtGui.QAction(text, self._mainWindow)
-        act.setStatusTip(tip)
-        act.triggered.connect(func)
-        menu.addAction(act)
+        menu.addAction(build_action(self._mainWindow, text, tip, func))
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Give the Python side one item builder, so the three drifted helpers converge.

## What this changes

- Add `build_action`, the single description-to-QAction builder, and
  `PilotFeature.add_action` over the menu model's `place()`. `add_action`
  returns the live action so a toggle feature can wire its own reverse
  connections later.
- Reimplement `_add_menu_item` on the shared builder, and replace the
  controller's private `_addAction` with the builder plus the model.
- Exit gains an explicit `QuitRole`, so macOS relocates it into the
  application menu and the platform special case (and the `sys` / `importlib`
  imports) go away. Console keeps its checkable state.

Existing call signatures keep working, so no feature changes yet. Local
`make lint` and `make run_pilot_pytest` pass.