### PR TITLE
Make the pilot console a persistent read-eval-print loop

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -278,10 +278,22 @@ void RPythonConsoleDockWidget::executeCommand()
     }
 
     commitCommand(command);
-    ++m_last_command_serial;
 
-    const auto formatted_command = std::format("[{}] {}\n\n", m_last_command_serial, command);
-    writeToHistory(formatted_command);
+    // Echo the submitted command with the interpreter's prompts: ">>> " for
+    // the first line and "... " for each continuation line, so the transcript
+    // reads like a read-eval-print loop.
+    {
+        QStringList const lines = QString::fromStdString(command).split('\n');
+        QString echo;
+        for (int i = 0; i < lines.size(); ++i)
+        {
+            echo += (0 == i) ? ">>> " : "... ";
+            echo += lines[i];
+            echo += '\n';
+        }
+        echo += '\n';
+        writeToHistory(echo.toStdString());
+    }
 
     m_command_edit->clear();
     m_current_command_index = static_cast<int>(m_committed_commands.size());

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -144,7 +144,6 @@ private:
     std::deque<std::string> m_committed_commands;
     size_t m_committed_commands_size_limit = 1024;
     int m_current_command_index = 0;
-    int m_last_command_serial = 0;
 
     python::PythonStreamRedirect m_python_redirect;
 

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -14,6 +14,7 @@ Tools to run applications
 # Use flake8 http://flake8.pycqa.org/en/latest/user/error-codes.html
 
 
+import code
 import importlib
 import rlcompleter
 
@@ -32,28 +33,71 @@ __all__ = [
 environ = {}
 
 
+class _ConsoleInterpreter(code.InteractiveConsole):
+    """
+    A :class:`code.InteractiveConsole` bound to an application namespace.
+
+    The console compiles in ``"single"`` mode, so a bare expression is
+    auto-displayed and bound to ``_`` the way the standard read-eval-print
+    loop does. Exceptions are formatted against the user's own input by
+    :meth:`showtraceback` and :meth:`showsyntaxerror`, not the host stack.
+
+    ``exit()`` or ``quit()`` typed in the console raises :exc:`SystemExit`,
+    which would tear down the interpreter that the pilot embeds. Guard it
+    here so the console reports the request without ending the process.
+    """
+    def push(self, line):
+        try:
+            return super().push(line)
+        except SystemExit:
+            self.write("SystemExit: use the window controls to quit.\n")
+            self.resetbuffer()
+            return False
+
+
 class AppEnvironment:
     """
     Collects the environment for an application.
 
+    The read-eval-print loop uses a single namespace, so :ivar:`globals`
+    and :ivar:`locals` are the same dict: names bound by executed code and
+    names injected by the pilot are both visible to the interpreter.
+
     :ivar globals:
-        The global namespace of the application.
+        The namespace of the application.
     :ivar locals:
-        The local namespace of the application.
+        An alias of :ivar:`globals`.
     """
     def __init__(self, name):
-        self.globals = {
+        namespace = {
             # Give the application an alias of the top package.
             'sc': importlib.import_module('solvcon'),
             'appenv': self,
         }
-        self.locals = {}
+        self.globals = namespace
+        self.locals = namespace
         self.name = name
+        self.console = _ConsoleInterpreter(namespace)
         # Each run of the application appends a new environment.
         environ[name] = self
 
-    def run_code(self, code):
-        exec(code, self.globals, self.locals)
+    def run_code(self, source):
+        """
+        Feed a possibly multi-line command to the persistent interpreter.
+
+        Each line drives ``push()``, which returns whether more input is
+        needed to complete the statement. A block left open after the last
+        line is closed with a blank line, the way a blank line ends a
+        compound statement in the interactive interpreter.
+
+        :return: True when the interpreter is still waiting for more input.
+        """
+        more = False
+        for line in source.split('\n'):
+            more = self.console.push(line)
+        if more:
+            more = self.console.push('')
+        return more
 
 
 def get_appenv(name=None):
@@ -100,9 +144,9 @@ def get_completions(text):
     return completions
 
 
-def run_code(code):
+def run_code(source):
     aenv = get_current_appenv()
-    aenv.run_code(code)
+    return aenv.run_code(source)
 
 
 def stop_code(appenvobj=None):

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -11,7 +11,6 @@ import builtins
 import sys
 import os
 import argparse
-import traceback
 import warnings
 
 import solvcon
@@ -132,13 +131,10 @@ def enter_main(argv):
 
 
 def exec_code(code):
-    try:
-        apputil.run_code(code)
-    except Exception as e:
-        sys.stdout.write("code:\n{}\n".format(code))
-        sys.stdout.write("{}: {}\n".format(type(e).__name__, str(e)))
-        sys.stdout.write("traceback:\n")
-        traceback.print_stack()
+    # The persistent interpreter reports a user exception through its own
+    # showtraceback/showsyntaxerror, which format the traceback against the
+    # console input. Do not wrap it in the host call stack.
+    return apputil.run_code(code)
 
 
 def get_completions(text):

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -17,11 +17,84 @@ class PilotTC(unittest.TestCase):
     def test_import(self):
         self.assertTrue(hasattr(solvcon.pilot, "mgr"))
 
-    @unittest.skip("headless testing is not ready")
+
+class PythonConsoleBackendTC(unittest.TestCase):
+    """
+    The persistent read-eval-print backend behind the pilot console.
+
+    These drive ``solvcon.apputil`` and ``solvcon.system`` directly, so
+    they run headlessly and do not need the Qt pilot to be built.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("test_{}".format(id(self)))
+
+    def _run(self, source):
+        """Run source in the test environment, capturing stdout and stderr."""
+        import io
+        from contextlib import redirect_stdout, redirect_stderr
+        out, err = io.StringIO(), io.StringIO()
+        with redirect_stdout(out), redirect_stderr(err):
+            more = self.env.run_code(source)
+        return more, out.getvalue(), err.getvalue()
+
     def test_pycon(self):
-        self.assertTrue(pilot.mgr.pycon.python_redirect)
-        pilot.mgr.pycon.python_redirect = False
-        self.assertFalse(pilot.mgr.pycon.python_redirect)
+        # A bare expression auto-displays and binds to _, the way a
+        # read-eval-print loop behaves, rather than printing nothing.
+        import builtins
+        more, out, err = self._run('21 + 21')
+        self.assertFalse(more)
+        self.assertEqual(out.strip(), '42')
+        self.assertEqual(builtins._, 42)
+        _, out, err = self._run('_ + 8')
+        self.assertEqual(out.strip(), '50')
+
+    def test_assignment_is_silent(self):
+        more, out, err = self._run('answer = 42')
+        self.assertFalse(more)
+        self.assertEqual(out, '')
+        _, out, err = self._run('answer')
+        self.assertEqual(out.strip(), '42')
+
+    def test_multiline_reports_more_then_runs(self):
+        import io
+        from contextlib import redirect_stdout
+        self.assertTrue(self.env.console.push('for i in range(3):'))
+        self.assertTrue(self.env.console.push('    print(i)'))
+        out = io.StringIO()
+        with redirect_stdout(out):
+            self.assertFalse(self.env.console.push(''))
+        self.assertEqual(out.getvalue(), '0\n1\n2\n')
+
+    def test_exception_reports_user_traceback(self):
+        _, out, err = self._run('raise ValueError("boom")')
+        self.assertIn('ValueError: boom', err)
+        self.assertIn('File "<console>"', err)
+        # The host call stack must not leak into the user-facing report.
+        self.assertNotIn('apputil', err)
+
+    def test_syntax_error_reports_offending_line(self):
+        _, out, err = self._run('def bad(:')
+        self.assertIn('SyntaxError', err)
+        self.assertIn('bad(', err)
+
+    def test_exit_does_not_kill_process(self):
+        # exit()/quit() raises SystemExit; the console swallows it so the
+        # embedded interpreter that hosts the pilot keeps running.
+        more, out, err = self._run('raise SystemExit(2)')
+        self.assertFalse(more)
+
+    def test_exec_code_entry_point_drives_the_console(self):
+        # The C++ widget calls solvcon.system.exec_code; it must feed the
+        # same persistent interpreter and auto-display the result.
+        import io
+        from contextlib import redirect_stdout
+        from solvcon import system
+        out = io.StringIO()
+        with redirect_stdout(out):
+            system.exec_code('6 * 7')
+        self.assertEqual(out.getvalue().strip(), '42')
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
## Summary

This makes the pilot's embedded Python console a persistent read-eval-print loop instead of running a fresh `exec()` for every submission. It is the first step of the console improvement work and unblocks the rest.

## What changes

`AppEnvironment` now owns a single `code.InteractiveConsole` bound to one namespace. `globals` and `locals` are the same dict, so names injected by the pilot (for example the `parser`, `world`, and `widget` handles the SVG and profiling panels push in) and names bound by executed code are both visible to the interpreter. `run_code` feeds a command to the console one line at a time through `push()`, which returns whether more input is needed and drives the `>>> ` and `... ` prompts; a block left open after the last line is closed with a blank line the way the interactive interpreter does.

Compiling in `"single"` mode auto-displays a bare expression and binds it to `_`, so `2 + 2` prints `4` without wrapping it in `print(...)`. Exceptions now surface through the interpreter's own `showtraceback` and `showsyntaxerror`, which format the user's traceback against the console input, and the wrong `traceback.print_stack()` path in `system.py:exec_code` (which printed the host call stack) is gone. `SystemExit` from `exit()` or `quit()` is caught so it cannot tear down the interpreter that the pilot embeds.

The console dock widget echoes a submitted command with the `>>> ` and `... ` prompts so the transcript reads like a real interpreter session.

## Tests

The console backend is exercisable from Python, so the tests run headlessly and do not need the Qt pilot. The previously skipped console test is un-skipped and rebuilt around the new backend, covering the bare-expression auto-display and `_` binding, the multiline more-input report, a user traceback (and that the host stack does not leak into it), a syntax error pointing at the offending line, the guarded `SystemExit`, and the `exec_code` entry point the C++ widget calls.
