### PR TITLE
Show a busy state during a command and add a worker-thread helper

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -8,6 +8,7 @@
 #include <solvcon/pilot/RPythonSyntaxRules.hpp>
 
 #include <QAbstractItemView>
+#include <QApplication>
 #include <QColor>
 #include <QKeyEvent>
 #include <QScrollBar>
@@ -430,6 +431,10 @@ void RPythonConsoleDockWidget::executeCommand()
     m_command_edit->clear();
     m_current_command_index = static_cast<int>(m_history.size());
 
+    // The command runs on the GUI thread, so a slow one freezes the window.
+    // Show a busy cursor for the duration; run_worker in the console offloads
+    // heavy work to a worker thread when responsiveness matters.
+    QApplication::setOverrideCursor(Qt::WaitCursor);
     auto & interp = solvcon::python::Interpreter::instance();
     m_python_redirect.activate();
     interp.exec_code(command);
@@ -439,6 +444,7 @@ void RPythonConsoleDockWidget::executeCommand()
         printCommandStderr(m_python_redirect.stderr_string());
     }
     m_python_redirect.deactivate();
+    QApplication::restoreOverrideCursor();
 }
 
 void RPythonConsoleDockWidget::navigateCommand(int offset)

--- a/solvcon/apputil.py
+++ b/solvcon/apputil.py
@@ -15,6 +15,7 @@ Tools to run applications
 
 
 import code
+import concurrent.futures
 import importlib
 import inspect
 import re
@@ -28,11 +29,16 @@ __all__ = [
     'get_completions',
     'get_call_tip',
     'run_code',
+    'run_worker',
     'stop_code',
     'build_pilot_namespace',
     'format_banner',
     'install_pilot_namespace',
 ]
+
+
+# A lazily created single-thread pool that backs run_worker.
+_worker_pool = None
 
 
 # A dotted identifier chain such as ``range`` or ``mgr.add3DWidget``. The
@@ -208,6 +214,23 @@ def run_code(source):
     return aenv.run_code(source)
 
 
+def run_worker(func, *args, **kwargs):
+    """
+    Run ``func`` on a background worker thread and return its Future.
+
+    A command in the console runs on the GUI thread, so heavy work freezes
+    the window until it returns; the console cannot interrupt a running
+    command in-process. Hand such work to this helper instead: the solver
+    core releases the GIL while it computes, so the GUI stays responsive.
+    Poll the returned :class:`concurrent.futures.Future` for the result.
+    """
+    global _worker_pool
+    if _worker_pool is None:
+        _worker_pool = concurrent.futures.ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix='solvcon-console-worker')
+    return _worker_pool.submit(func, *args, **kwargs)
+
+
 def stop_code(appenvobj=None):
     if None is appenvobj:
         environ.clear()
@@ -249,6 +272,7 @@ def build_pilot_namespace(mgr):
         'show_mesh': show_mesh,
         'viewers': viewers,
         'meshes': meshes,
+        'run_worker': run_worker,
     }
     entries = [
         ('mgr', 'the running pilot manager'),
@@ -257,6 +281,7 @@ def build_pilot_namespace(mgr):
         ('show_mesh(m)', 'open a mesh in a fresh 3D viewer'),
         ('viewers()', 'list the open 3D viewers'),
         ('meshes()', 'list the loaded meshes'),
+        ('run_worker(f)', 'run f on a worker thread; returns a Future'),
         ('sc', 'the solvcon package'),
     ]
     return handles, entries

--- a/tests/test_pilot.py
+++ b/tests/test_pilot.py
@@ -151,6 +151,7 @@ class PilotNamespaceTC(unittest.TestCase):
         self.assertIsNone(g['viewer'])
         self.assertIsNone(g['mesh'])
         self.assertTrue(callable(g['show_mesh']))
+        self.assertTrue(callable(g['run_worker']))
         self.assertIn('mgr', banner)
         self.assertIn('show_mesh(m)', banner)
 
@@ -249,6 +250,32 @@ class CallTipTC(unittest.TestCase):
         # 'boom()' is not a bare identifier chain, so it is rejected before
         # any evaluation and boom is never called.
         self.assertEqual(apputil.get_call_tip('boom()'), '')
+
+
+class WorkerTC(unittest.TestCase):
+    """The worker-thread helper for heavy console work."""
+
+    def test_runs_off_the_calling_thread(self):
+        import threading
+        from solvcon import apputil
+        caller = threading.get_ident()
+        future = apputil.run_worker(threading.get_ident)
+        self.assertNotEqual(future.result(timeout=5), caller)
+
+    def test_returns_the_result(self):
+        from solvcon import apputil
+        future = apputil.run_worker(lambda a, b: a + b, 2, 3)
+        self.assertEqual(future.result(timeout=5), 5)
+
+    def test_propagates_exceptions_through_the_future(self):
+        from solvcon import apputil
+
+        def boom():
+            raise ValueError("worker failed")
+
+        future = apputil.run_worker(boom)
+        with self.assertRaises(ValueError):
+            future.result(timeout=5)
 
 
 @unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")


### PR DESCRIPTION
## Summary

This is honest about the one limit of an in-process console, that a command runs on the GUI thread and cannot be interrupted, and it gives a way around a slow command instead of leaving the window silently frozen.

## Busy state

The console shows a busy cursor for the duration of a command. Execution is synchronous on the Qt thread, so the window is unresponsive while a command runs; the cursor makes that visible rather than leaving the freeze unexplained.

## Worker-thread helper

`run_worker` submits a callable to a background worker thread and returns its `concurrent.futures.Future`. Heavy solver work releases the GIL in the C++ core while it computes, so running it through this helper keeps the GUI event loop responsive; the result is read from the returned future. True in-console interrupt is not achievable in-process, so this is the honest mitigation rather than a promise of interruption. The helper is seeded into the console namespace and listed in the banner alongside the other handles.

## Tests

`run_worker` is exercisable from Python, so the tests run headlessly: it runs off the calling thread, returns the result, and propagates an exception through the future. The curated-namespace test also checks the handle is seeded.
