### PR TITLE
Consolidate the toggle classes onto the unified store

### DIFF
--- a/cpp/solvcon/toggle/CMakeLists.txt
+++ b/cpp/solvcon/toggle/CMakeLists.txt
@@ -4,6 +4,7 @@
 cmake_minimum_required(VERSION 4.0.1)
 
 set(SOLVCON_TOGGLE_HEADERS
+    ${CMAKE_CURRENT_SOURCE_DIR}/build_config.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/toggle.hpp
     CACHE FILEPATH "" FORCE)
 

--- a/cpp/solvcon/toggle/build_config.hpp
+++ b/cpp/solvcon/toggle/build_config.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Compile-time build switches for the toggle system.
+ *
+ * A build switch is decided once when the library is built, so it is an
+ * inline constexpr the optimizer can fold away, not a runtime toggle in the
+ * table. A genuine build switch (for example a future GPU backend flag)
+ * belongs here rather than in the runtime store.
+ *
+ * @ingroup group_core
+ */
+
+namespace solvcon
+{
+
+namespace build_config
+{
+
+/// Whether the pilot uses PySide for its Python integration.
+inline constexpr bool use_pyside = true;
+
+} /* end namespace build_config */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -16,6 +16,24 @@ namespace solvcon
 namespace python
 {
 
+namespace detail
+{
+
+// If child is a hierarchical access (a subkey view holding a raw table
+// pointer), tie its lifetime to parent so chaining off a temporary does not
+// dangle. A plain leaf value is returned unchanged, since it cannot carry a
+// keep_alive reference.
+inline pybind11::object tie_subkey_owner(pybind11::object child, pybind11::handle parent)
+{
+    if (pybind11::isinstance<HierarchicalToggleAccess>(child))
+    {
+        pybind11::detail::keep_alive_impl(child, parent);
+    }
+    return child;
+}
+
+} /* end namespace detail */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapSolidToggle
     : public WrapBase<WrapSolidToggle, SolidToggle>
 {
@@ -134,8 +152,18 @@ WrapHierarchicalToggleAccess::WrapHierarchicalToggleAccess(pybind11::module & mo
 
     // Dynamic properties.  Number of the properties can be freely changed
     // during runtime.
+    // A subkey access holds a raw table pointer, so a chained access off a
+    // temporary must keep its owner alive. __getattr__ may also return a
+    // plain value (a leaf toggle), which cannot carry a keep_alive reference,
+    // so tie the parent only when the result is itself an access.
     (*this)
-        .def("__getattr__", getattr)
+        .def(
+            "__getattr__",
+            [](py::object const & self_obj, std::string const & key)
+            {
+                auto & self = self_obj.cast<wrapped_type &>();
+                return detail::tie_subkey_owner(getattr(self, key), self_obj);
+            })
         .def("__setattr__", setattr)
         .def("get_bool", &wrapped_type::get_bool, py::arg("key"))
         .def("set_bool", &wrapped_type::set_bool, py::arg("key"), py::arg("value"))
@@ -151,7 +179,7 @@ WrapHierarchicalToggleAccess::WrapHierarchicalToggleAccess(pybind11::module & mo
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
         .def("get_string", &wrapped_type::get_string, py::arg("key"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
-        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"), py::keep_alive<0, 1>())
         .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
@@ -347,6 +375,13 @@ struct Toggle2Python
 
         for (auto const & fk : keys)
         {
+            // python_redirect and show_axis are declared toggles but are
+            // reported under the "fixed" section by the compatibility facade,
+            // so skip them here to avoid listing them twice.
+            if ("python_redirect" == fk || "show_axis" == fk)
+            {
+                continue;
+            }
             std::vector<std::string> const hk = split(fk);
             DynamicToggleIndex const index = table.get_index(fk);
             py::dict d = ret;
@@ -498,6 +533,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("declare_int64", &detail::declare_toggle<int64_t>, py::arg("key"), py::arg("default"))
         .def("declare_real", &detail::declare_toggle<double>, py::arg("key"), py::arg("default"))
         .def("declare_string", &detail::declare_toggle<std::string>, py::arg("key"), py::arg("default"))
+        .def("category", &wrapped_type::category, py::arg("key"))
         .def(
             "on_change",
             [](wrapped_type & self, std::string const & key, py::function const & callback)
@@ -534,13 +570,15 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
             py::arg("callback"))
         .def(
             "__getattr__",
-            [](wrapped_type & self, std::string const & key)
+            [](py::object const & self_obj, std::string const & key)
             {
+                auto & self = self_obj.cast<wrapped_type &>();
                 HierarchicalToggleAccess access(self.dynamic());
                 py::object ret;
                 if (access.get_index(key).type != DynamicToggleIndex::TYPE_NONE) // dynamic
                 {
-                    ret = WrapHierarchicalToggleAccess::getattr(access, key);
+                    // Tie a returned subkey access to the owning Toggle.
+                    ret = detail::tie_subkey_owner(WrapHierarchicalToggleAccess::getattr(access, key), self_obj);
                 }
                 else if (key == "show_axis") // fixed
                 {
@@ -585,7 +623,7 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         .def("set_int64", &wrapped_type::set_int64, py::arg("key"), py::arg("value"))
         .def("set_real", &wrapped_type::set_real, py::arg("key"), py::arg("value"))
         .def("set_string", &wrapped_type::set_string, py::arg("key"), py::arg("value"))
-        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"))
+        .def("get_subkey", &wrapped_type::get_subkey, py::arg("key"), py::keep_alive<0, 1>())
         .def("add_subkey", &wrapped_type::add_subkey, py::arg("key"))
         //
         ;
@@ -621,26 +659,35 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         //
         ;
 
-    // Instance properties.
+    // Instance properties. The solid and fixed facades and the hierarchical
+    // access are lightweight views; keep_alive ties each returned view to the
+    // owning Toggle so the store it reads through never dangles.
+    // def_property_readonly does not accept a keep_alive policy, so wrap the
+    // getters that return a table-referencing view in a py::cpp_function that
+    // carries keep_alive<0, 1> (tie the view to the owning Toggle).
     (*this)
         .def_property_readonly(
             "solid",
-            [](wrapped_type & self) -> auto &
+            [](wrapped_type & self)
             {
                 return self.solid();
             })
         .def_property_readonly(
             "fixed",
-            [](wrapped_type & self) -> auto &
-            {
-                return self.fixed();
-            })
+            py::cpp_function(
+                [](wrapped_type & self)
+                {
+                    return self.fixed();
+                },
+                py::keep_alive<0, 1>()))
         .def_property_readonly(
             "dynamic",
-            [](wrapped_type & self)
-            {
-                return HierarchicalToggleAccess(self.dynamic());
-            })
+            py::cpp_function(
+                [](wrapped_type & self)
+                {
+                    return HierarchicalToggleAccess(self.dynamic());
+                },
+                py::keep_alive<0, 1>()))
         //
         ;
 }
@@ -732,6 +779,11 @@ void wrap_Toggle(pybind11::module & mod)
     py::class_<ToggleSubscription>(mod, "ToggleSubscription")
         .def("unsubscribe", &ToggleSubscription::reset)
         .def_property_readonly("active", &ToggleSubscription::active);
+
+    py::enum_<ToggleCategory>(mod, "ToggleCategory")
+        .value("Release", ToggleCategory::Release)
+        .value("Ops", ToggleCategory::Ops)
+        .value("Experiment", ToggleCategory::Experiment);
 
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");

--- a/cpp/solvcon/toggle/toggle.cpp
+++ b/cpp/solvcon/toggle/toggle.cpp
@@ -40,11 +40,6 @@ Toggle & Toggle::instance()
     return o;
 }
 
-SolidToggle::SolidToggle()
-    : m_use_pyside(true)
-{
-}
-
 // NOLINTNEXTLINE(bugprone-throwing-static-initialization,fuchsia-statically-constructed-objects,readability-redundant-string-init,cert-err58-cpp)
 std::string const DynamicToggleTable::sentinel_string = "";
 
@@ -162,6 +157,7 @@ void DynamicToggleTable::clear()
 {
     std::scoped_lock const guard(m_mutex);
     m_key2index.clear();
+    m_categories.clear();
     m_column_bool.clear();
     m_column_int8.clear();
     m_column_int16.clear();

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -16,6 +16,7 @@
 #include <solvcon/buffer/buffer.hpp>
 #include <solvcon/profiling/profile.hpp>
 #include <solvcon/profiling/RadixTree.hpp>
+#include <solvcon/toggle/build_config.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -36,6 +37,23 @@ namespace solvcon
 {
 
 int setenv(const char * name, const char * value, int overwrite);
+
+/**
+ * Lifecycle category of a toggle (Fowler's feature-flag categories).
+ *
+ * The category enforces nothing by itself; it records the expected lifetime
+ * so a lint or test can flag, for example, a release toggle that outlived its
+ * feature. Ops and UI settings are long-lived; a release toggle is removed
+ * once its feature lands.
+ *
+ * @ingroup group_core
+ */
+enum class ToggleCategory : uint8_t
+{
+    Release,
+    Ops,
+    Experiment,
+}; /* end enum class ToggleCategory */
 
 template <typename T>
 class ToggleRef;
@@ -450,14 +468,22 @@ public:
     uint64_t generation() const { return m_generation.load(std::memory_order_relaxed); }
 
     /**
-     * Create a toggle with a default and return a handle to it.
+     * Create a toggle with a default and a category, and return a handle.
      *
      * Re-declaring an existing key of the same type is idempotent and
      * returns a handle to the existing register. A conflicting type is an
      * error.
      */
     template <typename T>
-    ToggleRef<T> declare(std::string const & key, T const & default_value);
+    ToggleRef<T> declare(std::string const & key, T const & default_value, ToggleCategory category = ToggleCategory::Ops);
+
+    /// The category recorded for a key, or Ops if the key was never declared.
+    ToggleCategory category(std::string const & key) const
+    {
+        std::scoped_lock const guard(m_mutex);
+        auto it = m_categories.find(key);
+        return (it != m_categories.end()) ? it->second : ToggleCategory::Ops;
+    }
 
     /// Resolve an existing key to a handle; an invalid handle if it is
     /// missing or has a different type.
@@ -494,6 +520,7 @@ private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
         : m_key2index(other.m_key2index)
+        , m_categories(other.m_categories)
         , m_column_bool(other.m_column_bool)
         , m_column_int8(other.m_column_int8)
         , m_column_int16(other.m_column_int16)
@@ -531,6 +558,7 @@ private:
 
     mutable std::mutex m_mutex;
     keymap_type m_key2index;
+    std::unordered_map<std::string, ToggleCategory> m_categories;
     ToggleRegisterColumn<bool> m_column_bool;
     ToggleRegisterColumn<int8_t> m_column_int8;
     ToggleRegisterColumn<int16_t> m_column_int16;
@@ -685,9 +713,10 @@ ToggleRegisterColumn<T> const & DynamicToggleTable::column() const
 }
 
 template <typename T>
-ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value)
+ToggleRef<T> DynamicToggleTable::declare(std::string const & key, T const & default_value, ToggleCategory category)
 {
     std::scoped_lock const guard(m_mutex);
+    m_categories[key] = category;
     auto it = m_key2index.find(key);
     if (it != m_key2index.end())
     {
@@ -741,19 +770,12 @@ T DynamicToggleTable::at(std::string const & key) const
     throw std::out_of_range(std::format("Toggle::at: key \"{}\" is missing or has a different type", key));
 }
 
-#define MM_TOGGLE_SOLID_BOOL(NAME)         \
-public:                                    \
-    bool NAME() const { return m_##NAME; } \
-                                           \
-private:                                   \
-    bool m_##NAME;
-
 /**
- * Toggles whose values are determined at compile time and read-only
- * during the process lifetime.
+ * Compatibility facade for the former compile-time solid toggles.
  *
- * Each accessor (for example use_pyside) returns a bool member that has
- * an address and cannot be optimized out, unlike a macro or constexpr.
+ * The one solid toggle, use_pyside, is now an inline constexpr build switch
+ * (see build_config.hpp) that the optimizer folds away. This stateless
+ * facade keeps the old accessor working until its callers move.
  *
  * @ingroup group_core
  */
@@ -762,27 +784,19 @@ class SolidToggle
 
 public:
 
-    SolidToggle();
-
-    MM_TOGGLE_SOLID_BOOL(use_pyside)
+    // Kept as an instance method for API compatibility with the old facade.
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    bool use_pyside() const { return build_config::use_pyside; }
 
 }; /* end class SolidToggle */
 
-#define MM_TOGGLE_FIXED_BOOL(NAME, DEFAULT)      \
-public:                                          \
-    bool get_##NAME() const { return m_##NAME; } \
-    void set_##NAME(bool v) { m_##NAME = v; }    \
-                                                 \
-private:                                         \
-    bool m_##NAME = DEFAULT;
-
 /**
- * Toggles whose names are fixed at compile time but whose bool values
- * can change at runtime.
+ * Compatibility facade for the former fixed toggles.
  *
- * Access needs no table lookup because the member addresses are known
- * to the compiler and linker (for example python_redirect and
- * show_axis).
+ * python_redirect and show_axis are now ordinary declared toggles in the
+ * store, so they gain change notification and serialization. This facade
+ * reads and writes them through the store (with their startup defaults),
+ * keeping the old get_/set_ accessors working until their callers move.
  *
  * @ingroup group_core
  */
@@ -791,8 +805,19 @@ class FixedToggle
 
 public:
 
-    MM_TOGGLE_FIXED_BOOL(python_redirect, true)
-    MM_TOGGLE_FIXED_BOOL(show_axis, false)
+    explicit FixedToggle(DynamicToggleTable & table)
+        : m_table(&table)
+    {
+    }
+
+    bool get_python_redirect() const { return m_table->get<bool>("python_redirect", true); }
+    void set_python_redirect(bool v) { m_table->set_bool("python_redirect", v); }
+    bool get_show_axis() const { return m_table->get<bool>("show_axis", false); }
+    void set_show_axis(bool v) { m_table->set_bool("show_axis", v); }
+
+private:
+
+    DynamicToggleTable * m_table = nullptr;
 
 }; /* end class FixedToggle */
 
@@ -852,10 +877,10 @@ public:
 
     ~Toggle() = default;
 
-    SolidToggle const & solid() const { return m_solid; }
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    SolidToggle solid() const { return SolidToggle{}; }
 
-    FixedToggle const & fixed() const { return m_fixed; }
-    FixedToggle & fixed() { return m_fixed; }
+    FixedToggle fixed() { return FixedToggle(m_dynamic_table); }
 
     DynamicToggleTable const & dynamic() const { return m_dynamic_table; }
     DynamicToggleTable & dynamic() { return m_dynamic_table; }
@@ -866,7 +891,11 @@ public:
     DynamicToggleIndex get_dynamic_index(std::string const & key) const { return m_dynamic_table.get_index(key); }
 
     template <typename T>
-    ToggleRef<T> declare(std::string const & key, T const & default_value) { return m_dynamic_table.declare<T>(key, default_value); }
+    ToggleRef<T> declare(std::string const & key, T const & default_value, ToggleCategory category = ToggleCategory::Ops)
+    {
+        return m_dynamic_table.declare<T>(key, default_value, category);
+    }
+    ToggleCategory category(std::string const & key) const { return m_dynamic_table.category(key); }
     template <typename T>
     ToggleRef<T> ref(std::string const & key) { return m_dynamic_table.ref<T>(key); }
     template <typename T>
@@ -905,11 +934,16 @@ public:
 
 private:
 
-    Toggle() = default;
+    // The formerly fixed toggles are now ordinary declared toggles with
+    // startup defaults and a category, so they carry notification and
+    // serialization like any other toggle.
+    Toggle()
+    {
+        m_dynamic_table.declare<bool>("python_redirect", true, ToggleCategory::Ops);
+        m_dynamic_table.declare<bool>("show_axis", false, ToggleCategory::Ops);
+    }
     Toggle(Toggle const &) = default;
 
-    SolidToggle m_solid;
-    FixedToggle m_fixed;
     DynamicToggleTable m_dynamic_table;
 
 }; /* end class Toggle */

--- a/gtests/test_nopython_toggle.cpp
+++ b/gtests/test_nopython_toggle.cpp
@@ -113,6 +113,23 @@ TEST(ToggleRefTest, declare_idempotent_and_type_conflict)
     EXPECT_THROW(table.declare<bool>("n", true), std::invalid_argument);
 }
 
+TEST(ToggleCategoryTest, records_and_defaults)
+{
+    DynamicToggleTable table;
+    table.declare<int32_t>("release_flag", 0, ToggleCategory::Release);
+    table.declare<int32_t>("ops_flag", 0, ToggleCategory::Ops);
+    table.declare<int32_t>("exp_flag", 0, ToggleCategory::Experiment);
+
+    EXPECT_EQ(table.category("release_flag"), ToggleCategory::Release);
+    EXPECT_EQ(table.category("ops_flag"), ToggleCategory::Ops);
+    EXPECT_EQ(table.category("exp_flag"), ToggleCategory::Experiment);
+    // An undeclared key reports the Ops default.
+    EXPECT_EQ(table.category("missing"), ToggleCategory::Ops);
+    // A clear forgets categories.
+    table.clear();
+    EXPECT_EQ(table.category("release_flag"), ToggleCategory::Ops);
+}
+
 TEST(ToggleOnChangeTest, fires_once_per_real_change)
 {
     DynamicToggleTable table;

--- a/solvcon/core.py
+++ b/solvcon/core.py
@@ -89,6 +89,8 @@ list_of_toggle = [
     'CallProfilerProbe',
     'HierarchicalToggleAccess',
     'Toggle',
+    'ToggleCategory',
+    'ToggleSubscription',
     'METAL_BUILT',
     'metal_running',
 ]

--- a/solvcon/toggle.py
+++ b/solvcon/toggle.py
@@ -12,6 +12,33 @@ import json
 from . import core
 
 
+def _set_value(node, key, value):
+    """Create or update one toggle, inferring its type from the JSON value."""
+    # bool must be checked before int: in Python, bool is a subclass of int.
+    if isinstance(value, bool):
+        node.set_bool(key, value)
+    elif isinstance(value, int):
+        node.set_int64(key, value)
+    elif isinstance(value, float):
+        node.set_real(key, value)
+    elif isinstance(value, str):
+        node.set_string(key, value)
+    else:
+        raise TypeError(
+            'cannot load toggle "%s" of unsupported type %s'
+            % (key, type(value).__name__))
+
+
+def _load_tree(node, tree):
+    """Walk a nested dict, creating subkeys and typed leaf toggles."""
+    for key, value in tree.items():
+        if isinstance(value, dict):
+            node.add_subkey(key)
+            _load_tree(getattr(node, key), value)
+        else:
+            _set_value(node, key, value)
+
+
 def load(data, toggle_instance=None):
     tg = toggle_instance
     if tg is None:
@@ -21,19 +48,12 @@ def load(data, toggle_instance=None):
     pdata = json.loads(data)
     if len(pdata) != 2:
         raise ValueError("input data must be 2 but get %d" % len(pdata))
-    # pfixed = pdata[0].get('fixed', {})
-    pdynamic = pdata[1].get('dynamic', {})
 
-    # Get the apps sub-section
-    papps = pdynamic.get('apps', {})
-    tg.add_subkey('apps')
-    ta = tg.apps
-
-    # App euler1d
-    ta.add_subkey('euler1d')
-    thisapp = ta.euler1d
-    thispdata = papps.get('euler1d', {})
-    thisapp.set_bool('use_sub', thispdata.get('use_sub', False))
+    # Fixed toggles are now ordinary declared toggles; apply them by name.
+    for name, value in pdata[0].get('fixed', {}).items():
+        _set_value(tg, name, value)
+    # Walk the dynamic tree generically for any app, not just euler1d.
+    _load_tree(tg, pdata[1].get('dynamic', {}))
 
     return tg
 

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -310,6 +310,19 @@ class ToggleTypedAccessTC(unittest.TestCase):
         with self.assertRaises(KeyError):
             tg.at("t.missing")
 
+    def test_category(self):
+        tg = solvcon.Toggle.instance.clone()
+        # The startup toggles are declared with the Ops category.
+        self.assertEqual(tg.category("python_redirect"),
+                         solvcon.ToggleCategory.Ops)
+        tg.dynamic_clear()
+        tg.declare_int32("t.count", 1)
+        self.assertEqual(tg.category("t.count"),
+                         solvcon.ToggleCategory.Ops)
+        # An undeclared key reports the default category.
+        self.assertEqual(tg.category("t.missing"),
+                         solvcon.ToggleCategory.Ops)
+
     def test_declare_is_idempotent(self):
         tg = solvcon.Toggle.instance.clone()
         tg.dynamic_clear()
@@ -499,19 +512,27 @@ class ToggleLoadTC(unittest.TestCase):
             toggle_instance=solvcon.Toggle.instance.clone())
         self.assertEqual(tg.apps.euler1d.use_sub, True)
 
-    @unittest.skip("the lifecycle issue may cause segfault")
     def test_load_bad_lifecycle(self):
+        # Chaining subkey access off a temporary Toggle used to dangle the raw
+        # table pointer the access holds and could segfault. keep_alive now
+        # keeps the owning Toggle alive through the whole chain.
         fixture = '''[{"fixed": {"show_axis": false}},
-{"dynamic": {"apps": {"euler1d": {"use_sub": false}}}}]'''
-        # TODO: Need to fix this later. It may be wrong lifecycle handling with
-        # WrapHierarchicalToggleAccess.
-        with self.assertRaisesRegex(
-                AttributeError,
-                r'Cannot get non-existing key "apps.euler1d"'
-        ):
-            solvcon.toggle.load(
-                fixture,
-                toggle_instance=solvcon.Toggle.instance.clone()).apps.euler1d
+{"dynamic": {"apps": {"euler1d": {"use_sub": true}}}}]'''
+        value = solvcon.toggle.load(
+            fixture,
+            toggle_instance=solvcon.Toggle.instance.clone()
+        ).apps.euler1d.use_sub
+        self.assertEqual(value, True)
+
+    def test_load_generic_app(self):
+        # load walks the dynamic tree for any app, not just euler1d.
+        fixture = '''[{"fixed": {}},
+{"dynamic": {"apps": {"myapp": {"count": 7, "name": "hi"}}}}]'''
+        tg = solvcon.toggle.load(
+            fixture,
+            toggle_instance=solvcon.Toggle.instance.clone())
+        self.assertEqual(tg.apps.myapp.count, 7)
+        self.assertEqual(tg.apps.myapp.name, "hi")
 
 
 class CommandLineInfoTC(unittest.TestCase):


### PR DESCRIPTION
Step 5 of the toggle unification: fold the three storage mechanisms into one,
and close two long-standing loose ends.

## Change

- **use_pyside** becomes an inline `constexpr` build switch in
  `build_config.hpp`; `SolidToggle` is now a stateless compatibility facade.
- **python_redirect** and **show_axis** are declared toggles created at
  `Toggle` construction with startup defaults and a category, so they gain
  change notification and serialization. `FixedToggle` is now a facade reading
  and writing them through the store. `to_python` still reports them under the
  `fixed` section (and skips them in `dynamic`), so the format is unchanged.
- **ToggleCategory** (release, ops, experiment) is recorded per key at declare
  time, so a lint or test can later flag a release toggle that outlived its
  feature. It enforces nothing by itself.
- **HierarchicalToggleAccess lifetime**: a subkey access holds a raw table
  pointer, so a returned access is tied to its owner with keep_alive. A leaf
  read returns a plain value (which cannot carry keep_alive), so the owner is
  tied only when the result is itself an access. This un-skips
  `test_load_bad_lifecycle`, which chained off a temporary and could segfault.
- **Generic `load`**: `solvcon.toggle.load` walks the JSON tree and creates
  subkeys and typed values for any app, not just euler1d.

The old solid/fixed accessors keep working as facades until their callers move
in Step 6.

## Verification

- Full `make pytest` green (1283 passed, +3: generic load, un-skipped
  lifecycle, category); `make gtest` 191/191 (+1 category case).
- Standalone-buffer compile path (`common.hpp` -> `toggle.hpp` ->
  `build_config.hpp`) verified locally.
- `clang-tidy` (llvm-22), `cformat`, `cinclude`, `flake8`, `checkascii`,
  `checktws` all clean.