### PR TITLE
Notify observers when a toggle changes

### DIFF
--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -499,6 +499,40 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("declare_real", &detail::declare_toggle<double>, py::arg("key"), py::arg("default"))
         .def("declare_string", &detail::declare_toggle<std::string>, py::arg("key"), py::arg("default"))
         .def(
+            "on_change",
+            [](wrapped_type & self, std::string const & key, py::function const & callback)
+            {
+                // Run the Python callback under the GIL (it may fire from a
+                // solver thread that does not hold it) and never let it
+                // propagate a C++ exception out of the store.
+                // The whole body is wrapped so nothing escapes into the
+                // store's notify loop (which also guards callbacks); the
+                // analysis cannot always see that through the GIL guard.
+                // NOLINTNEXTLINE(bugprone-exception-escape)
+                auto wrapped = [callback]()
+                {
+                    try
+                    {
+                        py::gil_scoped_acquire const acquire;
+                        try
+                        {
+                            callback();
+                        }
+                        catch (py::error_already_set & e)
+                        {
+                            e.discard_as_unraisable("solvcon.Toggle on_change callback");
+                        }
+                    }
+                    // NOLINTNEXTLINE(bugprone-empty-catch)
+                    catch (...)
+                    {
+                    }
+                };
+                return self.on_change(key, std::move(wrapped));
+            },
+            py::arg("key"),
+            py::arg("callback"))
+        .def(
             "__getattr__",
             [](wrapped_type & self, std::string const & key)
             {
@@ -691,6 +725,14 @@ WrapProcessInfo::WrapProcessInfo(pybind11::module & mod, char const * pyname, ch
 
 void wrap_Toggle(pybind11::module & mod)
 {
+    namespace py = pybind11;
+
+    // The RAII subscription token returned by Toggle.on_change. Dropping the
+    // Python handle (or calling unsubscribe) removes the callback.
+    py::class_<ToggleSubscription>(mod, "ToggleSubscription")
+        .def("unsubscribe", &ToggleSubscription::reset)
+        .def_property_readonly("active", &ToggleSubscription::active);
+
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
     WrapHierarchicalToggleAccess::commit(mod, "HierarchicalToggleAccess", "HierarchicalToggleAccess");

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -79,33 +79,42 @@ MM_DECL_DYNGET(std::string const &, string, sentinel_string)
 
 /* The macro gives debuggers a hard time. Manually expand it if you need to
  * step in a debugger. */
-#define MM_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                   \
-    /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                 \
-    void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                 \
-    {                                                                                                                          \
-        std::scoped_lock const guard(m_mutex);                                                                                 \
-        auto it = m_key2index.find(key);                                                                                       \
-        if (it != m_key2index.end())                                                                                           \
-        {                                                                                                                      \
-            if (it->second.is_##MTYPE())                                                                                       \
-            {                                                                                                                  \
-                m_column_##MTYPE.at(it->second.index).set(value);                                                              \
-            }                                                                                                                  \
-            else                                                                                                               \
-            {                                                                                                                  \
-                /* do nothing */                                                                                               \
-            }                                                                                                                  \
-        }                                                                                                                      \
-        else                                                                                                                   \
-        {                                                                                                                      \
-            DynamicToggleIndex const index{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
-            m_key2index.insert({key, index});                                                                                  \
-            m_column_##MTYPE.append(value);                                                                                    \
-        }                                                                                                                      \
-    }                                                                                                                          \
-    void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                           \
-    {                                                                                                                          \
-        m_table->set_##MTYPE(rekey(key), value);                                                                               \
+#define MM_DECL_DYNSET(CTYPE, MTYPE, MTYPEC)                                                                                     \
+    /* NOLINTNEXTLINE(bugprone-easily-swappable-parameters) */                                                                   \
+    void DynamicToggleTable::set_##MTYPE(std::string const & key, CTYPE value)                                                   \
+    {                                                                                                                            \
+        bool changed = false;                                                                                                    \
+        {                                                                                                                        \
+            std::scoped_lock const guard(m_mutex);                                                                               \
+            auto it = m_key2index.find(key);                                                                                     \
+            if (it != m_key2index.end())                                                                                         \
+            {                                                                                                                    \
+                if (it->second.is_##MTYPE())                                                                                     \
+                {                                                                                                                \
+                    auto & reg = m_column_##MTYPE.at(it->second.index);                                                          \
+                    if (!value_equal(reg.get(), value))                                                                          \
+                    {                                                                                                            \
+                        reg.set(value);                                                                                          \
+                        changed = true;                                                                                          \
+                    }                                                                                                            \
+                }                                                                                                                \
+            }                                                                                                                    \
+            else                                                                                                                 \
+            {                                                                                                                    \
+                DynamicToggleIndex const idx{static_cast<uint32_t>(m_column_##MTYPE.size()), DynamicToggleIndex::TYPE_##MTYPEC}; \
+                m_key2index.insert({key, idx});                                                                                  \
+                m_column_##MTYPE.append(value);                                                                                  \
+                changed = true;                                                                                                  \
+            }                                                                                                                    \
+        }                                                                                                                        \
+        if (changed)                                                                                                             \
+        {                                                                                                                        \
+            notify(key);                                                                                                         \
+        }                                                                                                                        \
+    }                                                                                                                            \
+    void HierarchicalToggleAccess::set_##MTYPE(std::string const & key, CTYPE value)                                             \
+    {                                                                                                                            \
+        m_table->set_##MTYPE(rekey(key), value);                                                                                 \
     }
 MM_DECL_DYNSET(bool, bool, BOOL)
 MM_DECL_DYNSET(int8_t, int8, INT8)
@@ -161,6 +170,37 @@ void DynamicToggleTable::clear()
     m_column_real.clear();
     m_column_string.clear();
     m_generation.fetch_add(1, std::memory_order_relaxed);
+}
+
+void DynamicToggleTable::notify(std::string const & key) const
+{
+    // Copy the callbacks out under the registry mutex, then run them with no
+    // lock held so a callback may re-enter the store or the registry.
+    std::vector<detail::ToggleChangeObservers::callback_type> callbacks;
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        auto it = m_observers->map.find(key);
+        if (it != m_observers->map.end())
+        {
+            for (auto const & pr : it->second)
+            {
+                callbacks.push_back(pr.second);
+            }
+        }
+    }
+    for (auto const & callback : callbacks)
+    {
+        try
+        {
+            (*callback)();
+        }
+        // A throwing observer must not corrupt the store or stop the other
+        // observers, so the exception is intentionally swallowed here.
+        // NOLINTNEXTLINE(bugprone-empty-catch)
+        catch (...)
+        {
+        }
+    }
 }
 
 // NOLINTNEXTLINE(modernize-use-equals-default) lack of SOLVCON_METAL

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -17,10 +17,13 @@
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
 
+#include <algorithm>
 #include <atomic>
+#include <bit>
 #include <cstdint>
 #include <deque>
 #include <format>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -199,6 +202,117 @@ MM_TOGGLE_TYPE_TRAITS(double, TYPE_REAL)
 MM_TOGGLE_TYPE_TRAITS(std::string, TYPE_STRING)
 #undef MM_TOGGLE_TYPE_TRAITS
 
+namespace detail
+{
+
+/**
+ * Shared registry of change callbacks, keyed by toggle key.
+ *
+ * It is owned by a shared_ptr so a ToggleSubscription can hold a weak
+ * reference and unsubscribe safely even if the table is gone. Its own mutex
+ * guards the map and is never held while a callback runs.
+ *
+ * @ingroup group_core
+ */
+struct ToggleChangeObservers
+{
+    using callback_type = std::shared_ptr<std::function<void()>>;
+    std::mutex mutex;
+    uint64_t next_id = 0;
+    // The callback is held by shared_ptr so a firing thread can copy the
+    // pointer (a cheap atomic) rather than the std::function itself. Copying
+    // a std::function that wraps a Python callable would touch a Python
+    // refcount without the GIL, from a solver thread that does not hold it.
+    std::unordered_map<std::string, std::vector<std::pair<uint64_t, callback_type>>> map;
+}; /* end struct ToggleChangeObservers */
+
+} /* end namespace detail */
+
+/**
+ * RAII handle for one change subscription.
+ *
+ * Dropping it unsubscribes, so a callback never outlives the widget it
+ * belongs to. It is move-only and tolerates the table being destroyed first
+ * (the weak reference simply expires).
+ *
+ * @ingroup group_core
+ */
+class ToggleSubscription
+{
+
+public:
+
+    ToggleSubscription() = default;
+
+    ToggleSubscription(std::shared_ptr<detail::ToggleChangeObservers> const & observers, std::string key, uint64_t id)
+        : m_observers(observers)
+        , m_key(std::move(key))
+        , m_id(id)
+        , m_active(true)
+    {
+    }
+
+    ToggleSubscription(ToggleSubscription const &) = delete;
+    ToggleSubscription & operator=(ToggleSubscription const &) = delete;
+
+    ToggleSubscription(ToggleSubscription && other) noexcept { swap(other); }
+    ToggleSubscription & operator=(ToggleSubscription && other) noexcept
+    {
+        if (this != &other)
+        {
+            reset();
+            swap(other);
+        }
+        return *this;
+    }
+
+    ~ToggleSubscription() { reset(); }
+
+    bool active() const { return m_active; }
+
+    void reset()
+    {
+        if (!m_active)
+        {
+            return;
+        }
+        m_active = false;
+        if (std::shared_ptr<detail::ToggleChangeObservers> const obs = m_observers.lock())
+        {
+            std::scoped_lock const guard(obs->mutex);
+            auto it = obs->map.find(m_key);
+            if (it != obs->map.end())
+            {
+                auto & subs = it->second;
+                subs.erase(
+                    std::remove_if(subs.begin(), subs.end(), [this](auto const & pr)
+                                   { return pr.first == m_id; }),
+                    subs.end());
+                if (subs.empty())
+                {
+                    obs->map.erase(it);
+                }
+            }
+        }
+    }
+
+private:
+
+    void swap(ToggleSubscription & other) noexcept
+    {
+        m_observers.swap(other.m_observers);
+        m_key.swap(other.m_key);
+        std::swap(m_id, other.m_id);
+        std::swap(m_active, other.m_active);
+    }
+
+    std::weak_ptr<detail::ToggleChangeObservers> m_observers;
+    std::string m_key;
+    uint64_t m_id = 0;
+    bool m_active = false;
+
+}; /* end class ToggleSubscription */
+
 class DynamicToggleTable;
 
 /**
@@ -359,6 +473,23 @@ public:
     template <typename T>
     T at(std::string const & key) const;
 
+    /**
+     * Subscribe to changes of a key.
+     *
+     * The callback runs after the write lock is released, so it may call back
+     * into the store (including set) without deadlock, and firing outside the
+     * lock keeps a Python callback from inverting lock order against the GIL.
+     * A no-op write (setting the value already stored) does not fire. Dropping
+     * the returned token unsubscribes.
+     */
+    [[nodiscard]] ToggleSubscription on_change(std::string const & key, std::function<void()> callback)
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        uint64_t const id = m_observers->next_id++;
+        m_observers->map[key].emplace_back(id, std::make_shared<std::function<void()>>(std::move(callback)));
+        return ToggleSubscription(m_observers, key, id);
+    }
+
 private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
@@ -379,6 +510,25 @@ private:
     template <typename T>
     ToggleRegisterColumn<T> const & column() const;
 
+    // Fire the change callbacks for a key, called after the write lock is
+    // released. A throwing callback is caught so the store is never corrupted.
+    void notify(std::string const & key) const;
+
+    // Equality used by the no-op-write guard. Doubles compare by bit pattern
+    // so NaN and -0.0 behave sanely under the load-compare-store.
+    template <typename T>
+    static bool value_equal(T const & lhs, T const & rhs)
+    {
+        if constexpr (std::is_same_v<T, double>)
+        {
+            return std::bit_cast<uint64_t>(lhs) == std::bit_cast<uint64_t>(rhs);
+        }
+        else
+        {
+            return lhs == rhs;
+        }
+    }
+
     mutable std::mutex m_mutex;
     keymap_type m_key2index;
     ToggleRegisterColumn<bool> m_column_bool;
@@ -389,6 +539,8 @@ private:
     ToggleRegisterColumn<double> m_column_real;
     ToggleRegisterColumn<std::string> m_column_string;
     std::atomic<uint64_t> m_generation{0};
+    // A fresh registry per table; a clone does not inherit subscriptions.
+    std::shared_ptr<detail::ToggleChangeObservers> m_observers = std::make_shared<detail::ToggleChangeObservers>();
 
 }; /* end class DynamicToggleTable */
 
@@ -721,6 +873,11 @@ public:
     T get(std::string const & key, T const & default_value) const { return m_dynamic_table.get<T>(key, default_value); }
     template <typename T>
     T at(std::string const & key) const { return m_dynamic_table.at<T>(key); }
+
+    [[nodiscard]] ToggleSubscription on_change(std::string const & key, std::function<void()> callback)
+    {
+        return m_dynamic_table.on_change(key, std::move(callback));
+    }
 
     bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }
     void set_bool(std::string const & key, bool value) { m_dynamic_table.set_bool(key, value); }

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -7,6 +7,8 @@
 #include <solvcon/toggle/toggle.hpp>
 
 #include <atomic>
+#include <limits>
+#include <stdexcept>
 #include <string>
 #include <thread>
 #include <vector>
@@ -109,6 +111,94 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
 
     // A conflicting type is an error.
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
+}
+
+TEST(ToggleOnChangeTest, fires_once_per_real_change)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 1);
+
+    int fired = 0;
+    ToggleSubscription const tok = table.on_change("k", [&]
+                                                   { ++fired; });
+    table.set_int32("k", 2); // change
+    table.set_int32("k", 2); // no-op
+    table.set_int32("k", 3); // change
+    EXPECT_EQ(fired, 2);
+}
+
+TEST(ToggleOnChangeTest, double_noop_uses_bit_pattern)
+{
+    DynamicToggleTable table;
+    table.declare<double>("r", 0.0);
+
+    int fired = 0;
+    ToggleSubscription const tok = table.on_change("r", [&]
+                                                   { ++fired; });
+
+    table.set_real("r", 0.0); // same bits -> no fire
+    EXPECT_EQ(fired, 0);
+    table.set_real("r", -0.0); // different bits from +0.0 -> fire
+    EXPECT_EQ(fired, 1);
+
+    double const nan_value = std::numeric_limits<double>::quiet_NaN();
+    table.set_real("r", nan_value); // -0.0 -> NaN -> fire
+    EXPECT_EQ(fired, 2);
+    table.set_real("r", nan_value); // same NaN bits -> no fire
+    EXPECT_EQ(fired, 2);
+}
+
+TEST(ToggleOnChangeTest, coalesced_across_observers_and_reentrant)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+    table.declare<int32_t>("mirror", -1);
+
+    int a = 0;
+    int b = 0;
+    ToggleSubscription const t0 = table.on_change("k", [&]
+                                                  { ++a; });
+    // A reentrant observer writes another key from inside the callback.
+    ToggleSubscription const t1 = table.on_change("k", [&]
+                                                  { ++b; table.set_int32("mirror", table.at<int32_t>("k")); });
+
+    table.set_int32("k", 7);
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 1);
+    EXPECT_EQ(table.at<int32_t>("mirror"), 7);
+}
+
+TEST(ToggleOnChangeTest, throwing_observer_is_contained)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+
+    int after = 0;
+    ToggleSubscription const t0 = table.on_change("k", []
+                                                  { throw std::runtime_error("boom"); });
+    ToggleSubscription const t1 = table.on_change("k", [&]
+                                                  { ++after; });
+
+    EXPECT_NO_THROW(table.set_int32("k", 1));
+    EXPECT_EQ(after, 1);
+    EXPECT_EQ(table.at<int32_t>("k"), 1);
+}
+
+TEST(ToggleOnChangeTest, dropped_subscription_stops_firing)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("k", 0);
+
+    int fired = 0;
+    {
+        ToggleSubscription const tok = table.on_change("k", [&]
+                                                       { ++fired; });
+        table.set_int32("k", 1);
+        EXPECT_EQ(fired, 1);
+    }
+    // Token destroyed at scope exit -> unsubscribed.
+    table.set_int32("k", 2);
+    EXPECT_EQ(fired, 1);
 }
 
 TEST(ToggleRefTest, concurrent_readers_and_writers)

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -332,6 +332,96 @@ class ToggleTypedAccessTC(unittest.TestCase):
         self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
 
 
+class ToggleOnChangeTC(unittest.TestCase):
+
+    def test_fires_on_real_change_only(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 1)
+
+        seen = []
+        tok = tg.on_change("k", lambda: seen.append(tg.get("k", -1)))
+        self.assertTrue(tok.active)
+        tg.set_int32("k", 2)   # change -> fire
+        tg.set_int32("k", 2)   # no-op -> no fire
+        tg.set_int32("k", 3)   # change -> fire
+        self.assertEqual(seen, [2, 3])
+
+    def test_attribute_set_fires(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_bool("flag", False)
+
+        seen = []
+        tok = tg.on_change("flag", lambda: seen.append(1))
+        tg.flag = True
+        self.assertEqual(seen, [1])
+        self.assertTrue(tok.active)
+
+    def test_multiple_observers_each_fire_once(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        counts = [0, 0]
+
+        def make(i):
+            def cb():
+                counts[i] += 1
+            return cb
+
+        t0 = tg.on_change("k", make(0))
+        t1 = tg.on_change("k", make(1))
+        tg.set_int32("k", 5)
+        self.assertEqual(counts, [1, 1])
+        self.assertTrue(t0.active and t1.active)
+
+    def test_reentrant_callback(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+        tg.declare_int32("mirror", -1)
+
+        def mirror():
+            tg.set_int32("mirror", tg.get("k", -1))
+
+        tok = tg.on_change("k", mirror)
+        tg.set_int32("k", 42)
+        self.assertEqual(tg.get("mirror", -1), 42)
+        self.assertTrue(tok.active)
+
+    def test_dropping_token_unsubscribes(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        seen = []
+        tok = tg.on_change("k", lambda: seen.append(1))
+        tg.set_int32("k", 1)
+        tok.unsubscribe()
+        tg.set_int32("k", 2)
+        self.assertEqual(seen, [1])
+        self.assertFalse(tok.active)
+
+    def test_throwing_callback_is_contained(self):
+        tg = solvcon.Toggle.instance.clone()
+        tg.dynamic_clear()
+        tg.declare_int32("k", 0)
+
+        after = []
+
+        def boom():
+            raise ValueError("boom")
+
+        t0 = tg.on_change("k", boom)
+        t1 = tg.on_change("k", lambda: after.append(1))
+        # The throwing observer must not propagate nor stop the other one.
+        tg.set_int32("k", 1)
+        self.assertEqual(after, [1])
+        self.assertEqual(tg.get("k", -1), 1)
+        self.assertTrue(t0.active and t1.active)
+
+
 class ToggleSerializationTC(unittest.TestCase):
 
     def test_to_json(self):


### PR DESCRIPTION
Step 4 of the toggle unification: an observable change hook, built on the
thread-safe store.

## Problem

Nothing could subscribe to a toggle. The UI learned of a change only by
polling, and a solver could not be told to re-read.

## Change

- `on_change(key, callback)` returns an RAII `ToggleSubscription`; dropping it
  unsubscribes, so a callback never outlives the widget it belongs to.
- A write fires the callback through one mutating entry point (`set`), and only
  when the stored value actually changes. The no-op guard compares under the
  write lock; doubles compare by bit pattern (NaN and -0.0 behave), which also
  stops a two-way UI binding from echoing.
- The callback runs after the write lock is released, so it may call back into
  the store without deadlock, and firing outside the lock keeps a Python
  callback from inverting lock order against the GIL. A throwing callback is
  caught so it neither propagates nor stops the other observers.
- Callbacks are held by `shared_ptr` so a firing thread copies a pointer, not
  the `std::function` (copying one that wraps a Python callable would touch a
  refcount without the GIL). The Python binding runs the callback under a
  reacquired GIL and reports a raising callback through the unraisable hook.

## Scope note

The Qt bridge to a queued UI-thread signal lands in Step 7 with the menu
wiring that consumes it, so it is tested against a real consumer rather than in
isolation.

## Verification

- `make gtest` 190/190 (+5 `ToggleOnChangeTest`: no-op guard incl. double bit
  pattern, coalescing, reentrancy, throwing-observer guard, unsubscribe).
- Full `make pytest` green (1280 passed, +6 on_change cases through attribute
  and set writes).
- Concurrent notify + subscribe/unsubscribe churn checked clean under
  **ThreadSanitizer**.
- `clang-tidy` (llvm-22), `cformat`, `cinclude`, `flake8`, `checkascii`,
  `checktws` all clean.