### PR TITLE
try/pilotmenu/step6

### DIFF
--- a/solvcon/pilot/_burgers1d.py
+++ b/solvcon/pilot/_burgers1d.py
@@ -78,11 +78,13 @@ class Burgers1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Burgers equation",
             tip="One-dimensional Burgers equation problem",
             func=self.run,
+            id="one.burgers",
+            weight=20,
         )
 
     def get_region_solver_config(self):

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -29,67 +29,84 @@ class Canvas(_gui_common.PilotFeature):
         self._blank_worlds = []
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Create ICCAD-2013",
             tip="Create ICCAD-2013 polygon examples",
             func=self.mesh_iccad_2013,
+            id="canvas.sample.iccad2013",
+            weight=10,
         )
-
-        tip = "Draw a sample S-shaped cubic Bezier curve with control points"
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier S-curve",
-            tip=tip,
+            tip="Draw a sample S-shaped cubic Bezier curve with control "
+                "points",
             func=self._bezier_s_curve,
+            id="canvas.sample.bezier_s",
+            weight=20,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier Arch",
             tip="Draw a sample arch-shaped cubic Bezier curve with control "
                 "points",
             func=self._bezier_arch,
+            id="canvas.sample.bezier_arch",
+            weight=30,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Bezier Loop",
             tip="Draw a sample loop-like cubic Bezier curve with control "
                 "points",
             func=self._bezier_loop,
+            id="canvas.sample.bezier_loop",
+            weight=40,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Ellipse",
             tip="Draw a sample ellipse (a=2, b=1)",
             func=self._ellipse,
+            id="canvas.sample.ellipse",
+            weight=50,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Parabola",
             tip="Draw a sample parabola (y = 0.5*x^2)",
             func=self._parabola,
+            id="canvas.sample.parabola",
+            weight=60,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="Sample: Hyperbola",
             tip="Draw a sample hyperbola (both branches)",
             func=self._hyperbola,
+            id="canvas.sample.hyperbola",
+            weight=70,
         )
 
-        self._mgr.canvasMenu.addSeparator()
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self._mgr.menu_model.place_separator("Canvas", weight=75)
+        self.add_action(
+            "Canvas",
             text="Create blank 2D canvas",
             tip="Open an empty 2D canvas with the Painter toolbox for "
                 "drawing shapes",
             func=self._create_blank_2d_canvas,
+            id="canvas.blank_2d",
+            weight=80,
         )
-        self._add_menu_item(
-            menu=self._mgr.canvasMenu,
+        self.add_action(
+            "Canvas",
             text="View: Open canvas in 2D",
             tip="Show the current canvas world in a strictly-2D QPainter "
                 "widget; the same world also drives the 3D view",
             func=self._open_2d,
+            id="canvas.open_2d",
+            weight=90,
         )
 
     def _create_blank_2d_canvas(self):

--- a/solvcon/pilot/_euler1d.py
+++ b/solvcon/pilot/_euler1d.py
@@ -16,11 +16,13 @@ class Euler1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Euler solver",
             tip="One-dimensional shock-tube problem with Euler solver",
             func=self.run,
+            id="one.euler",
+            weight=10,
         )
 
     def init_solver_config(self):

--- a/solvcon/pilot/_linear_wave.py
+++ b/solvcon/pilot/_linear_wave.py
@@ -34,11 +34,13 @@ class LinearWave1DApp(_base_app.OneDimBaseApp):
         """
         Set menu item for GUI.
         """
-        self._add_menu_item(
-            menu=self._mgr.oneMenu,
+        self.add_action(
+            "One",
             text="Linear Wave",
             tip="",
             func=self.run,
+            id="one.linear_wave",
+            weight=30,
         )
 
     def init_solver_config(self):

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -293,11 +293,13 @@ class SampleMeshDialog(_gui_common.PilotFeature):
         self._tree = None
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.meshMenu,
+        self.add_action(
+            "Mesh",
             text="Sample mesh dialog",
             tip="Choose an example mesh to create",
             func=self.open_dialog,
+            id="mesh.sample_dialog",
+            weight=10,
         )
 
     def open_dialog(self):
@@ -432,11 +434,13 @@ class GmshFileDialog(_gui_common.PilotFeature):
         self._diag.open(self, QtCore.SLOT('on_finished()'))
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.fileMenu,
+        self.add_action(
+            "File",
             text="Open Gmsh file",
             tip="Open Gmsh file",
             func=self.run,
+            id="file.gmsh",
+            weight=10,
         )
 
     @QtCore.Slot()

--- a/solvcon/pilot/_oblique.py
+++ b/solvcon/pilot/_oblique.py
@@ -129,12 +129,14 @@ class ObliqueShockSolver(_gui_common.PilotFeature):
         super(ObliqueShockSolver, self).__init__(*args, **kw)
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.meshMenu,
+        self.add_action(
+            "Mesh",
             text="(WIP) Oblique-shock solution (density)",
             tip="March the oblique-shock Euler solver and draw the density "
                 "as a 2D color field",
             func=self._run,
+            id="mesh.oblique_solver",
+            weight=20,
         )
 
     def _run(self):

--- a/solvcon/pilot/_profiling.py
+++ b/solvcon/pilot/_profiling.py
@@ -46,11 +46,13 @@ class Profiling(_gui_common.PilotFeature):
         self._diag.setWindowTitle("Open profiling file")
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.profilingMenu,
+        self.add_action(
+            "Profiling",
             text="Open profiling result",
             tip="Open JSON file of profiling result",
             func=self.open_profiling_result,
+            id="profiling.open",
+            weight=10,
         )
 
     def open_profiling_result(self):
@@ -191,11 +193,13 @@ class RunProfiling(_gui_common.PilotFeature):
         self.prof_opt = {}
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.profilingMenu,
+        self.add_action(
+            "Profiling",
             text="Profiling script",
             tip="Run profiling from script",
             func=self.load_profile_util,
+            id="profiling.run",
+            weight=20,
         )
 
     def load_profile_util(self):

--- a/solvcon/pilot/_svg_gui.py
+++ b/solvcon/pilot/_svg_gui.py
@@ -35,11 +35,13 @@ class SVGFileDialog(_gui_common.PilotFeature):
         self._diag.open(self, QtCore.SLOT('on_finished()'))
 
     def populate_menu(self):
-        self._add_menu_item(
-            menu=self._mgr.fileMenu,
+        self.add_action(
+            "File",
             text="Open SVG file",
             tip="Open SVG file",
             func=self.run,
+            id="file.svg",
+            weight=20,
         )
 
     @QtCore.Slot()


### PR DESCRIPTION
Migrate the flat features onto `add_action`.

Give every non-toggle `populate_menu` an explicit path, id, and weight instead
of a bare menu handle:

- the Gmsh and SVG file dialogs (File),
- the sample-mesh dialog and the oblique-shock solver (Mesh),
- the three 1D apps (One),
- the two profiling items (Profiling),
- the Canvas samples and working items with their separator (Canvas).

The bar is unchanged; its order now comes from the weights rather than the
call sequence. Local `make lint` and `make run_pilot_pytest` pass, and the
assembled menus were checked item-by-item against the previous order.