### PR TITLE
Make the toggle store safe under concurrent access

### DIFF
--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -53,12 +53,13 @@ std::string const DynamicToggleTable::sentinel_string = "";
 #define MM_DECL_DYNGET(CTYPE, MTYPE, SENTINEL)                                 \
     CTYPE DynamicToggleTable::get_##MTYPE(std::string const & key) const       \
     {                                                                          \
+        std::scoped_lock const guard(m_mutex);                                 \
         auto it = m_key2index.find(key);                                       \
         if (it != m_key2index.end())                                           \
         {                                                                      \
             if (it->second.is_##MTYPE())                                       \
             {                                                                  \
-                return m_column_##MTYPE.at(it->second.index).value;            \
+                return m_column_##MTYPE.at(it->second.index).get();            \
             }                                                                  \
         }                                                                      \
         return SENTINEL;                                                       \
@@ -82,12 +83,13 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
     /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                 \
     void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                 \
     {                                                                                                                          \
+        std::scoped_lock const guard(m_mutex);                                                                                 \
         auto it = m_key2index.find(key);                                                                                       \
         if (it != m_key2index.end())                                                                                           \
         {                                                                                                                      \
             if (it->second.is_##MTYPE())                                                                                       \
             {                                                                                                                  \
-                m_column_##MTYPE.at(it->second.index).value = value;                                                           \
+                m_column_##MTYPE.at(it->second.index).set(value);                                                              \
             }                                                                                                                  \
             else                                                                                                               \
             {                                                                                                                  \
@@ -126,6 +128,7 @@ void HierarchicalToggleAccess::add_subkey(const std::string & key)
 
 void DynamicToggleTable::add_subkey(std::string const & key)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it == m_key2index.end())
     {
@@ -136,6 +139,7 @@ void DynamicToggleTable::add_subkey(std::string const & key)
 
 std::vector<std::string> DynamicToggleTable::keys() const
 {
+    std::scoped_lock const guard(m_mutex);
     std::vector<std::string> ret;
     ret.reserve(m_key2index.size());
     for (auto const & it : m_key2index)
@@ -147,6 +151,7 @@ std::vector<std::string> DynamicToggleTable::keys() const
 
 void DynamicToggleTable::clear()
 {
+    std::scoped_lock const guard(m_mutex);
     m_key2index.clear();
     m_column_bool.clear();
     m_column_int8.clear();
@@ -155,7 +160,7 @@ void DynamicToggleTable::clear()
     m_column_int64.clear();
     m_column_real.clear();
     m_column_string.clear();
-    ++m_generation;
+    m_generation.fetch_add(1, std::memory_order_relaxed);
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,9 +17,12 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <atomic>
 #include <cstdint>
 #include <deque>
 #include <format>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
 #include <type_traits>
@@ -38,25 +41,46 @@ class ToggleRef;
  * A single stored toggle value.
  *
  * Named after the atomic register of shared-memory theory: a single-value
- * shared location. For now it boxes a plain value; a later step makes the
- * scalar read and write atomic without changing this shape.
+ * shared location. A scalar register holds a std::atomic so its read and
+ * write are lock-free and never torn; get and set use memory_order_relaxed
+ * because a toggle publishes nothing but itself.
  *
  * @ingroup group_core
  */
 template <typename T>
 struct ToggleRegister
 {
-    T value;
+    std::atomic<T> value;
+    T get() const { return value.load(std::memory_order_relaxed); }
+    void set(T v) { value.store(v, std::memory_order_relaxed); }
 }; /* end struct ToggleRegister */
 
 /**
- * Segmented column of ToggleRegister<T> with stable element addresses.
+ * String register.
  *
- * Registers append into a std::deque, so a register keeps its address as
- * the column grows, unlike a reallocating std::vector. A resolved handle
- * can therefore keep pointing at its register while unrelated toggles are
- * added. Indices are dense and start at zero, matching the offsets held by
- * DynamicToggleIndex.
+ * A string is not a hot-path value: it is read by the UI and config code
+ * only, never in a tight loop, so it is a plain std::string guarded by the
+ * table mutex rather than an atomic. get returns a reference that is valid
+ * only while no writer mutates the same key.
+ *
+ * @ingroup group_core
+ */
+template <>
+struct ToggleRegister<std::string>
+{
+    std::string value;
+    std::string const & get() const { return value; }
+    void set(std::string v) { value = std::move(v); }
+}; /* end struct ToggleRegister<std::string> */
+
+/**
+ * Column of ToggleRegister<T> with stable register addresses.
+ *
+ * Each register is heap-owned through a unique_ptr, so a register keeps its
+ * address for its lifetime even as the column grows, and a resolved handle
+ * stays valid. The heap box also lets a non-movable atomic register live in
+ * a standard container. Indices are dense and start at zero, matching the
+ * offsets held by DynamicToggleIndex.
  *
  * @ingroup group_core
  */
@@ -66,16 +90,30 @@ class ToggleRegisterColumn
 
 public:
 
+    ToggleRegisterColumn() = default;
+
+    ToggleRegisterColumn(ToggleRegisterColumn const & other)
+    {
+        for (auto const & reg : other.m_registers)
+        {
+            append(reg->get());
+        }
+    }
+    ToggleRegisterColumn(ToggleRegisterColumn &&) = default;
+    ToggleRegisterColumn & operator=(ToggleRegisterColumn const &) = delete;
+    ToggleRegisterColumn & operator=(ToggleRegisterColumn &&) = default;
+    ~ToggleRegisterColumn() = default;
+
     size_t size() const { return m_registers.size(); }
 
-    ToggleRegister<T> & at(size_t index) { return m_registers.at(index); }
-    ToggleRegister<T> const & at(size_t index) const { return m_registers.at(index); }
+    ToggleRegister<T> & at(size_t index) { return *m_registers.at(index); }
+    ToggleRegister<T> const & at(size_t index) const { return *m_registers.at(index); }
 
     size_t append(T const & value)
     {
         size_t const index = m_registers.size();
-        m_registers.emplace_back();
-        m_registers.back().value = value;
+        m_registers.push_back(std::make_unique<ToggleRegister<T>>());
+        m_registers.back()->set(value);
         return index;
     }
 
@@ -83,7 +121,7 @@ public:
 
 private:
 
-    std::deque<ToggleRegister<T>> m_registers;
+    std::deque<std::unique_ptr<ToggleRegister<T>>> m_registers;
 
 }; /* end class ToggleRegisterColumn */
 
@@ -241,6 +279,21 @@ public:
 
     static std::string const sentinel_string; // FIXME: NOLINT(readability-redundant-string-init)
 
+    DynamicToggleTable() = default;
+
+    // The atomic generation and the mutex are not copyable. Delegate to a
+    // private constructor that holds the source lock for the whole deep copy
+    // (the scoped_lock temporary outlives the delegated-to body) and starts a
+    // fresh mutex.
+    DynamicToggleTable(DynamicToggleTable const & other)
+        : DynamicToggleTable(other, std::scoped_lock<std::mutex>(other.m_mutex))
+    {
+    }
+    DynamicToggleTable(DynamicToggleTable &&) = delete;
+    DynamicToggleTable & operator=(DynamicToggleTable const &) = delete;
+    DynamicToggleTable & operator=(DynamicToggleTable &&) = delete;
+    ~DynamicToggleTable() = default;
+
     bool get_bool(std::string const & key) const;
     void set_bool(std::string const & key, bool value);
     int8_t get_int8(std::string const & key) const;
@@ -266,6 +319,7 @@ public:
     // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
     DynamicToggleIndex get_index(std::string const & key) const
     {
+        std::scoped_lock const guard(m_mutex);
         auto it = m_key2index.find(key);
         return (it != m_key2index.end()) ? it->second : DynamicToggleIndex{.index = 0, .type = DynamicToggleIndex::TYPE_NONE};
     }
@@ -279,7 +333,7 @@ public:
      * can be detected as stale rather than aliasing a register reused
      * after the clear.
      */
-    uint64_t generation() const { return m_generation; }
+    uint64_t generation() const { return m_generation.load(std::memory_order_relaxed); }
 
     /**
      * Create a toggle with a default and return a handle to it.
@@ -307,11 +361,25 @@ public:
 
 private:
 
+    DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
+        : m_key2index(other.m_key2index)
+        , m_column_bool(other.m_column_bool)
+        , m_column_int8(other.m_column_int8)
+        , m_column_int16(other.m_column_int16)
+        , m_column_int32(other.m_column_int32)
+        , m_column_int64(other.m_column_int64)
+        , m_column_real(other.m_column_real)
+        , m_column_string(other.m_column_string)
+        , m_generation(other.m_generation.load(std::memory_order_relaxed))
+    {
+    }
+
     template <typename T>
     ToggleRegisterColumn<T> & column();
     template <typename T>
     ToggleRegisterColumn<T> const & column() const;
 
+    mutable std::mutex m_mutex;
     keymap_type m_key2index;
     ToggleRegisterColumn<bool> m_column_bool;
     ToggleRegisterColumn<int8_t> m_column_int8;
@@ -320,7 +388,7 @@ private:
     ToggleRegisterColumn<int64_t> m_column_int64;
     ToggleRegisterColumn<double> m_column_real;
     ToggleRegisterColumn<std::string> m_column_string;
-    uint64_t m_generation = 0;
+    std::atomic<uint64_t> m_generation{0};
 
 }; /* end class DynamicToggleTable */
 
@@ -360,12 +428,12 @@ public:
     T load() const
     {
         check();
-        return m_register->value;
+        return m_register->get();
     }
     void store(T const & value) const
     {
         check();
-        m_register->value = value;
+        m_register->set(value);
     }
 
     uint32_t index() const { return m_index; }
@@ -467,6 +535,7 @@ ToggleRegisterColumn<T> const & DynamicToggleTable::column() const
 template <typename T>
 ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end())
     {
@@ -476,21 +545,22 @@ ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & defa
                 std::format("Toggle::declare: key \"{}\" already declared with a different type", key));
         }
         uint32_t const idx = it->second.index;
-        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
     }
     auto const idx = static_cast<uint32_t>(column<T>().append(default_value));
     m_key2index.insert({key, DynamicToggleIndex{idx, ToggleTypeTraits<T>::tag}});
-    return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+    return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
 }
 
 template <typename T>
 ToggleRef<T> DynamicToggleTable::ref(std::string const & key)
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
         uint32_t const idx = it->second.index;
-        return ToggleRef<T>(this, &column<T>().at(idx), idx, m_generation);
+        return ToggleRef<T>(this, &column<T>().at(idx), idx, generation());
     }
     return ToggleRef<T>();
 }
@@ -498,10 +568,11 @@ ToggleRef<T> DynamicToggleTable::ref(std::string const & key)
 template <typename T>
 T DynamicToggleTable::get(std::string const & key, T const & default_value) const
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
-        return column<T>().at(it->second.index).value;
+        return column<T>().at(it->second.index).get();
     }
     return default_value;
 }
@@ -509,10 +580,11 @@ T DynamicToggleTable::get(std::string const & key, T const & default_value) cons
 template <typename T>
 T DynamicToggleTable::at(std::string const & key) const
 {
+    std::scoped_lock const guard(m_mutex);
     auto it = m_key2index.find(key);
     if (it != m_key2index.end() && it->second.type == ToggleTypeTraits<T>::tag)
     {
-        return column<T>().at(it->second.index).value;
+        return column<T>().at(it->second.index).get();
     }
     throw std::out_of_range(std::format("Toggle::at: key \"{}\" is missing or has a different type", key));
 }
@@ -667,13 +739,17 @@ public:
     HierarchicalToggleAccess get_subkey(std::string const & key) { return m_dynamic_table.get_subkey(key); }
     void add_subkey(std::string const & key) { m_dynamic_table.add_subkey(key); }
 
+    // The store holds an atomic and a mutex, so it is not movable or
+    // assignable, and neither is the Toggle that owns it. clone() still copies
+    // through the private copy constructor.
+    Toggle(Toggle &&) = delete;
+    Toggle & operator=(Toggle const &) = delete;
+    Toggle & operator=(Toggle &&) = delete;
+
 private:
 
     Toggle() = default;
     Toggle(Toggle const &) = default;
-    Toggle(Toggle &&) = default;
-    Toggle & operator=(Toggle const &) = default;
-    Toggle & operator=(Toggle &&) = default;
 
     SolidToggle m_solid;
     FixedToggle m_fixed;

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -6,7 +6,10 @@
 
 #include <solvcon/toggle/toggle.hpp>
 
+#include <atomic>
 #include <string>
+#include <thread>
+#include <vector>
 
 namespace solvcon
 {
@@ -106,6 +109,118 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
 
     // A conflicting type is an error.
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
+}
+
+TEST(ToggleRefTest, concurrent_readers_and_writers)
+{
+    DynamicToggleTable table;
+    ToggleRef<int64_t> const r = table.declare<int64_t>("counter", 0);
+
+    constexpr int readers = 4;
+    constexpr int writers = 4;
+    constexpr int iters = 20000;
+    std::atomic<bool> start{false};
+    std::vector<std::thread> threads;
+
+    // Readers load through the handle and the typed getter; an atomic
+    // register is never torn, so every read is a value some writer stored.
+    for (int i = 0; i < readers; ++i)
+    {
+        threads.emplace_back(
+            [&]
+            {
+                while (!start.load())
+                {
+                }
+                int64_t sink = 0;
+                for (int k = 0; k < iters; ++k)
+                {
+                    sink += r.load();
+                    sink += table.get<int64_t>("counter", -1);
+                }
+                (void)sink;
+            });
+    }
+    // Writers store through the handle and through the table set path.
+    for (int w = 0; w < writers; ++w)
+    {
+        threads.emplace_back(
+            [&, w]
+            {
+                while (!start.load())
+                {
+                }
+                for (int k = 0; k < iters; ++k)
+                {
+                    r.store(static_cast<int64_t>(k));
+                    table.set_int64("counter", static_cast<int64_t>(w));
+                }
+            });
+    }
+
+    start.store(true);
+    for (auto & t : threads)
+    {
+        t.join();
+    }
+
+    int64_t const final_value = r.load();
+    EXPECT_GE(final_value, 0);
+    EXPECT_LT(final_value, iters);
+    EXPECT_TRUE(r.valid());
+}
+
+TEST(ToggleRefTest, concurrent_declare_and_read)
+{
+    DynamicToggleTable table;
+    ToggleRef<int32_t> const base = table.declare<int32_t>("base", 7);
+
+    std::atomic<bool> start{false};
+    std::atomic<bool> reads_ok{true};
+    std::vector<std::thread> threads;
+
+    // Writers declare distinct new keys, growing the map and columns under
+    // the table mutex.
+    for (int w = 0; w < 4; ++w)
+    {
+        threads.emplace_back(
+            [&, w]
+            {
+                while (!start.load())
+                {
+                }
+                for (int k = 0; k < 2000; ++k)
+                {
+                    table.declare<int32_t>("w" + std::to_string(w) + "_" + std::to_string(k), k);
+                }
+            });
+    }
+    // A reader hammers the base handle while the table grows; its register is
+    // heap-stable, so the lock-free load stays valid and correct.
+    threads.emplace_back(
+        [&]
+        {
+            while (!start.load())
+            {
+            }
+            for (int k = 0; k < 40000; ++k)
+            {
+                if (base.load() != 7)
+                {
+                    reads_ok.store(false);
+                }
+            }
+        });
+
+    start.store(true);
+    for (auto & t : threads)
+    {
+        t.join();
+    }
+
+    EXPECT_TRUE(reads_ok.load());
+    EXPECT_EQ(base.load(), 7);
+    EXPECT_TRUE(base.valid());
 }
 
 } /* end namespace detail */


### PR DESCRIPTION
Step 3 of the toggle unification: thread safety, built on the atomic-register
storage and typed handles from the earlier steps.

## Problem

`Toggle::instance()` is a process-global that a solver thread and the UI
thread both reach, with no synchronization. A dynamic set could grow a value
column while another thread read it, and the read was an unguarded plain load.

## Change

- `ToggleRegister<T>` boxes a `std::atomic` for scalars and exposes `get`/`set`
  with `memory_order_relaxed` (sound because a toggle publishes nothing but
  itself). The `std::string` register stays a plain string guarded by the
  table mutex, documented as not a hot-path value.
- Each register is heap-owned in the column (`deque` of `unique_ptr`), so a
  non-movable atomic lives in the container and register addresses stay stable
  for the handles.
- The key map, structural growth, string access, and `clear` run under the
  table mutex. The generation is a `std::atomic` bumped on `clear`, so a
  handle's validity check stays lock-free. A `ToggleRef` scalar read is one
  relaxed atomic load, no lock.
- The store holds an atomic and a mutex, so it is no longer movable or
  assignable; `clone()` still deep-copies through a private constructor that
  holds the source lock for the whole copy.

## Verification

- `make gtest` 185/185, including two new concurrent cases: readers vs writers
  over the handle/typed-getter/set path, and concurrent `declare`s growing the
  table while a handle is read.
- Checked clean under **ThreadSanitizer** with a standalone harness (readers,
  writers, and concurrent declares).
- Full `make pytest` green (1274 passed); `clone()` deep-copy verified.
- `clang-tidy` (llvm-22, lint-as-errors), `cformat`, `cinclude`, `flake8`,
  `checkascii`, `checktws` all clean.