### PR TITLE
try/pilotmenu/step7

### DIFF
--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -14,7 +14,6 @@ from . import airfoil
 
 if _pcore.enable:
     from PySide6.QtGui import QAction
-    from PySide6.QtWidgets import QMenu
     from . import _gui_common
     from . import _mesh
     from . import _mesh_info
@@ -51,7 +50,6 @@ class _Controller(metaclass=_Singleton):
         # Do not construct any Qt member objects before calling launch(), or
         # Windows may "exited with code -1073740791."
         self._rmgr = None
-        self.panels_menu = None
         self.mesh_sample_dialog = None
         self.gmsh_dialog = None
         self.svg_dialog = None
@@ -73,27 +71,28 @@ class _Controller(metaclass=_Singleton):
         return None if self._rmgr is None else getattr(self._rmgr, name)
 
     def launch(self, name="pilot", size=(1000, 600)):
+        self.build(name=name, size=size)
+        self._rmgr.show()
+        return self._rmgr.exec()
+
+    def build(self, name="pilot", size=(1000, 600)):
+        """Assemble the window, features, and menu bar without the event
+        loop, so the fully built bar can be exercised from a test."""
         self._rmgr = _pcore.RManager.instance
         self._rmgr.setUp()
         self._rmgr.windowTitle = name
         self._rmgr.resize(w=size[0], h=size[1])
 
-        # Add the "Panels" submenu as the first item in the View menu.
-        view = self._rmgr.viewMenu
-        self.panels_menu = QMenu("Panels", self._rmgr.mainWindow)
-        actions = view.actions()
-        if actions:
-            view.insertMenu(actions[0], self.panels_menu)
-        else:
-            view.addMenu(self.panels_menu)
+        # Declare the Panels submenu first on the View menu; features place
+        # their toggles under the "View/Panels" path.
+        self._rmgr.menu_model.menu("View/Panels", weight=0)
 
         self.gmsh_dialog = _mesh.GmshFileDialog(mgr=self._rmgr)
         self.svg_dialog = _svg_gui.SVGFileDialog(mgr=self._rmgr)
         self.sample_mesh = _mesh.SampleMesh(mgr=self._rmgr)
         self.mesh_style_status = _mesh.MeshStyleStatus(mgr=self._rmgr)
         self.mesh_info = _mesh_info.MeshInfo(
-            mgr=self._rmgr, menu=self.panels_menu,
-            style_status=self.mesh_style_status)
+            mgr=self._rmgr, style_status=self.mesh_style_status)
         self.oblique_shock = _oblique.ObliqueShockMesh(mgr=self._rmgr)
         self.oblique_solver = _oblique.ObliqueShockSolver(mgr=self._rmgr)
         self.naca4airfoil = airfoil.Naca4Airfoil(mgr=self._rmgr)
@@ -102,14 +101,12 @@ class _Controller(metaclass=_Singleton):
         self.eulerone = _euler1d.Euler1DApp(mgr=self._rmgr)
         self.burgers = _burgers1d.Burgers1DApp(mgr=self._rmgr)
         self.linear_wave = _linear_wave.LinearWave1DApp(mgr=self._rmgr)
-        self.painter = _painter_gui.Painter(mgr=self._rmgr,
-                                            menu=self.panels_menu)
+        self.painter = _painter_gui.Painter(mgr=self._rmgr)
         self.canvas = _canvas_gui.Canvas(mgr=self._rmgr, painter=self.painter)
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
-        self._rmgr.show()
-        return self._rmgr.exec()
+        return self._rmgr
 
     def _mesh_sample_dialog_entries(self):
         """Every example mesh as ``(category, label, tip, func)``, in menu

--- a/solvcon/pilot/_mesh_info.py
+++ b/solvcon/pilot/_mesh_info.py
@@ -7,7 +7,6 @@
 import numpy as np
 
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QAction
 from PySide6.QtWidgets import (QWidget, QVBoxLayout, QDockWidget,
                                QTreeWidget, QTreeWidgetItem, QFrame)
 
@@ -208,13 +207,12 @@ class MeshInfoTree(QWidget):
 class MeshInfo(_gui_common.PilotFeature):
     """Mesh information panel, toggled from the View "Panels" submenu.
 
-    The caller supplies the ``menu`` group the toggle item is added to. When
-    on, the panel shows the active sub-window's mesh and follows the active
+    The toggle item is placed under the "View/Panels" path. When on, the
+    panel shows the active sub-window's mesh and follows the active
     sub-window; sub-windows without a mesh show "No mesh loaded".
     """
 
     def __init__(self, *args, **kw):
-        self._menu = kw.pop('menu')
         self._status = kw.pop('style_status')
         super().__init__(*args, **kw)
         self._action = None
@@ -222,11 +220,10 @@ class MeshInfo(_gui_common.PilotFeature):
         self._panel = None
 
     def populate_menu(self):
-        self._action = QAction("Mesh", self._mainWindow)
-        self._action.setStatusTip("Toggle the mesh information panel")
-        self._action.setCheckable(True)
+        self._action = self.add_action(
+            "View/Panels", "Mesh", "Toggle the mesh information panel", None,
+            id="panel.mesh_info", weight=10, checkable=True)
         self._action.toggled.connect(self._on_toggled)
-        self._menu.addAction(self._action)
 
     def _on_toggled(self, checked):
         """Show or hide the panel."""

--- a/solvcon/pilot/_painter_gui.py
+++ b/solvcon/pilot/_painter_gui.py
@@ -5,7 +5,7 @@
 Painter toolbox for the 2D canvas.
 """
 
-from PySide6 import QtCore, QtGui, QtWidgets
+from PySide6 import QtCore, QtWidgets
 
 from . import _gui_common
 from ._pilot_core import draw_tool_names, default_draw_tool_name
@@ -35,19 +35,17 @@ class Painter(_gui_common.PilotFeature):
     }
 
     def __init__(self, *args, **kw):
-        self._menu = kw.pop('menu', None)
         super(Painter, self).__init__(*args, **kw)
         self._action = None
         self._dock = None
         self._buttons = {}
 
     def populate_menu(self):
-        """Add a checkable "Painter" toggle to the supplied Panels menu."""
-        self._action = QtGui.QAction("Painter", self._mainWindow)
-        self._action.setStatusTip("Toggle the Painter toolbox")
-        self._action.setCheckable(True)
+        """Add a checkable "Painter" toggle under the View/Panels path."""
+        self._action = self.add_action(
+            "View/Panels", "Painter", "Toggle the Painter toolbox", None,
+            id="panel.painter", weight=20, checkable=True)
         self._action.toggled.connect(self._on_toggled)
-        self._menu.addAction(self._action)
 
     def _on_toggled(self, checked):
         """Show or hide the toolbox dock from the menu toggle."""

--- a/tests/test_pilot_bar.py
+++ b/tests/test_pilot_bar.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+BUILTINS = ["File", "Edit", "View", "One", "Mesh", "Canvas", "Profiling",
+            "Window"]
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class BarStructureTC(unittest.TestCase):
+    def test_full_bar_is_assembled_from_the_model(self):
+        mgr = _gui.controller.build()
+        model = mgr.menu_model
+
+        # The eight built-in menus keep their declared order. Other tests may
+        # append scratch menus to the shared singleton, so filter to these.
+        bar = [a.text() for a in mgr.mainWindow.menuBar().actions()]
+        self.assertEqual([t for t in bar if t in BUILTINS], BUILTINS)
+
+        # A known feature item lands under its intended path and id.
+        self.assertIsNotNone(model.action("mesh.sample_dialog"))
+        self.assertIn("Sample mesh dialog",
+                      [a.text() for a in model.menu("Mesh").actions()])
+
+        # Panels sits first in View and holds the two dock toggles.
+        view = [a.text() for a in model.menu("View").actions()]
+        self.assertEqual(view[0], "Panels")
+        panels = [a.text() for a in model.menu("View/Panels").actions()]
+        self.assertEqual(panels, ["Mesh", "Painter"])
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_mesh_info.py
+++ b/tests/test_pilot_mesh_info.py
@@ -12,7 +12,7 @@ try:
     from solvcon.pilot import _mesh_info
     from solvcon.pilot._mesh import MeshStyleStatus
     from PySide6.QtCore import Qt
-    from PySide6.QtWidgets import QApplication, QMenu
+    from PySide6.QtWidgets import QApplication
 except ImportError:
     pilot = None
 
@@ -107,8 +107,6 @@ class MakeMeshInfoTC(unittest.TestCase):
 class MeshInfoTC(unittest.TestCase):
     def setUp(self):
         self.mgr = pilot.RManager.instance.setUp()
-        # The "Panels" group is owned by the caller, not by MeshInfo.
-        self.menu = QMenu("Panels", self.mgr.mainWindow)
         # The View menu and the panel share one MeshStyleStatus.
         self.status = MeshStyleStatus(mgr=self.mgr)
 
@@ -125,10 +123,11 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_shows_active_mesh(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
-        self.assertIn(feature._action, self.menu.actions())
+        panels = self.mgr.menu_model.menu("View/Panels")
+        self.assertIn(feature._action, panels.actions())
         feature._action.setChecked(True)
         sections = _tree_sections(feature._panel._tree)
         self.assertEqual(sections["Counts"]["cell"], "3")
@@ -137,7 +136,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_boundary_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -163,7 +162,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_style_toggle_drives_viewer(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -197,7 +196,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_menu_and_panel_stay_linked(self):
         widget = self.mgr.add3DWidget()
         widget.updateMesh(_make_sample_mesh())
-        panel_feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        panel_feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                             style_status=self.status)
         panel_feature.populate_menu()
         panel_feature._action.setChecked(True)
@@ -216,7 +215,7 @@ class MeshInfoTC(unittest.TestCase):
 
     def test_panel_without_mesh(self):
         self.mgr.add3DWidget()  # fresh viewer becomes current, no mesh
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)
@@ -227,7 +226,7 @@ class MeshInfoTC(unittest.TestCase):
     def test_panel_updates_on_menu_load(self):
         # Loading from a menu creates and activates the viewer before
         # updateMesh runs, so the refresh is deferred to the event loop.
-        feature = _mesh_info.MeshInfo(mgr=self.mgr, menu=self.menu,
+        feature = _mesh_info.MeshInfo(mgr=self.mgr,
                                       style_status=self.status)
         feature.populate_menu()
         feature._action.setChecked(True)


### PR DESCRIPTION
Turn Panels into a path.

## What this changes

- Convert the Painter and MeshInfo toggles to `add_action` and drop the
  `menu=` constructor injection: both place their checkable item under the
  "View/Panels" path, the submenu the controller now declares at weight 0 so
  it stays first in the View menu.
- Split the controller's `launch` into a `build()` that assembles the window,
  features, and bar without the event loop, so the finished bar can be
  exercised from a test; `launch()` runs `build()` then the loop.

## Testing

- A new bar-structure test builds the whole controller and asserts the
  built-in menus and their order, a feature item under its path, and the two
  dock toggles under View/Panels.
- The mesh-info tests reach the toggle through the menu model instead of
  constructing and injecting their own Panels menu.

Local `make lint` and `make run_pilot_pytest` pass.