### PR TITLE
Migrate toggle call sites off the compatibility facades

### DIFF
--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -243,7 +243,7 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     : QDockWidget(title, parent, flags)
     , m_history_edit(new RPythonHistoryTextEdit)
     , m_command_edit(new RPythonCommandTextEdit)
-    , m_python_redirect(Toggle::instance().fixed().get_python_redirect())
+    , m_python_redirect(Toggle::instance().get<bool>("python_redirect", true))
 {
     auto * container = new QWidget;
     auto * layout = new QVBoxLayout;

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -1033,7 +1033,7 @@ void initialize_pilot(pybind11::module & mod)
         wrap_pilot(mod);
     };
 
-    if (Toggle::instance().solid().use_pyside())
+    if (build_config::use_pyside)
     {
         try
         {

--- a/cpp/solvcon/python/common.hpp
+++ b/cpp/solvcon/python/common.hpp
@@ -529,12 +529,12 @@ public:
 
     PythonStreamRedirect & set_enabled(bool enabled)
     {
-        Toggle::instance().fixed().set_python_redirect(enabled);
+        Toggle::instance().set_bool("python_redirect", enabled);
         return *this;
     }
 
     // FIXME: NOLINTNEXTLINE(readability-convert-member-functions-to-static)
-    bool is_enabled() const { return Toggle::instance().fixed().get_python_redirect(); }
+    bool is_enabled() const { return Toggle::instance().get<bool>("python_redirect", true); }
     bool is_disabled() const { return !is_enabled(); }
 
     PythonStreamRedirect & activate();

--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -447,17 +447,6 @@ void declare_toggle(Toggle & self, std::string const & key, T const & value)
     self.declare<T>(key, value);
 }
 
-void warn_deprecated_getter(char const * name)
-{
-    PyErr_WarnEx(
-        PyExc_DeprecationWarning,
-        std::format("Toggle.{} returns a silent sentinel on a missing or wrong-typed "
-                    "key and is deprecated; use get(key, default) or at(key)",
-                    name)
-            .c_str(),
-        1);
-}
-
 } /* end namespace detail */
 
 WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const * pydoc)
@@ -628,27 +617,8 @@ WrapToggle::WrapToggle(pybind11::module & mod, char const * pyname, char const *
         //
         ;
 
-    // The type-specific getters return a silent sentinel on a missing or
-    // wrong-typed key. They are kept for compatibility but deprecated in
-    // favor of get(key, default) and at(key); each emits a
-    // DeprecationWarning.
-#define MM_PYTHON_TOGGLE_DEPRECATED_GET(MTYPE)             \
-    (*this).def(                                           \
-        "get_" #MTYPE,                                     \
-        [](wrapped_type & self, std::string const & key)   \
-        {                                                  \
-            detail::warn_deprecated_getter("get_" #MTYPE); \
-            return self.get_##MTYPE(key);                  \
-        },                                                 \
-        py::arg("key"));
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(bool)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int8)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int16)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int32)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(int64)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(real)
-    MM_PYTHON_TOGGLE_DEPRECATED_GET(string)
-#undef MM_PYTHON_TOGGLE_DEPRECATED_GET
+    // The type-specific sentinel getters (get_bool, get_int8, ...) have been
+    // removed in favor of get(key, default) and at(key).
 
     // Static properties.
     (*this)

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -822,47 +822,28 @@ private:
 }; /* end class FixedToggle */
 
 /**
- * The toggle system for solvcon. There are 3 types of toggles:
+ * The toggle system for solvcon.
  *
- * 1. solid toggles: managed by SolidToggle class. It is the toggles whose value
- *    is determined during compile time. The value is read-only (const) through
- *    out the program lifecycle (the process).
+ * All toggles now live in one store, the DynamicToggleTable of typed
+ * registers. A toggle is created and named once with declare<T>(key, default,
+ * category); a hot path binds a typed handle (ref<T>) and reads it with a
+ * single atomic load; the UI edits it by key and subscribes with on_change.
  *
- *    The solid toggles have address and can be referenced. They cannot be
- *    optimized out (unlike macros and constexpr). It could add overhead when
- *    used in tight loops. The overhead may usually be too low to be noticed,
- *    but sometimes one needs to be careful about it.
+ * Two access styles read the same store:
  *
- * 2. fixed toggles: managed by FixedToggle class. It is the toggles whose name
- *    is determined during compile time. The value can be changed during
- *    runtime.
- *
- *    Because the names are determined during compile time, when accessing the
- *    toggles, no table lookup is needed. The address of the toggle variables
- *    has been determined by the compiler and linker.
- *
- *    The runtime cost of fixed toggles is the same as solid toggles. It may
- *    be used in tight loops. Just becareful about the potential runtime
- *    overhead.
- *
- * 3. dynamic toggles: managed by DynamicToggleTable. The toggles are
- *    hierarchical and the names and values can be added, removed, and modified
- *    during runtime. The value needs to use limited data types: bool, int8,
- *    int16, int32, int64, real, and string. It is intentional not to support
- *    unsigned integers.
- *
- *    Accessing dynamic toggles requires table lookup and string comparison. It
- *    is slow but flexible.
- *
- *    To access the dynamic toggles from C++, the data type of the toggle
- *    The hierarchical access (from C++) uses ".", like:
- *
- *      tg.get_int8("top_level.second_level.key_name")
- *
- *    In Python, the wrapper can determine the type dynamically, and the
- *    hierarchical access may use attribute syntax:
+ * 1. Typed evaluation by key: get<T>(key, default) returns the caller default
+ *    on a missing or wrong-typed key, and at<T>(key) throws. From Python the
+ *    wrapper infers the type and the hierarchy uses dotted keys or attribute
+ *    syntax, for example:
  *
  *      tg.top_level.second_level.key_name = value
+ *
+ * 2. Hoisted handles: ToggleRef<T> resolves the key once and reads the atomic
+ *    register with no map lookup, for tight loops.
+ *
+ * The former solid and fixed toggles are compatibility facades: use_pyside is
+ * an inline constexpr build switch (see build_config.hpp), and python_redirect
+ * and show_axis are ordinary declared toggles in the store.
  *
  * @ingroup group_core
  */
@@ -908,19 +889,14 @@ public:
         return m_dynamic_table.on_change(key, std::move(callback));
     }
 
-    bool get_bool(std::string const & key) const { return m_dynamic_table.get_bool(key); }
+    // The type-specific sentinel getters are gone; use get<T>/at<T>. The
+    // set_TYPE writers remain as the mutating entry point that fires on_change.
     void set_bool(std::string const & key, bool value) { m_dynamic_table.set_bool(key, value); }
-    int8_t get_int8(std::string const & key) const { return m_dynamic_table.get_int8(key); }
     void set_int8(std::string const & key, int8_t value) { m_dynamic_table.set_int8(key, value); }
-    int16_t get_int16(std::string const & key) const { return m_dynamic_table.get_int16(key); }
     void set_int16(std::string const & key, int16_t value) { m_dynamic_table.set_int16(key, value); }
-    int32_t get_int32(std::string const & key) const { return m_dynamic_table.get_int32(key); }
     void set_int32(std::string const & key, int32_t value) { m_dynamic_table.set_int32(key, value); }
-    int64_t get_int64(std::string const & key) const { return m_dynamic_table.get_int64(key); }
     void set_int64(std::string const & key, int64_t value) { m_dynamic_table.set_int64(key, value); }
-    double get_real(std::string const & key) const { return m_dynamic_table.get_real(key); }
     void set_real(std::string const & key, double value) { m_dynamic_table.set_real(key, value); }
-    std::string const & get_string(std::string const & key) const { return m_dynamic_table.get_string(key); }
     void set_string(std::string const & key, std::string const & value) { m_dynamic_table.set_string(key, value); }
     HierarchicalToggleAccess get_subkey(std::string const & key) { return m_dynamic_table.get_subkey(key); }
     void add_subkey(std::string const & key) { m_dynamic_table.add_subkey(key); }

--- a/tests/test_toggle.py
+++ b/tests/test_toggle.py
@@ -4,9 +4,7 @@
 
 import os
 import unittest
-import math
 import json
-import warnings
 
 import solvcon
 
@@ -50,12 +48,13 @@ class ToggleTC(unittest.TestCase):
         self.assertEqual(tg.dynamic_keys(), [])
 
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
 
         tg1 = tg.clone()
         self.assertEqual(tg.dynamic_keys(), tg1.dynamic_keys())
-        self.assertEqual(tg.get_bool("test_bool"), tg1.get_bool("test_bool"))
+        self.assertEqual(tg.get("test_bool", False),
+                         tg1.get("test_bool", False))
 
 
 class ToggleDynamicTC(unittest.TestCase):
@@ -67,49 +66,44 @@ class ToggleDynamicTC(unittest.TestCase):
 
         # Add a key of Boolean.
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         # Make sure the key appears.
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
-        # Test sentinel.
-        self.assertEqual(tg.get_bool("test_no_bool"), False)
+        # A missing key returns the caller default and at() raises.
+        self.assertEqual(tg.get("test_no_bool", False), False)
+        with self.assertRaises(KeyError):
+            tg.at("test_no_bool")
 
         # Add a key of int8.
         tg.set_int8("test_int8", 23)
-        self.assertEqual(tg.get_int8("test_int8"), 23)
+        self.assertEqual(tg.get("test_int8", 0), 23)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int8("test_no_int8"), 0)
+        self.assertEqual(tg.get("test_no_int8", 0), 0)
 
         # Add a key of int16.
         tg.set_int16("test_int16", -46)
-        self.assertEqual(tg.get_int16("test_int16"), -46)
+        self.assertEqual(tg.get("test_int16", 0), -46)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int16("test_no_int16"), 0)
 
         # Add a key of int32.
         tg.set_int32("test_int32", 842)
-        self.assertEqual(tg.get_int32("test_int32"), 842)
+        self.assertEqual(tg.get("test_int32", 0), 842)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int32",
                           "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int32("test_no_int32"), 0)
 
         # Add a key of int64.
         tg.set_int64("test_int64", -9912)
-        self.assertEqual(tg.get_int64("test_int64"), -9912)
+        self.assertEqual(tg.get("test_int64", 0), -9912)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_bool", "test_int16", "test_int32",
                           "test_int64", "test_int8"])
-        # Test sentinel.
-        self.assertEqual(tg.get_int64("test_no_int64"), 0)
 
         # Clear dynamic keys (and the values).
         tg.dynamic_clear()
@@ -117,20 +111,17 @@ class ToggleDynamicTC(unittest.TestCase):
 
         # Add a key of real.
         tg.set_real("test_real", 2.87)
-        self.assertEqual(tg.get_real("test_real"), 2.87)
+        self.assertEqual(tg.get("test_real", 0.0), 2.87)
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()), ["test_real"])
-        # Test sentinel.
-        self.assertTrue(math.isnan(tg.get_real("test_no_real")))
 
         # Add a key of string.
         tg.set_string("test_string", "a random line")
-        self.assertEqual(tg.get_string("test_string"), "a random line")
+        self.assertEqual(tg.get("test_string", ""), "a random line")
         # Make sure the key appears
         self.assertEqual(sorted(tg.dynamic_keys()),
                          ["test_real", "test_string"])
-        # Test sentinel.
-        self.assertEqual(tg.get_string("test_no_string"), "")
+        self.assertEqual(tg.get("test_no_string", ""), "")
 
         # Clear dynamic keys (and the values) the second time.
         tg.dynamic_clear()
@@ -141,24 +132,24 @@ class ToggleDynamicTC(unittest.TestCase):
         tg.dynamic_clear()
         self.assertEqual(tg.dynamic_keys(), [])
 
-        # Test sentinel.
-        self.assertEqual(tg.get_bool("test_bool"), False)
+        # A missing key returns the caller default.
+        self.assertEqual(tg.get("test_bool", False), False)
 
         # Add a key of Boolean.
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         # Make sure the key appears.
         self.assertEqual(tg.dynamic_keys(), ["test_bool"])
 
         # Fatigue test.
         tg.set_bool("test_bool", False)
-        self.assertFalse(tg.get_bool("test_bool"))
+        self.assertFalse(tg.get("test_bool", True))
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
         tg.set_bool("test_bool", False)
-        self.assertFalse(tg.get_bool("test_bool"))
+        self.assertFalse(tg.get("test_bool", True))
         tg.set_bool("test_bool", True)
-        self.assertTrue(tg.get_bool("test_bool"))
+        self.assertTrue(tg.get("test_bool", False))
 
         tg.dynamic_clear()
 
@@ -246,7 +237,7 @@ class ToggleHierarchicalTC(unittest.TestCase):
         self.assertIsInstance(tg.level1p.level2p,
                               solvcon.HierarchicalToggleAccess)
         tg.level1p.set_bool("test_bool", True)
-        self.assertEqual(tg.get_bool('level1p.test_bool'), True)
+        self.assertEqual(tg.get('level1p.test_bool', False), True)
         tg.set_int32('level1p.level2p.test_int32', -2132)
         self.assertEqual(tg.level1p.level2p.test_int32, -2132)
         self.assertEqual(sorted(tg.dynamic_keys()),
@@ -332,17 +323,12 @@ class ToggleTypedAccessTC(unittest.TestCase):
         tg.declare_int32("t.count", 100)
         self.assertEqual(tg.get("t.count", 0), 42)
 
-    def test_deprecated_getter_warns(self):
+    def test_sentinel_getters_removed(self):
         tg = solvcon.Toggle.instance.clone()
-        tg.dynamic_clear()
-        tg.set_bool("t.flag", True)
-
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            value = tg.get_bool("t.flag")
-        self.assertTrue(value)
-        self.assertEqual(len(caught), 1)
-        self.assertTrue(issubclass(caught[0].category, DeprecationWarning))
+        # The old silent-sentinel getters no longer exist on Toggle.
+        self.assertFalse(hasattr(tg, "get_bool"))
+        self.assertFalse(hasattr(tg, "get_int32"))
+        self.assertFalse(hasattr(tg, "get_string"))
 
 
 class ToggleOnChangeTC(unittest.TestCase):


### PR DESCRIPTION
Step 6 of the toggle unification: move the remaining readers off the solid and
fixed facades and retire the deprecated sentinel getters.

## Change

- `wrap_pilot` reads the compile-time `use_pyside` directly from
  `build_config` instead of `Toggle::instance().solid()`, so the branch folds
  at compile time.
- The Python stream redirect (`common.hpp`) and the console dock
  (`RPythonConsoleDockWidget.cpp`) read and write `python_redirect` through the
  typed store (`get<bool>(key, default)` / `set_bool`) instead of
  `Toggle::instance().fixed()`, so they observe the same value as everything
  else and pick up change notification.
- Remove the silent-sentinel getters: the Python `get_bool`/.../`get_string`
  on `Toggle` (deprecated earlier) and the now-unused C++ `Toggle::get_TYPE`
  forwards. Callers use `get<T>(key, default)` or `at<T>(key)`; the `set_TYPE`
  writers stay as the mutating entry point. The lower-level `get_TYPE` on the
  dynamic access and the table remain (the type-dispatched read uses them).

Tests that encoded the old silent-sentinel behavior now assert the typed
contract (missing key -> caller default from `get`, raise from `at`). The
`Toggle` class documentation is rewritten around the one-store model.

The solid/fixed facade classes remain only for the Python serialization
compatibility (`to_python`), with no C++ callers left.

## Verification

- Full `make pytest` green (1283 passed); `make gtest` 191/191.
- Pilot compiles (BUILD_QT=ON) with the migrated `use_pyside` and
  `python_redirect` reads.
- `clang-tidy` (llvm-22) on the changed C++ files, `cformat`, `cinclude`,
  `flake8`, `checkascii`, `checktws` all clean.