### PR TITLE
Persist the console history and add reverse incremental search

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/pilot.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_pilot.hpp
@@ -53,6 +54,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RAction.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/wrap_pilot.cpp
     CACHE FILEPATH "" FORCE

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -8,6 +8,7 @@
 #include <QAbstractItemView>
 #include <QKeyEvent>
 #include <QScrollBar>
+#include <QStandardPaths>
 #include <QTextBlock>
 #include <QVBoxLayout>
 
@@ -102,6 +103,11 @@ void RPythonCommandTextEdit::insertCompletion(const QString & completion)
 //    - Shows a QCompleter popup if there are multiple matches
 // 4. While the popup is visible, Enter/Tab accepts the selection, Escape dismisses,
 //    and typing continues to narrow the matches via updateCompletionPrefix()
+bool RPythonCommandTextEdit::isModifierKey(int key)
+{
+    return Qt::Key_Control == key || Qt::Key_Shift == key || Qt::Key_Alt == key || Qt::Key_Meta == key;
+}
+
 void RPythonCommandTextEdit::keyPressEvent(QKeyEvent * event)
 {
     const bool popup_visible = m_completer && m_completer->popup()->isVisible();
@@ -125,6 +131,21 @@ void RPythonCommandTextEdit::keyPressEvent(QKeyEvent * event)
         default:
             break;
         }
+    }
+
+    // Ctrl-R drives reverse incremental search over the command history.
+    // Repeated presses walk to older matches; any editing key ends the
+    // session, while a bare modifier keeps it alive.
+    if (Qt::Key_R == event->key() && (event->modifiers() & Qt::ControlModifier))
+    {
+        m_searching = true;
+        searchHistory();
+        return;
+    }
+    if (m_searching && !isModifierKey(event->key()))
+    {
+        m_searching = false;
+        searchHistoryReset();
     }
 
     const QTextCursor cursor = textCursor();
@@ -239,6 +260,18 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
         });
     connect(m_command_edit, &RPythonCommandTextEdit::execute, this, &RPythonConsoleDockWidget::executeCommand);
     connect(m_command_edit, &RPythonCommandTextEdit::navigate, this, &RPythonConsoleDockWidget::navigateCommand);
+    connect(m_command_edit, &RPythonCommandTextEdit::searchHistory, this, &RPythonConsoleDockWidget::searchHistoryBackward);
+    connect(m_command_edit, &RPythonCommandTextEdit::searchHistoryReset, this, &RPythonConsoleDockWidget::endHistorySearch);
+
+    // Persist the command history under the solvcon profile directory and
+    // restore it, so recall survives across pilot sessions.
+    QString const config_dir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+    if (!config_dir.isEmpty())
+    {
+        m_history.setFilePath((config_dir + "/solvcon/console_history").toStdString());
+        m_history.load();
+        m_current_command_index = static_cast<int>(m_history.size());
+    }
 
     m_completer_model = new QStringListModel(this);
     m_completer = new QCompleter(m_completer_model, this);
@@ -278,6 +311,7 @@ void RPythonConsoleDockWidget::executeCommand()
     }
 
     commitCommand(command);
+    endHistorySearch();
 
     // Echo the submitted command with the interpreter's prompts: ">>> " for
     // the first line and "... " for each continuation line, so the transcript
@@ -296,7 +330,7 @@ void RPythonConsoleDockWidget::executeCommand()
     }
 
     m_command_edit->clear();
-    m_current_command_index = static_cast<int>(m_committed_commands.size());
+    m_current_command_index = static_cast<int>(m_history.size());
 
     auto & interp = solvcon::python::Interpreter::instance();
     m_python_redirect.activate();
@@ -311,7 +345,7 @@ void RPythonConsoleDockWidget::executeCommand()
 
 void RPythonConsoleDockWidget::navigateCommand(int offset)
 {
-    int const commands_num = static_cast<int>(m_committed_commands.size()); // make msc happy.
+    int const commands_num = static_cast<int>(m_history.size()); // make msc happy.
     if (commands_num == m_current_command_index)
     {
         m_draft_command = m_command_edit->toPlainText().toStdString();
@@ -321,7 +355,7 @@ void RPythonConsoleDockWidget::navigateCommand(int offset)
 
     const std::string & command_to_show = new_index == commands_num
                                               ? m_draft_command
-                                              : m_committed_commands[new_index];
+                                              : m_history.at(new_index);
 
     m_current_command_index = new_index;
     setCommand(QString::fromStdString(command_to_show));
@@ -341,12 +375,44 @@ int RPythonConsoleDockWidget::calcHeightToFitContents(const QTextEdit * edit)
 
 void RPythonConsoleDockWidget::commitCommand(const std::string & command)
 {
-    m_committed_commands.push_back(command);
+    m_history.add(command);
+}
 
-    if (m_committed_commands.size() > m_committed_commands_size_limit)
+void RPythonConsoleDockWidget::searchHistoryBackward()
+{
+    if (m_history.empty())
     {
-        m_committed_commands.pop_front();
+        return;
     }
+    // A fresh session takes the current editor text as the query and starts
+    // at the newest entry; a continuing session resumes just past the last
+    // match so repeated Ctrl-R walks toward older commands.
+    if (!m_history_search_active)
+    {
+        m_history_search_active = true;
+        m_history_search_query = m_command_edit->toPlainText().toStdString();
+        m_history_search_next = m_history.size() - 1;
+    }
+    if (RPythonConsoleHistory::npos == m_history_search_next)
+    {
+        return;
+    }
+
+    std::size_t const found = m_history.searchBackward(m_history_search_query, m_history_search_next);
+    if (RPythonConsoleHistory::npos == found)
+    {
+        return;
+    }
+
+    setCommand(QString::fromStdString(m_history.at(found)));
+    m_history_search_next = (0 == found) ? RPythonConsoleHistory::npos : found - 1;
+}
+
+void RPythonConsoleDockWidget::endHistorySearch()
+{
+    m_history_search_active = false;
+    m_history_search_query.clear();
+    m_history_search_next = 0;
 }
 
 void RPythonConsoleDockWidget::printCommandStdout(const std::string & stdout_message) const

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -15,10 +15,11 @@
 
 #include <solvcon/python/common.hpp> // must be first.
 
+#include <solvcon/pilot/RPythonConsoleHistory.hpp>
+
+#include <cstddef>
 #include <string>
-#include <deque>
 #include <stdexcept>
-#include <fstream>
 
 #include <Qt>
 #include <QCompleter>
@@ -59,6 +60,8 @@ signals:
     void execute();
     void navigate(int offset);
     void completionRequested(const QString & prefix);
+    void searchHistory();
+    void searchHistoryReset();
 
 private slots:
 
@@ -66,7 +69,10 @@ private slots:
 
 private:
 
+    static bool isModifierKey(int key);
+
     QCompleter * m_completer = nullptr;
+    bool m_searching = false;
 
 }; /* end class RPythonCommandTextEdit */
 
@@ -126,6 +132,8 @@ public:
 public slots:
     void executeCommand();
     void navigateCommand(int offset);
+    void searchHistoryBackward();
+    void endHistorySearch();
 
 private slots:
     void handleCompletionRequest(const QString & prefix);
@@ -141,9 +149,12 @@ private:
     RPythonHistoryTextEdit * m_history_edit = nullptr;
     RPythonCommandTextEdit * m_command_edit = nullptr;
     std::string m_draft_command;
-    std::deque<std::string> m_committed_commands;
-    size_t m_committed_commands_size_limit = 1024;
+    RPythonConsoleHistory m_history;
     int m_current_command_index = 0;
+
+    bool m_history_search_active = false;
+    std::string m_history_search_query;
+    std::size_t m_history_search_next = 0;
 
     python::PythonStreamRedirect m_python_redirect;
 

--- a/cpp/solvcon/pilot/RPythonConsoleHistory.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleHistory.cpp
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonConsoleHistory.hpp>
+
+#include <filesystem>
+#include <fstream>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// A command may span several lines, so escape backslash and newline to
+// keep each entry on one line in the file.
+std::string escape(std::string const & text)
+{
+    std::string out;
+    out.reserve(text.size());
+    for (char ch : text)
+    {
+        if (ch == '\\')
+        {
+            out += "\\\\";
+        }
+        else if (ch == '\n')
+        {
+            out += "\\n";
+        }
+        else
+        {
+            out += ch;
+        }
+    }
+    return out;
+}
+
+std::string unescape(std::string const & text)
+{
+    std::string out;
+    out.reserve(text.size());
+    for (std::size_t i = 0; i < text.size(); ++i)
+    {
+        if (text[i] == '\\' && i + 1 < text.size())
+        {
+            char const next = text[i + 1];
+            if (next == 'n')
+            {
+                out += '\n';
+                ++i;
+                continue;
+            }
+            if (next == '\\')
+            {
+                out += '\\';
+                ++i;
+                continue;
+            }
+        }
+        out += text[i];
+    }
+    return out;
+}
+
+} /* end namespace */
+
+void RPythonConsoleHistory::add(std::string const & command)
+{
+    if (command.empty())
+    {
+        return;
+    }
+    // Skip a consecutive duplicate so repeating a command does not flood
+    // the ring, matching how a shell history behaves.
+    if (!m_commands.empty() && m_commands.back() == command)
+    {
+        return;
+    }
+    m_commands.push_back(command);
+    while (m_commands.size() > m_limit)
+    {
+        m_commands.pop_front();
+    }
+    save();
+}
+
+void RPythonConsoleHistory::load()
+{
+    m_commands.clear();
+    if (m_path.empty())
+    {
+        return;
+    }
+    std::ifstream ifs(m_path);
+    if (!ifs)
+    {
+        return;
+    }
+    std::string line;
+    while (std::getline(ifs, line))
+    {
+        if (line.empty())
+        {
+            continue;
+        }
+        m_commands.push_back(unescape(line));
+    }
+    while (m_commands.size() > m_limit)
+    {
+        m_commands.pop_front();
+    }
+}
+
+void RPythonConsoleHistory::save() const
+{
+    if (m_path.empty())
+    {
+        return;
+    }
+    std::filesystem::path const path(m_path);
+    if (path.has_parent_path())
+    {
+        std::error_code ec;
+        std::filesystem::create_directories(path.parent_path(), ec);
+    }
+    std::ofstream ofs(m_path, std::ios::trunc);
+    if (!ofs)
+    {
+        return;
+    }
+    for (auto const & command : m_commands)
+    {
+        ofs << escape(command) << '\n';
+    }
+}
+
+std::size_t RPythonConsoleHistory::searchBackward(std::string const & query, std::size_t from) const
+{
+    if (m_commands.empty())
+    {
+        return npos;
+    }
+    std::size_t index = from < m_commands.size() ? from : m_commands.size() - 1;
+    while (true)
+    {
+        if (m_commands[index].find(query) != std::string::npos)
+        {
+            return index;
+        }
+        if (index == 0)
+        {
+            break;
+        }
+        --index;
+    }
+    return npos;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RPythonConsoleHistory.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleHistory.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * A persistent, searchable ring of console command history.
+ *
+ * @ingroup group_domain
+ */
+
+#include <cstddef>
+#include <deque>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * A capped ring of committed console commands, persisted to a file and
+ * searchable backward for reverse incremental search.
+ *
+ * The store is intentionally free of Qt so the persistence and search
+ * logic can be exercised by the C++ test suite. Commands may span several
+ * lines; they are escaped when written so each entry stays on one line in
+ * the file.
+ *
+ * @ingroup group_domain
+ */
+class RPythonConsoleHistory
+{
+
+public:
+
+    static constexpr std::size_t npos = static_cast<std::size_t>(-1);
+
+    explicit RPythonConsoleHistory(std::size_t limit = 1024)
+        : m_limit(limit)
+    {
+    }
+
+    void setFilePath(std::string path) { m_path = std::move(path); }
+    std::string const & filePath() const { return m_path; }
+
+    std::size_t size() const { return m_commands.size(); }
+    bool empty() const { return m_commands.empty(); }
+    std::string const & at(std::size_t index) const { return m_commands.at(index); }
+
+    /// Append a command, skipping an empty one or a consecutive duplicate,
+    /// cap the ring at the limit, and persist when a file path is set.
+    void add(std::string const & command);
+
+    /// Replace the in-memory ring with the content of the file path.
+    void load();
+
+    /// Persist the whole ring to the file path, creating parent directories.
+    void save() const;
+
+    /// The most recent entry at or before @p from whose text contains
+    /// @p query. Returns npos when none matches; an empty query matches the
+    /// entry at @p from.
+    std::size_t searchBackward(std::string const & query, std::size_t from) const;
+
+private:
+
+    std::deque<std::string> m_commands;
+    std::size_t m_limit;
+    std::string m_path;
+
+}; /* end class RPythonConsoleHistory */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -35,6 +35,8 @@ add_executable(
     test_nopython_formatter.cpp
     test_nopython_mdspan.cpp
     test_nopython_multidim.cpp
+    test_nopython_pilot_history.cpp
+    ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonConsoleHistory.cpp
     ${SOLVCON_TOGGLE_SOURCES}
     ${SOLVCON_BUFFER_SOURCES}
     ${SOLVCON_SERIALIZATION_SOURCES}

--- a/gtests/test_nopython_pilot_history.cpp
+++ b/gtests/test_nopython_pilot_history.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonConsoleHistory.hpp>
+
+#include <filesystem>
+#include <string>
+
+#include <gtest/gtest.h>
+
+using solvcon::RPythonConsoleHistory;
+
+namespace
+{
+
+std::string temp_path(char const * name)
+{
+    return (std::filesystem::temp_directory_path() / name).string();
+}
+
+} /* end namespace */
+
+TEST(PilotConsoleHistory, AddSkipsEmptyAndConsecutiveDuplicate)
+{
+    RPythonConsoleHistory hist;
+    hist.add("");
+    hist.add("a");
+    hist.add("a");
+    hist.add("b");
+    ASSERT_EQ(hist.size(), 2u);
+    EXPECT_EQ(hist.at(0), "a");
+    EXPECT_EQ(hist.at(1), "b");
+}
+
+TEST(PilotConsoleHistory, CapsAtLimit)
+{
+    RPythonConsoleHistory hist(3);
+    hist.add("1");
+    hist.add("2");
+    hist.add("3");
+    hist.add("4");
+    ASSERT_EQ(hist.size(), 3u);
+    EXPECT_EQ(hist.at(0), "2");
+    EXPECT_EQ(hist.at(2), "4");
+}
+
+TEST(PilotConsoleHistory, RoundTripsThroughFileWithMultilineAndBackslash)
+{
+    std::string const path = temp_path("solvcon_hist_roundtrip.txt");
+    std::filesystem::remove(path);
+
+    std::string const multiline = "for i in range(2):\n    print(i)";
+    std::string const backslash = R"(path = 'a\b')";
+    {
+        RPythonConsoleHistory hist;
+        hist.setFilePath(path);
+        hist.add("x = 1");
+        hist.add(multiline);
+        hist.add(backslash);
+    }
+
+    RPythonConsoleHistory loaded;
+    loaded.setFilePath(path);
+    loaded.load();
+    ASSERT_EQ(loaded.size(), 3u);
+    EXPECT_EQ(loaded.at(0), "x = 1");
+    EXPECT_EQ(loaded.at(1), multiline);
+    EXPECT_EQ(loaded.at(2), backslash);
+
+    std::filesystem::remove(path);
+}
+
+TEST(PilotConsoleHistory, SearchBackwardFindsMostRecentMatch)
+{
+    RPythonConsoleHistory hist;
+    hist.add("import os");
+    hist.add("mesh = load()");
+    hist.add("import sys");
+    hist.add("print(mesh)");
+
+    std::size_t index = hist.searchBackward("import", hist.size() - 1);
+    EXPECT_EQ(index, 2u);
+    index = hist.searchBackward("import", index - 1);
+    EXPECT_EQ(index, 0u);
+    EXPECT_EQ(hist.searchBackward("mesh", hist.size() - 1), 3u);
+    EXPECT_EQ(
+        hist.searchBackward("zzz", hist.size() - 1),
+        RPythonConsoleHistory::npos);
+}
+
+TEST(PilotConsoleHistory, EmptyQueryMatchesAtClampedFrom)
+{
+    RPythonConsoleHistory hist;
+    hist.add("a");
+    hist.add("b");
+    hist.add("c");
+    EXPECT_EQ(hist.searchBackward("", 1), 1u);
+    EXPECT_EQ(hist.searchBackward("", 100), 2u);
+}
+
+TEST(PilotConsoleHistory, SearchBackwardOnEmptyReturnsNpos)
+{
+    RPythonConsoleHistory hist;
+    EXPECT_EQ(hist.searchBackward("x", 0), RPythonConsoleHistory::npos);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
## Summary

This gives the console a persistent, searchable command history, so recall survives across pilot sessions and a long history is navigable. It replaces the in-memory-only ring from before.

## The history store

`RPythonConsoleHistory` is a small store kept deliberately free of Qt so its persistence and search logic can be exercised by the C++ test suite. It caps the ring, skips an empty command and a consecutive duplicate the way a shell history does, and saves each command to a file under the solvcon profile directory. A command may span several lines, so backslash and newline are escaped on write to keep each entry on one line. `searchBackward` returns the most recent entry at or before a given index whose text contains the query, which is what drives reverse incremental search.

## Widget wiring

The console dock widget owns the store instead of the old deque. It resolves the history file under the writable config location (`<config>/solvcon/console_history`), loads it at startup, and appends to it as commands run. `Ctrl-R` starts a reverse search: it takes the current editor text as the query and shows the most recent match, and each further `Ctrl-R` walks toward older matches. Any editing key ends the session, while a bare modifier keeps it alive.

## Tests

The store is Qt-free, so a C++ test in `test_nopython` covers it headlessly: the empty and consecutive-duplicate skipping, the ring cap, the file round trip with a multi-line command and a command containing a backslash, and the backward search including the no-match and empty-history cases. The store's `.cpp` is compiled into the test target directly, so the coverage does not need the Qt build.
