### PR TITLE
Store dynamic toggles in stable-address registers

### DIFF
--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -58,7 +58,7 @@ std::string const DynamicToggleTable::sentinel_string = "";
         {                                                                      \
             if (it->second.is_##MTYPE())                                       \
             {                                                                  \
-                return m_vector_##MTYPE.at(it->second.index);                  \
+                return m_column_##MTYPE.at(it->second.index).value;            \
             }                                                                  \
         }                                                                      \
         return SENTINEL;                                                       \
@@ -87,7 +87,7 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
         {                                                                                                                      \
             if (it->second.is_##MTYPE())                                                                                       \
             {                                                                                                                  \
-                m_vector_##MTYPE.at(it->second.index) = value;                                                                 \
+                m_column_##MTYPE.at(it->second.index).value = value;                                                           \
             }                                                                                                                  \
             else                                                                                                               \
             {                                                                                                                  \
@@ -96,9 +96,9 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
         }                                                                                                                      \
         else                                                                                                                   \
         {                                                                                                                      \
-            DynamicToggleIndex const index{static_cast<uint32_t>(m_vector_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
+            DynamicToggleIndex const index{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
             m_key2index.insert({key, index});                                                                                  \
-            m_vector_##MTYPE.push_back(value);                                                                                 \
+            m_column_##MTYPE.append(value);                                                                                    \
         }                                                                                                                      \
     }                                                                                                                          \
     void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                           \
@@ -148,13 +148,14 @@ std::vector<std::string> DynamicToggleTable::keys() const
 void DynamicToggleTable::clear()
 {
     m_key2index.clear();
-    m_vector_bool.clear();
-    m_vector_int8.clear();
-    m_vector_int16.clear();
-    m_vector_int32.clear();
-    m_vector_int64.clear();
-    m_vector_real.clear();
-    m_vector_string.clear();
+    m_column_bool.clear();
+    m_column_int8.clear();
+    m_column_int16.clear();
+    m_column_int32.clear();
+    m_column_int64.clear();
+    m_column_real.clear();
+    m_column_string.clear();
+    ++m_generation;
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,6 +17,8 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <cstdint>
+#include <deque>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -25,6 +27,59 @@ namespace solvcon
 {
 
 int setenv(const char * name, const char * value, int overwrite);
+
+/**
+ * A single stored toggle value.
+ *
+ * Named after the atomic register of shared-memory theory: a single-value
+ * shared location. For now it boxes a plain value; a later step makes the
+ * scalar read and write atomic without changing this shape.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+struct ToggleRegister
+{
+    T value;
+}; /* end struct ToggleRegister */
+
+/**
+ * Segmented column of ToggleRegister<T> with stable element addresses.
+ *
+ * Registers append into a std::deque, so a register keeps its address as
+ * the column grows, unlike a reallocating std::vector. A resolved handle
+ * can therefore keep pointing at its register while unrelated toggles are
+ * added. Indices are dense and start at zero, matching the offsets held by
+ * DynamicToggleIndex.
+ *
+ * @ingroup group_core
+ */
+template <typename T>
+class ToggleRegisterColumn
+{
+
+public:
+
+    size_t size() const { return m_registers.size(); }
+
+    ToggleRegister<T> & at(size_t index) { return m_registers.at(index); }
+    ToggleRegister<T> const & at(size_t index) const { return m_registers.at(index); }
+
+    size_t append(T const & value)
+    {
+        size_t const index = m_registers.size();
+        m_registers.emplace_back();
+        m_registers.back().value = value;
+        return index;
+    }
+
+    void clear() { m_registers.clear(); }
+
+private:
+
+    std::deque<ToggleRegister<T>> m_registers;
+
+}; /* end class ToggleRegisterColumn */
 
 /**
  * Index and type tag that locates a dynamic toggle value in its typed
@@ -184,16 +239,26 @@ public:
     std::vector<std::string> keys() const;
     void clear();
 
+    /**
+     * Monotonic stamp bumped on every clear.
+     *
+     * A handle resolved before a clear carries the old generation, so it
+     * can be detected as stale rather than aliasing a register reused
+     * after the clear.
+     */
+    uint64_t generation() const { return m_generation; }
+
 private:
 
     keymap_type m_key2index;
-    std::vector<bool> m_vector_bool;
-    std::vector<int8_t> m_vector_int8;
-    std::vector<int16_t> m_vector_int16;
-    std::vector<int32_t> m_vector_int32;
-    std::vector<int64_t> m_vector_int64;
-    std::vector<double> m_vector_real;
-    std::vector<std::string> m_vector_string;
+    ToggleRegisterColumn<bool> m_column_bool;
+    ToggleRegisterColumn<int8_t> m_column_int8;
+    ToggleRegisterColumn<int16_t> m_column_int16;
+    ToggleRegisterColumn<int32_t> m_column_int32;
+    ToggleRegisterColumn<int64_t> m_column_int64;
+    ToggleRegisterColumn<double> m_column_real;
+    ToggleRegisterColumn<std::string> m_column_string;
+    uint64_t m_generation = 0;
 
 }; /* end class DynamicToggleTable */
 
@@ -323,6 +388,7 @@ public:
 
     std::vector<std::string> dynamic_keys() const { return m_dynamic_table.keys(); }
     void dynamic_clear() { m_dynamic_table.clear(); }
+    uint64_t dynamic_generation() const { return m_dynamic_table.generation(); }
     DynamicToggleIndex get_dynamic_index(std::string const & key) const { return m_dynamic_table.get_index(key); }
 
     bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }


### PR DESCRIPTION
Step 1 of the toggle unification: introduce the storage the redesign needs,
behind the current API, with no public API change.

## Problem

The dynamic table held its values in seven parallel `std::vector`s, one per
type. A vector reallocates as it grows, so a stored value's address moves
when unrelated toggles are added. That makes it impossible to hand a hot path
a stable reference to a value, which the later steps require.

## Change

- Add `ToggleRegister<T>`, a boxed single value (named after the atomic
  register of shared-memory theory), and `ToggleRegisterColumn<T>`, a
  segmented per-type column backed by `std::deque` so an appended register
  keeps its address for the column's lifetime.
- Replace the seven value vectors with these columns and route the existing
  `get`/`set` through them. Behavior is unchanged: sentinel on missing or
  wrong-typed read, overwrite on matching type, ignore on mismatch, append
  otherwise.
- Add a table generation counter bumped on every `clear`, so a handle taken
  before a clear can later be told from one taken after. Nothing reads it
  yet; it is the seam the next step builds the handle on.

The public `get`/`set`/`clear`/`keys` surface is unchanged.

## Verification

- `make` builds clean under `-Werror`.
- Full `make pytest` green (1269 passed / 67 skipped / 3 xfailed).
- `make gtest` 177/177.
- Stable-address invariant checked directly: a register keeps its address
  across 10,000 unrelated appends.
- `checkascii`, `checktws`, `cformat`, `cinclude` clean.