### PR TITLE
Curate the pilot console namespace and fix the environment bookkeeping

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -172,6 +172,26 @@ R2DWidget * RManager::currentR2DWidget()
     return dynamic_cast<R2DWidget *>(subwin->widget());
 }
 
+std::vector<RDomainWidget *> RManager::list3DWidgets()
+{
+    std::vector<RDomainWidget *> widgets;
+    if (m_mdiArea == nullptr)
+    {
+        return widgets;
+    }
+
+    // A 3D viewer sits inside a host container subwindow, so resolve it
+    // through domainWidgetOf rather than casting the subwindow's widget.
+    for (auto subwin : m_mdiArea->subWindowList())
+    {
+        if (auto * viewer = domainWidgetOf(subwin))
+        {
+            widgets.push_back(viewer);
+        }
+    }
+    return widgets;
+}
+
 std::vector<R2DWidget *> RManager::list2DWidgets()
 {
     std::vector<R2DWidget *> widgets;

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -61,6 +61,7 @@ public:
     R2DWidget * add2DWidget();
     RDomainWidget * currentR3DWidget();
     R2DWidget * currentR2DWidget();
+    std::vector<RDomainWidget *> list3DWidgets();
     std::vector<R2DWidget *> list2DWidgets();
 
     /// Name of the active canvas drawing tool.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -742,6 +742,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                     return self.currentR2DWidget();
                 })
             .def(
+                "list3DWidgets",
+                [](wrapped_type & self)
+                {
+                    return self.list3DWidgets();
+                })
+            .def(
                 "list2DWidgets",
                 [](wrapped_type & self)
                 {

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -26,6 +26,9 @@ __all__ = [
     'get_completions',
     'run_code',
     'stop_code',
+    'build_pilot_namespace',
+    'format_banner',
+    'install_pilot_namespace',
 ]
 
 
@@ -77,9 +80,23 @@ class AppEnvironment:
         self.globals = namespace
         self.locals = namespace
         self.name = name
+        self.namespace_refreshers = []
         self.console = _ConsoleInterpreter(namespace)
         # Each run of the application appends a new environment.
         environ[name] = self
+
+    def seed(self, **handles):
+        """Install curated handles into the interpreter namespace."""
+        self.globals.update(handles)
+
+    def add_namespace_refresher(self, refresh):
+        """
+        Register a callback that refreshes the namespace before each command.
+
+        The callback receives the namespace dict. Use it for handles whose
+        value tracks live session state, such as the current viewer.
+        """
+        self.namespace_refreshers.append(refresh)
 
     def run_code(self, source):
         """
@@ -92,6 +109,8 @@ class AppEnvironment:
 
         :return: True when the interpreter is still waiting for more input.
         """
+        for refresh in self.namespace_refreshers:
+            refresh(self.globals)
         more = False
         for line in source.split('\n'):
             more = self.console.push(line)
@@ -118,13 +137,9 @@ get_appenv(name='master')
 
 
 def get_current_appenv():
-    has_key = False
-    for k in reversed(environ):
-        has_key = True
-        break
-    if not has_key:
+    if not environ:
         raise KeyError("No AppEnviron is available")
-    return environ[k]
+    return environ[next(reversed(environ))]
 
 
 def get_completions(text):
@@ -153,9 +168,84 @@ def stop_code(appenvobj=None):
     if None is appenvobj:
         environ.clear()
     else:
-        indices = [i for i, o in enumerate(environ) if o == appenvobj]
-        indices = reversed(indices)
-        for i in indices:
-            del environ[i]
+        names = [name for name, env in environ.items() if env is appenvobj]
+        for name in names:
+            del environ[name]
+
+
+def build_pilot_namespace(mgr):
+    """
+    Curated console handles and their descriptions for the pilot.
+
+    Duck-typed on the pilot manager (``mgr``) so it can be exercised with a
+    stand-in in the tests. Returns ``(handles, entries)`` where ``handles``
+    is a name-to-object dict to seed the namespace and ``entries`` is an
+    ordered list of ``(name, description)`` for the banner.
+    """
+    def show_mesh(m):
+        """Open a mesh in a fresh 3D viewer and return the viewer."""
+        w = mgr.add3DWidget()
+        w.updateMesh(m)
+        w.showAxis(True)
+        return w
+
+    def viewers():
+        """List the open 3D viewers."""
+        return list(mgr.list3DWidgets())
+
+    def meshes():
+        """List the meshes currently loaded in the 3D viewers."""
+        return [w.mesh for w in mgr.list3DWidgets() if w.mesh is not None]
+
+    viewer = mgr.currentR3DWidget()
+    handles = {
+        'mgr': mgr,
+        'viewer': viewer,
+        'mesh': None if viewer is None else viewer.mesh,
+        'show_mesh': show_mesh,
+        'viewers': viewers,
+        'meshes': meshes,
+    }
+    entries = [
+        ('mgr', 'the running pilot manager'),
+        ('viewer', 'the current 3D viewer (or None)'),
+        ('mesh', 'the current mesh (or None)'),
+        ('show_mesh(m)', 'open a mesh in a fresh 3D viewer'),
+        ('viewers()', 'list the open 3D viewers'),
+        ('meshes()', 'list the loaded meshes'),
+        ('sc', 'the solvcon package'),
+    ]
+    return handles, entries
+
+
+def _refresh_pilot_namespace(mgr, namespace):
+    viewer = mgr.currentR3DWidget()
+    namespace['viewer'] = viewer
+    namespace['mesh'] = None if viewer is None else viewer.mesh
+
+
+def format_banner(entries):
+    """Format ``(name, description)`` entries as an aligned banner."""
+    width = max(len(name) for name, _ in entries)
+    lines = ["solvcon pilot console. Handles in scope:"]
+    for name, desc in entries:
+        lines.append("  {}  {}".format(name.ljust(width), desc))
+    return "\n".join(lines) + "\n"
+
+
+def install_pilot_namespace(mgr, appenv):
+    """
+    Seed the console namespace from the pilot manager and keep it fresh.
+
+    The dynamic handles (``viewer``, ``mesh``) are refreshed before each
+    command so they track the focused viewer.
+
+    :return: The banner text listing the curated handles.
+    """
+    handles, entries = build_pilot_namespace(mgr)
+    appenv.seed(**handles)
+    appenv.add_namespace_refresher(
+        lambda namespace: _refresh_pilot_namespace(mgr, namespace))
+    return format_banner(entries)
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -12,6 +12,7 @@ Graphical-user interface code
 import sys
 import importlib
 
+from .. import apputil
 from . import _pilot_core as _pcore
 from . import airfoil
 
@@ -110,8 +111,15 @@ class _Controller(metaclass=_Singleton):
         self.openprofiledata = _profiling.Profiling(mgr=self._rmgr)
         self.runprofiling = _profiling.RunProfiling(mgr=self._rmgr)
         self.populate_menu()
+        self._seed_console_namespace()
         self._rmgr.show()
         return self._rmgr.exec()
+
+    def _seed_console_namespace(self):
+        """Curate the console namespace and greet with a banner."""
+        appenv = apputil.get_current_appenv()
+        banner = apputil.install_pilot_namespace(self._rmgr, appenv)
+        self._rmgr.pycon.writeToHistory(banner)
 
     def _mesh_sample_dialog_entries(self):
         """Every example mesh as ``(category, label, tip, func)``, in menu

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -97,6 +97,106 @@ class PythonConsoleBackendTC(unittest.TestCase):
         self.assertEqual(out.getvalue().strip(), '42')
 
 
+class _FakeViewer:
+    """A stand-in for a 3D viewer widget."""
+
+    def __init__(self):
+        self.mesh = None
+        self.axis = False
+
+    def updateMesh(self, mesh):
+        self.mesh = mesh
+
+    def showAxis(self, shown):
+        self.axis = shown
+
+
+class _FakeManager:
+    """A duck-typed stand-in for the pilot manager."""
+
+    def __init__(self):
+        self._viewers = []
+
+    def add3DWidget(self):
+        viewer = _FakeViewer()
+        self._viewers.append(viewer)
+        return viewer
+
+    def currentR3DWidget(self):
+        return self._viewers[-1] if self._viewers else None
+
+    def list3DWidgets(self):
+        return list(self._viewers)
+
+
+class PilotNamespaceTC(unittest.TestCase):
+    """
+    The curated console namespace and banner.
+
+    Driven with a stand-in manager, so it runs headlessly and does not
+    need the Qt pilot.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("ns_{}".format(id(self)))
+        self.mgr = _FakeManager()
+
+    def test_curated_handles_are_seeded(self):
+        from solvcon import apputil
+        banner = apputil.install_pilot_namespace(self.mgr, self.env)
+        g = self.env.globals
+        self.assertIs(g['mgr'], self.mgr)
+        self.assertIn('sc', g)
+        self.assertIsNone(g['viewer'])
+        self.assertIsNone(g['mesh'])
+        self.assertTrue(callable(g['show_mesh']))
+        self.assertIn('mgr', banner)
+        self.assertIn('show_mesh(m)', banner)
+
+    def test_show_mesh_opens_a_viewer(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        sentinel = object()
+        viewer = self.env.globals['show_mesh'](sentinel)
+        self.assertIs(viewer.mesh, sentinel)
+        self.assertTrue(viewer.axis)
+        self.assertEqual(self.env.globals['viewers'](), [viewer])
+        self.assertEqual(self.env.globals['meshes'](), [sentinel])
+
+    def test_refresher_tracks_the_current_viewer(self):
+        from solvcon import apputil
+        apputil.install_pilot_namespace(self.mgr, self.env)
+        # No viewer is open yet, so a command leaves the handles empty.
+        self.env.run_code('pass')
+        self.assertIsNone(self.env.globals['viewer'])
+        # Opening a viewer must be reflected on the next command, not stay
+        # stale at the value captured when the namespace was seeded.
+        sentinel = object()
+        self.mgr.add3DWidget().updateMesh(sentinel)
+        self.env.run_code('pass')
+        self.assertIs(self.env.globals['mesh'], sentinel)
+
+
+class HousekeepingTC(unittest.TestCase):
+    """The two latent bugs in the environment bookkeeping."""
+
+    def test_get_current_appenv_returns_the_latest(self):
+        from solvcon import apputil
+        first = apputil.AppEnvironment("hk_first_{}".format(id(self)))
+        latest = apputil.AppEnvironment("hk_latest_{}".format(id(self)))
+        self.assertIsNot(first, latest)
+        self.assertIs(apputil.get_current_appenv(), latest)
+
+    def test_stop_code_removes_the_named_environment(self):
+        from solvcon import apputil
+        name = "hk_stop_{}".format(id(self))
+        env = apputil.AppEnvironment(name)
+        self.assertIn(name, apputil.environ)
+        apputil.stop_code(env)
+        self.assertNotIn(name, apputil.environ)
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class SetupProcessTC(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

This makes the live pilot session discoverable from the console and fixes two latent bugs in the environment bookkeeping. It builds on the persistent read-eval-print loop from the previous step.

## Curated namespace and banner

`install_pilot_namespace` seeds the interpreter namespace with the handles a scientist actually reaches for and greets with a banner that lists them, so the running session no longer has to be reached through the `pilot` module by hand. The seeded names are `mgr` (the running manager), `viewer` (the current 3D viewer), `mesh` (its mesh), and the helpers `show_mesh(m)` (open a mesh in a fresh 3D viewer), `viewers()` (list the open 3D viewers), and `meshes()` (list the loaded meshes), alongside the existing `sc`.

`viewer` and `mesh` track the focused viewer through a namespace refresher that runs before each command, so they never go stale at the value captured when the console opened. The builder is duck-typed on the manager, and the banner is written to the transcript when the pilot starts.

`RManager` gains `list3DWidgets`, the 3D counterpart of the existing `list2DWidgets`. It resolves each viewer through `domainWidgetOf` because a 3D viewer sits inside a host container widget, so casting the subwindow's widget directly would miss it.

## Housekeeping fixes

Two latent bugs in the same module are fixed while here. `get_current_appenv` walked the environment dict only to take the last key; it now returns the latest environment directly. `stop_code` compared a dict key against the environment object and then deleted by integer index, so it never removed anything; it now removes the environment by name.

## Tests

The curation is duck-typed on the manager, so the tests drive it with a stand-in manager and run headlessly. They cover the seeded handles and banner, `show_mesh` opening a viewer, the refresher tracking the current viewer rather than the value seeded at open time, and both bookkeeping fixes (the `stop_code` test fails against the old integer-index code).
