### PR TITLE
try/pilotmenu/step9

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -76,14 +76,6 @@ void RManager::reset()
     }
     m_core.reset();
     m_mainWindow = nullptr;
-    m_fileMenu = nullptr;
-    m_editMenu = nullptr;
-    m_viewMenu = nullptr;
-    m_oneMenu = nullptr;
-    m_meshMenu = nullptr;
-    m_canvasMenu = nullptr;
-    m_profilingMenu = nullptr;
-    m_windowMenu = nullptr;
     m_menuModel = nullptr;
     m_pycon = nullptr;
     m_mdiArea = nullptr;
@@ -328,16 +320,16 @@ void RManager::setUpMenu()
 
     // Seed the bar from one weighted table, the single source of truth for
     // its order. The weight bands leave room to slot a menu between two
-    // others without renumbering. The members hold the model's menus until
-    // the getters become adapters over the model.
-    m_fileMenu = m_menuModel->menu("File", 0);
-    m_editMenu = m_menuModel->menu("Edit", 10);
-    m_viewMenu = m_menuModel->menu("View", 20);
-    m_oneMenu = m_menuModel->menu("One", 30);
-    m_meshMenu = m_menuModel->menu("Mesh", 40);
-    m_canvasMenu = m_menuModel->menu("Canvas", 50);
-    m_profilingMenu = m_menuModel->menu("Profiling", 60);
-    m_windowMenu = m_menuModel->menu("Window", 70);
+    // others without renumbering. Consumers reach these menus through the
+    // model by path.
+    m_menuModel->menu("File", 0);
+    m_menuModel->menu("Edit", 10);
+    m_menuModel->menu("View", 20);
+    m_menuModel->menu("One", 30);
+    m_menuModel->menu("Mesh", 40);
+    m_menuModel->menu("Canvas", 50);
+    m_menuModel->menu("Profiling", 60);
+    m_menuModel->menu("Window", 70);
 
     setUpEditMenuItems();
     // Code for controlling camera is not exposed to Python yet.

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -80,15 +80,6 @@ public:
     template <typename... Args>
     QMdiSubWindow * addSubWindow(Args &&... args);
 
-    QMenu * fileMenu() { return m_fileMenu; }
-    QMenu * editMenu() { return m_editMenu; }
-    QMenu * viewMenu() { return m_viewMenu; }
-    QMenu * oneMenu() { return m_oneMenu; }
-    QMenu * meshMenu() { return m_meshMenu; }
-    QMenu * canvasMenu() { return m_canvasMenu; }
-    QMenu * profilingMenu() { return m_profilingMenu; }
-    QMenu * windowMenu() { return m_windowMenu; }
-
     /// The live model of the menu bar, addressable by path from Python.
     RMenuModel * menuModel() { return m_menuModel; }
 
@@ -133,15 +124,6 @@ private:
     std::unique_ptr<QCoreApplication> m_core = nullptr;
 
     QMainWindow * m_mainWindow = nullptr;
-
-    QMenu * m_fileMenu = nullptr;
-    QMenu * m_editMenu = nullptr;
-    QMenu * m_viewMenu = nullptr;
-    QMenu * m_oneMenu = nullptr;
-    QMenu * m_meshMenu = nullptr;
-    QMenu * m_canvasMenu = nullptr;
-    QMenu * m_profilingMenu = nullptr;
-    QMenu * m_windowMenu = nullptr;
 
     /// Live menu model owned by the widget tree (parented to the main window).
     RMenuModel * m_menuModel = nullptr;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -537,14 +537,6 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.mainWindow();
                 })
-            .def_property_readonly("fileMenu", &wrapped_type::fileMenu)
-            .def_property_readonly("editMenu", &wrapped_type::editMenu)
-            .def_property_readonly("viewMenu", &wrapped_type::viewMenu)
-            .def_property_readonly("oneMenu", &wrapped_type::oneMenu)
-            .def_property_readonly("meshMenu", &wrapped_type::meshMenu)
-            .def_property_readonly("canvasMenu", &wrapped_type::canvasMenu)
-            .def_property_readonly("profilingMenu", &wrapped_type::profilingMenu)
-            .def_property_readonly("windowMenu", &wrapped_type::windowMenu)
             .def_property_readonly(
                 "menu_model",
                 [](wrapped_type & self)

--- a/solvcon/pilot/_mesh.py
+++ b/solvcon/pilot/_mesh.py
@@ -399,7 +399,7 @@ class MeshStyleStatus(QtCore.QObject):
     def populate_menu(self):
         """Add the View > Mesh styles submenu of independent check items."""
         window = self._mgr.mainWindow
-        submenu = QtWidgets.QMenu("Mesh styles", window)
+        submenu = self._mgr.menu_model.menu("View/Mesh styles")
         for name, label in self.STYLES:
             act = QtGui.QAction(label, window)
             act.setCheckable(True)
@@ -410,7 +410,6 @@ class MeshStyleStatus(QtCore.QObject):
             self._actions[name] = act
             submenu.addAction(act)
         self.changed.connect(self._sync_menu)
-        self._mgr.viewMenu.addMenu(submenu)
 
     def _sync_menu(self):
         """Match the menu check marks to the active viewer's styles."""


### PR DESCRIPTION
Delete the per-menu getters.

The mesh-style status was the last consumer of a per-menu getter; it now
creates its "View/Mesh styles" submenu through the menu model. With no
consumer left, remove the eight `QMenu*` members, their getters, and their
pybind11 bindings. `setUpMenu` declares the top-level menus on the model
without storing handles, and `reset()` no longer nulls them. Every menu is
now reached by path through the model.

Local `make lint`, `make gtest`, and `make run_pilot_pytest` pass.