### PR TITLE
Show a call tip with the signature and docstring on an open paren

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -13,6 +13,7 @@
 #include <QScrollBar>
 #include <QStandardPaths>
 #include <QTextBlock>
+#include <QToolTip>
 #include <QVBoxLayout>
 
 namespace solvcon
@@ -82,6 +83,40 @@ QString RPythonCommandTextEdit::completionPrefix() const
         prefix = prefix.mid(1);
     }
     return prefix;
+}
+
+QString RPythonCommandTextEdit::callableExpression() const
+{
+    QTextCursor const tc = textCursor();
+    QString const block_text = tc.block().text();
+    int const pos = tc.positionInBlock();
+
+    // The cursor sits just past the '(' that triggered the tip; the callable
+    // is the identifier chain immediately before that '('.
+    if (pos < 2 || block_text[pos - 1] != '(')
+    {
+        return QString();
+    }
+    int const end = pos - 1;
+    int start = end - 1;
+    while (start >= 0)
+    {
+        QChar const ch = block_text[start];
+        if (ch.isLetterOrNumber() || ch == '_' || ch == '.')
+        {
+            --start;
+        }
+        else
+        {
+            break;
+        }
+    }
+    QString expr = block_text.mid(start + 1, end - start - 1);
+    while (expr.startsWith('.'))
+    {
+        expr = expr.mid(1);
+    }
+    return expr;
 }
 
 void RPythonCommandTextEdit::insertCompletion(const QString & completion)
@@ -236,6 +271,15 @@ void RPythonCommandTextEdit::keyPressEvent(QKeyEvent * event)
     else
     {
         QTextEdit::keyPressEvent(event);
+        // A '(' just typed after a callable asks for its signature tip.
+        if (event->text() == "(")
+        {
+            QString const expr = callableExpression();
+            if (!expr.isEmpty())
+            {
+                callTipRequested(expr);
+            }
+        }
     }
 }
 
@@ -330,6 +374,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     m_completer = new QCompleter(m_completer_model, this);
     m_command_edit->setCompleter(m_completer);
     connect(m_command_edit, &RPythonCommandTextEdit::completionRequested, this, &RPythonConsoleDockWidget::handleCompletionRequest);
+    connect(m_command_edit, &RPythonCommandTextEdit::callTipRequested, this, &RPythonConsoleDockWidget::handleCallTipRequest);
     connect(m_command_edit, &QTextEdit::textChanged, this, &RPythonConsoleDockWidget::updateCompletionPrefix);
 }
 
@@ -532,6 +577,19 @@ void RPythonConsoleDockWidget::handleCompletionRequest(const QString & prefix)
     cr.setWidth(
         m_completer->popup()->sizeHintForColumn(0) + m_completer->popup()->verticalScrollBar()->sizeHint().width());
     m_completer->complete(cr);
+}
+
+void RPythonConsoleDockWidget::handleCallTipRequest(const QString & expression)
+{
+    auto & interp = solvcon::python::Interpreter::instance();
+    std::string const tip = interp.get_call_tip(expression.toStdString());
+    if (tip.empty())
+    {
+        return;
+    }
+
+    QPoint const anchor = m_command_edit->mapToGlobal(m_command_edit->cursorRect().bottomRight());
+    QToolTip::showText(anchor, QString::fromStdString(tip), m_command_edit);
 }
 
 // Called on every textChanged signal while the popup is visible. As the user

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -53,6 +53,7 @@ public:
     void setCompleter(QCompleter * completer);
     QCompleter * completer() const { return m_completer; }
     QString completionPrefix() const;
+    QString callableExpression() const;
 
     void keyPressEvent(QKeyEvent * event) override;
 
@@ -63,6 +64,7 @@ signals:
     void completionRequested(const QString & prefix);
     void searchHistory();
     void searchHistoryReset();
+    void callTipRequested(const QString & expression);
 
 public slots:
 
@@ -142,6 +144,7 @@ public slots:
 
 private slots:
     void handleCompletionRequest(const QString & prefix);
+    void handleCallTipRequest(const QString & expression);
     void updateCompletionPrefix();
 
 private:

--- a/cpp/solvcon/python/common.cpp
+++ b/cpp/solvcon/python/common.cpp
@@ -206,6 +206,29 @@ std::vector<std::string> Interpreter::get_completions(std::string const & text)
     return result;
 }
 
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+std::string Interpreter::get_call_tip(std::string const & text)
+{
+    std::string result;
+    try
+    {
+        pybind11::gil_scoped_acquire const gil;
+        // NOLINTNEXTLINE(misc-const-correctness)
+        pybind11::object mod_sys = pybind11::module_::import("solvcon.system");
+        pybind11::object const py_result = mod_sys.attr("get_call_tip")(text);
+        result = py_result.cast<std::string>();
+    }
+    catch (const pybind11::error_already_set & e)
+    {
+        std::cerr << e.what() << std::endl;
+    }
+    catch (const std::exception & e)
+    {
+        std::cerr << "get_call_tip error: " << e.what() << std::endl;
+    }
+    return result;
+}
+
 PythonStreamRedirect & PythonStreamRedirect::activate()
 {
     if (is_enabled())

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -500,6 +500,7 @@ public:
     int enter_main();
     void exec_code(std::string const & code);
     std::vector<std::string> get_completions(std::string const & text);
+    std::string get_call_tip(std::string const & text);
 
 private:
 

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -16,6 +16,8 @@ Tools to run applications
 
 import code
 import importlib
+import inspect
+import re
 import rlcompleter
 
 
@@ -24,12 +26,20 @@ __all__ = [
     'AppEnvironment',
     'get_current_appenv',
     'get_completions',
+    'get_call_tip',
     'run_code',
     'stop_code',
     'build_pilot_namespace',
     'format_banner',
     'install_pilot_namespace',
 ]
+
+
+# A dotted identifier chain such as ``range`` or ``mgr.add3DWidget``. The
+# call tip only introspects such an expression, never one that calls or
+# subscripts, so evaluating it cannot run arbitrary user code.
+_IDENTIFIER_CHAIN = re.compile(
+    r'[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$')
 
 
 # All environment objects of this process.
@@ -157,6 +167,40 @@ def get_completions(text):
         completions.append(c)
         i += 1
     return completions
+
+
+def get_call_tip(expr):
+    """
+    A signature and docstring summary for the callable named by ``expr``.
+
+    ``expr`` is a dotted identifier chain such as ``range`` or
+    ``mgr.add3DWidget``. It is resolved against the current namespace, so,
+    like the introspective completion, it can touch live objects. It is
+    never evaluated when it is anything other than an identifier chain, so
+    a call or subscript cannot run arbitrary code. Returns an empty string
+    when the expression does not resolve to a callable.
+    """
+    expr = expr.strip()
+    if not _IDENTIFIER_CHAIN.match(expr):
+        return ''
+    aenv = get_current_appenv()
+    namespace = {'__builtins__': __builtins__}
+    namespace.update(aenv.globals)
+    try:
+        obj = eval(expr, namespace)
+    except Exception:
+        return ''
+    if not callable(obj):
+        return ''
+    try:
+        signature = str(inspect.signature(obj))
+    except (TypeError, ValueError):
+        signature = '(...)'
+    tip = expr + signature
+    doc = inspect.getdoc(obj)
+    if doc:
+        tip += '\n' + doc.strip().split('\n\n')[0]
+    return tip
 
 
 def run_code(source):

--- a/solvcon/system.py
+++ b/solvcon/system.py
@@ -22,6 +22,7 @@ __all__ = [
     'enter_main',
     'exec_code',
     'get_completions',
+    'get_call_tip',
 ]
 
 
@@ -143,5 +144,13 @@ def get_completions(text):
     except Exception as e:
         sys.stderr.write("get_completions error: {}\n".format(e))
         return []
+
+
+def get_call_tip(text):
+    try:
+        return apputil.get_call_tip(text)
+    except Exception as e:
+        sys.stderr.write("get_call_tip error: {}\n".format(e))
+        return ''
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -197,6 +197,60 @@ class HousekeepingTC(unittest.TestCase):
         self.assertNotIn(name, apputil.environ)
 
 
+class CallTipTC(unittest.TestCase):
+    """
+    The call tip that the console shows when a ``(`` is typed.
+
+    Driven through solvcon.apputil directly, so it runs headlessly.
+    """
+
+    def setUp(self):
+        from solvcon.apputil import AppEnvironment
+        self.env = AppEnvironment("tip_{}".format(id(self)))
+
+    def test_builtin_signature_and_docstring(self):
+        from solvcon import apputil
+        tip = apputil.get_call_tip('range')
+        self.assertTrue(tip.startswith('range('))
+        self.assertIn('range', tip)
+
+    def test_seeded_callable_signature_and_first_paragraph(self):
+        from solvcon import apputil
+
+        def greet(name, count=1):
+            """Say hello to someone.
+
+            This second paragraph must not appear in the tip.
+            """
+            return name
+
+        self.env.seed(greet=greet)
+        tip = apputil.get_call_tip('greet')
+        self.assertIn('greet(name, count=1)', tip)
+        self.assertIn('Say hello to someone.', tip)
+        self.assertNotIn('second paragraph', tip)
+
+    def test_non_callable_returns_empty(self):
+        from solvcon import apputil
+        self.env.seed(value=42)
+        self.assertEqual(apputil.get_call_tip('value'), '')
+
+    def test_unknown_name_returns_empty(self):
+        from solvcon import apputil
+        self.assertEqual(apputil.get_call_tip('does_not_exist'), '')
+
+    def test_call_expression_is_not_evaluated(self):
+        from solvcon import apputil
+
+        def boom():
+            raise AssertionError("the call tip must not invoke the callable")
+
+        self.env.seed(boom=boom)
+        # 'boom()' is not a bare identifier chain, so it is rejected before
+        # any evaluation and boom is never called.
+        self.assertEqual(apputil.get_call_tip('boom()'), '')
+
+
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
 class SetupProcessTC(unittest.TestCase):
 


### PR DESCRIPTION
## Summary

This keeps the introspective `rlcompleter` completion, which reflects real runtime state, and adds a call tip: when a `(` is typed after a callable, the console shows the callable's signature and the first line of its docstring.

## The tip

`get_call_tip` resolves the identifier chain before the paren against the current namespace and formats `inspect.signature` plus the first paragraph of the docstring. It reflects live runtime state the way the completion does, but it refuses to evaluate anything other than a dotted identifier chain (`range`, `mgr.add3DWidget`), so a call or subscript sitting in the text cannot run arbitrary code. When the expression does not resolve to a callable it returns an empty string and nothing is shown.

The C++ side reaches it through `Interpreter::get_call_tip`. The command editor extracts the callable immediately before the `(` it just inserted and shows the returned tip in a tooltip anchored at the cursor.

## Tests

`get_call_tip` is exercisable from Python, so the tests run headlessly: a builtin signature and docstring, a seeded function whose tip carries the exact signature and only the first docstring paragraph, a non-callable and an unknown name each returning empty, and a call expression that is rejected without ever invoking the callable (guarding against introspection side effects).

## Note on Jedi

The plan lists Jedi as an optional, additive back-end for type-aware completion. This step keeps the introspective path as the default and does not pull in the Jedi dependency; it can be added later without changing this surface.
