### PR TITLE
try/pilotmenu/step8

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -223,6 +223,17 @@ void RManager::setDrawTool(std::string const & name)
     }
     m_draw_tool = name;
     applyDrawTool();
+    // Keep the draw-tool action group in step, so scripting setDrawTool from
+    // the console checks the matching radio item and toolbox button. The
+    // action group's triggered wiring is unaffected because setChecked emits
+    // toggled, not triggered.
+    if (m_menuModel)
+    {
+        if (QAction * action = m_menuModel->action("draw.tool." + name))
+        {
+            action->setChecked(true);
+        }
+    }
 }
 
 void RManager::applyDrawTool()

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -29,8 +29,11 @@ class Canvas(_gui_common.PilotFeature):
         self._blank_worlds = []
 
     def populate_menu(self):
+        # Group the geometry samples under their own submenu, leaving the
+        # working items at the Canvas top level.
+        self._mgr.menu_model.menu("Canvas/Samples", weight=20)
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Create ICCAD-2013",
             tip="Create ICCAD-2013 polygon examples",
             func=self.mesh_iccad_2013,
@@ -38,7 +41,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=10,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier S-curve",
             tip="Draw a sample S-shaped cubic Bezier curve with control "
                 "points",
@@ -47,7 +50,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=20,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier Arch",
             tip="Draw a sample arch-shaped cubic Bezier curve with control "
                 "points",
@@ -56,7 +59,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=30,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Bezier Loop",
             tip="Draw a sample loop-like cubic Bezier curve with control "
                 "points",
@@ -65,7 +68,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=40,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Ellipse",
             tip="Draw a sample ellipse (a=2, b=1)",
             func=self._ellipse,
@@ -73,7 +76,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=50,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Parabola",
             tip="Draw a sample parabola (y = 0.5*x^2)",
             func=self._parabola,
@@ -81,7 +84,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=60,
         )
         self.add_action(
-            "Canvas",
+            "Canvas/Samples",
             text="Sample: Hyperbola",
             tip="Draw a sample hyperbola (both branches)",
             func=self._hyperbola,
@@ -89,7 +92,7 @@ class Canvas(_gui_common.PilotFeature):
             weight=70,
         )
 
-        self._mgr.menu_model.place_separator("Canvas", weight=75)
+        self._mgr.menu_model.place_separator("Canvas", weight=30)
         self.add_action(
             "Canvas",
             text="Create blank 2D canvas",

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -50,6 +50,7 @@ class _Controller(metaclass=_Singleton):
         # Do not construct any Qt member objects before calling launch(), or
         # Windows may "exited with code -1073740791."
         self._rmgr = None
+        self._built = False
         self.mesh_sample_dialog = None
         self.gmsh_dialog = None
         self.svg_dialog = None
@@ -77,7 +78,13 @@ class _Controller(metaclass=_Singleton):
 
     def build(self, name="pilot", size=(1000, 600)):
         """Assemble the window, features, and menu bar without the event
-        loop, so the fully built bar can be exercised from a test."""
+        loop, so the fully built bar can be exercised from a test.
+
+        Idempotent: the bar is populated once, so a second call (for example
+        from another test) returns the already-built manager unchanged.
+        """
+        if self._built:
+            return self._rmgr
         self._rmgr = _pcore.RManager.instance
         self._rmgr.setUp()
         self._rmgr.windowTitle = name
@@ -106,6 +113,7 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
+        self._built = True
         return self._rmgr
 
     def _mesh_sample_dialog_entries(self):

--- a/solvcon/pilot/_painter_gui.py
+++ b/solvcon/pilot/_painter_gui.py
@@ -39,13 +39,49 @@ class Painter(_gui_common.PilotFeature):
         self._action = None
         self._dock = None
         self._buttons = {}
+        self._tool_group = None
+        self._tool_actions = {}
 
     def populate_menu(self):
-        """Add a checkable "Painter" toggle under the View/Panels path."""
+        """Add the Painter toggle and the draw-tool radio group."""
         self._action = self.add_action(
             "View/Panels", "Painter", "Toggle the Painter toolbox", None,
             id="panel.painter", weight=20, checkable=True)
         self._action.toggled.connect(self._on_toggled)
+        self._build_tool_actions()
+
+    def _build_tool_actions(self):
+        """One exclusive checkable action per draw tool, the single source of
+        truth shared by the Canvas/Draw tool radio items and the toolbox
+        buttons. Each action routes its own trigger to the manager.
+
+        Idempotent: the tools are declared once on the model, so a second
+        Painter reuses the existing actions instead of duplicating them.
+        """
+        if self._tool_actions:
+            return
+        model = self._mgr.menu_model
+        model.menu("Canvas/Draw tool", weight=10)
+        # Held by the model under a group id so the selection is queryable.
+        self._tool_group = model.group("draw.tool")
+        self._tool_group.setExclusive(True)
+        mgr = self._mgr
+        weight = 10
+        created = False
+        for tool in draw_tool_names():
+            act = model.action("draw.tool." + tool)
+            if act is None:
+                label = self.TOOL_LABELS.get(tool, tool.title())
+                act = self.add_action(
+                    "Canvas/Draw tool", label, f"Draw with the {label} tool",
+                    lambda t=tool: mgr.setDrawTool(t),
+                    id="draw.tool." + tool, weight=weight, checkable=True)
+                self._tool_group.addAction(act)
+                created = True
+            self._tool_actions[tool] = act
+            weight += 10
+        if created:
+            self._tool_actions[default_draw_tool_name()].setChecked(True)
 
     def _on_toggled(self, checked):
         """Show or hide the toolbox dock from the menu toggle."""
@@ -56,25 +92,23 @@ class Painter(_gui_common.PilotFeature):
             self._dock.hide()
 
     def _ensure_dock(self):
-        """Create the dock and its tool buttons once, lazily."""
+        """Create the dock once, its buttons views of the tool actions."""
         if self._dock is not None:
             return
+        # A standalone Painter (used in tests) reaches the dock without
+        # populate_menu, so make sure the tool actions exist first.
+        self._build_tool_actions()
         dock = QtWidgets.QDockWidget("Painter", self._mainWindow)
         dock.setAllowedAreas(
             QtCore.Qt.LeftDockWidgetArea | QtCore.Qt.RightDockWidgetArea)
 
         body = QtWidgets.QWidget(dock)
         layout = QtWidgets.QVBoxLayout(body)
-        group = QtWidgets.QButtonGroup(body)
-        group.setExclusive(True)
-
         for tool in draw_tool_names():
             button = QtWidgets.QToolButton(body)
-            button.setText(self.TOOL_LABELS.get(tool, tool.title()))
-            button.setCheckable(True)
-            button.clicked.connect(
-                lambda checked=False, t=tool: self._select_tool(t))
-            group.addButton(button)
+            # The default action drives the button and reflects its checked
+            # state, so a menu radio and a button stay one selection.
+            button.setDefaultAction(self._tool_actions[tool])
             layout.addWidget(button)
             self._buttons[tool] = button
 
@@ -87,20 +121,12 @@ class Painter(_gui_common.PilotFeature):
         self._dock = dock
 
     def present(self):
-        """
-        Show the toolbox dock and reset the focused canvas to the Pan tool.
-        """
+        """Show the toolbox dock and reset the focused canvas to the default
+        tool; the action group updates every surface."""
         self._ensure_dock()
-        default_tool = default_draw_tool_name()
-        self._buttons[default_tool].setChecked(True)
-        self._select_tool(default_tool)
+        self._mgr.setDrawTool(default_draw_tool_name())
         self._dock.show()
         self._dock.raise_()
-
-    def _select_tool(self, tool):
-        """Set the selected tool; the manager applies it to the focused
-        canvas and re-applies it as focus moves between canvases."""
-        self._mgr.setDrawTool(tool)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4 tw=79:

--- a/tests/test_pilot_draw_tool.py
+++ b/tests/test_pilot_draw_tool.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot._pilot_core import draw_tool_names
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class DrawToolTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.painter = _gui.controller.painter
+
+    def test_one_radio_item_per_registered_tool(self):
+        items = [a.text()
+                 for a in self.model.menu("Canvas/Draw tool").actions()]
+        self.assertEqual(len(items), len(draw_tool_names()))
+
+    def test_samples_moved_under_their_own_submenu(self):
+        samples = [a.text()
+                   for a in self.model.menu("Canvas/Samples").actions()]
+        self.assertEqual(len(samples), 7)
+        # The samples no longer sit at the Canvas top level.
+        top = [a.text() for a in self.model.menu("Canvas").actions()
+               if not a.isSeparator()]
+        self.assertNotIn("Sample: Parabola", top)
+
+    def test_menu_radio_drives_manager_and_toolbox(self):
+        self.painter._ensure_dock()
+        self.model.action("draw.tool.line").trigger()
+        self.assertEqual(self.mgr.drawTool, "line")
+        # The toolbox button is a view of the same action.
+        self.assertTrue(
+            self.painter._buttons["line"].defaultAction().isChecked())
+        self.assertFalse(
+            self.painter._buttons["pan"].defaultAction().isChecked())
+
+    def test_console_set_draw_tool_checks_the_menu(self):
+        self.mgr.setDrawTool("rectangle")
+        group = self.model.group("draw.tool")
+        self.assertEqual(group.checkedAction().objectName(),
+                         "draw.tool.rectangle")
+        # The group is exclusive, so the previous choice clears.
+        self.assertFalse(self.model.action("draw.tool.line").isChecked())
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Drive the draw tools from one action group.

## What this changes

- The draw tools become an exclusive `QActionGroup` held by the model: one
  checkable action per registered tool, surfaced as "Canvas/Draw tool" radio
  items. The Painter toolbox buttons become `QToolButton` default-action views
  of the same actions, so every surface shows one selection and `present()` no
  longer hand-syncs button state.
- `setDrawTool` stays the programmatic entry point and now checks the matching
  action, so scripting it from the console updates the menu and buttons.
- The seven geometry samples move under "Canvas/Samples", leaving the working
  items at the Canvas top level.
- The controller's `build()` is made idempotent so a second call does not
  duplicate the bar.

## Testing

`tests/test_pilot_draw_tool.py` asserts one radio item per tool, that a menu
radio drives the manager and the toolbox button state, that scripting
`setDrawTool` checks the group's action, and that the samples moved under
Canvas/Samples. Local `make lint`, `make gtest`, and `make run_pilot_pytest`
pass.