### PR TITLE
Bind pilot menu toggles to the store with a Qt bridge

### DIFF
--- a/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
+++ b/cpp/solvcon/toggle/pymod/wrap_Toggle.cpp
@@ -755,6 +755,14 @@ void wrap_Toggle(pybind11::module & mod)
         .value("Ops", ToggleCategory::Ops)
         .value("Experiment", ToggleCategory::Experiment);
 
+    // Release every change callback held by the global store at interpreter
+    // shutdown, while Python is still alive, so a callback holding a Python
+    // object (for example a pilot menu bridge) is not freed after
+    // finalization when the store's static destructor runs.
+    py::module_::import("atexit").attr("register")(
+        py::cpp_function([]()
+                         { Toggle::instance().clear_change_observers(); }));
+
     WrapSolidToggle::commit(mod, "SolidToggle", "SolidToggle");
     WrapFixedToggle::commit(mod, "FixedToggle", "FixedToggle");
     WrapHierarchicalToggleAccess::commit(mod, "HierarchicalToggleAccess", "HierarchicalToggleAccess");

--- a/cpp/solvcon/toggle/toggle.hpp
+++ b/cpp/solvcon/toggle/toggle.hpp
@@ -516,6 +516,15 @@ public:
         return ToggleSubscription(m_observers, key, id);
     }
 
+    // Drop every change callback. Used at interpreter shutdown so a callback
+    // holding a Python object is released while the interpreter is still
+    // alive, not when this store is destroyed after finalization.
+    void clear_observers()
+    {
+        std::scoped_lock const guard(m_observers->mutex);
+        m_observers->map.clear();
+    }
+
 private:
 
     DynamicToggleTable(DynamicToggleTable const & other, std::scoped_lock<std::mutex> const &)
@@ -888,6 +897,7 @@ public:
     {
         return m_dynamic_table.on_change(key, std::move(callback));
     }
+    void clear_change_observers() { m_dynamic_table.clear_observers(); }
 
     // The type-specific sentinel getters are gone; use get<T>/at<T>. The
     // set_TYPE writers remain as the mutating entry point that fires on_change.

--- a/solvcon/pilot/_gui_common.py
+++ b/solvcon/pilot/_gui_common.py
@@ -3,17 +3,70 @@
 
 
 from . import _pilot_core as _pcore
+from ..core import Toggle
 from PySide6 import QtCore, QtGui
 
 
+class ToggleActionBridge(QtCore.QObject):
+    """Two-way binding between a checkable QAction and a store toggle.
+
+    The action's ``toggled`` writes the toggle; the toggle's ``on_change``
+    re-checks the action. The change is delivered on the UI thread through a
+    queued signal, so a change from a solver thread is safe. The store's no-op
+    guard (a set to the value already stored fires no ``on_change``) plus Qt
+    emitting ``toggled`` only on a real change together stop the echo, so the
+    old ``blockSignals`` guard is not needed.
+
+    The bridge is parented to its action, so it and its subscription live
+    exactly as long as the action.
+    """
+
+    _store_changed = QtCore.Signal(bool)
+
+    def __init__(self, action, key):
+        super().__init__(action)
+        self._action = action
+        self._key = key
+        tg = Toggle.instance
+        tg.declare_bool(key, action.isChecked())
+        action.setChecked(tg.get(key, action.isChecked()))
+        action.toggled.connect(self._on_action_toggled)
+        # Deliver a store change to the UI thread, then re-check the action.
+        self._store_changed.connect(action.setChecked,
+                                    QtCore.Qt.QueuedConnection)
+        self._token = tg.on_change(key, self._on_store_changed)
+        # Drop the subscription when the action goes away, so a later store
+        # change never calls back into a destroyed widget.
+        action.destroyed.connect(self._release)
+
+    def _release(self, *args):
+        self._token = None
+
+    def _on_action_toggled(self, checked):
+        if self._token is None:
+            return
+        Toggle.instance.set_bool(self._key, checked)
+
+    def _on_store_changed(self):
+        if self._token is None:
+            return
+        tg = Toggle.instance
+        self._store_changed.emit(tg.get(self._key, self._action.isChecked()))
+
+
 def build_action(parent, text, tip, func, *, id=None, checkable=False,
-                 checked=False, shortcut=None, menu_role=None):
+                 checked=False, shortcut=None, menu_role=None,
+                 toggle_key=None):
     """Build a QAction from one description, the single item builder.
 
     The id becomes the action's objectName (its handle in the menu model and
     in tests). A checkable action carries its initial check state; ``func``,
     when given, runs on trigger. A checkable feature that needs the toggled
     state wires ``toggled`` on the returned action itself.
+
+    When ``toggle_key`` is given, the action is bound two-way to that store
+    toggle through a ToggleActionBridge, so its state persists, round-trips to
+    JSON, and can be observed by a solver or a second widget.
     """
     act = QtGui.QAction(text, parent)
     if id:
@@ -28,6 +81,8 @@ def build_action(parent, text, tip, func, *, id=None, checkable=False,
         act.setChecked(checked)
     if func is not None:
         act.triggered.connect(lambda *a: func())
+    if toggle_key is not None:
+        ToggleActionBridge(act, toggle_key)
     return act
 
 
@@ -68,16 +123,19 @@ class PilotFeature(QtCore.QObject):
 
     def add_action(self, path, text, tip, func, *, id, weight=50,
                    checkable=False, checked=False, shortcut=None,
-                   menu_role=None):
+                   menu_role=None, toggle_key=None):
         """Build an action and place it in the menu at ``path`` by ``weight``.
 
         This is the one Python item builder over the shared placement: it
         returns the live action so a toggle feature can wire its own reverse
-        connections.
+        connections. When ``toggle_key`` is given, the action is bound two-way
+        to that store toggle (see build_action), so RMenuModel stays the
+        placement layer and the Toggle store owns the value.
         """
         act = build_action(self._mainWindow, text, tip, func, id=id,
                            checkable=checkable, checked=checked,
-                           shortcut=shortcut, menu_role=menu_role)
+                           shortcut=shortcut, menu_role=menu_role,
+                           toggle_key=toggle_key)
         self._mgr.menu_model.place(path, act, weight)
         return act
 

--- a/tests/test_pilot_toggle_action.py
+++ b/tests/test_pilot_toggle_action.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.pilot import _gui
+    from solvcon.pilot import _gui_common
+    from PySide6 import QtCore, QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ToggleActionBridgeTC(unittest.TestCase):
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.tg = solvcon.Toggle.instance
+        # A unique key per test isolates the shared global store.
+        self.KEY = "pilot.test.toggle_action." + self._testMethodName
+        self.tg.declare_bool(self.KEY, False)
+        self.tg.set_bool(self.KEY, False)
+        self.act = _gui_common.build_action(
+            self.mgr.mainWindow, "Flag", "A test toggle", None,
+            id="test.flag", checkable=True, checked=False,
+            toggle_key=self.KEY)
+
+    def tearDown(self):
+        # Destroy the action so its bridge unsubscribes from the store.
+        self.act.deleteLater()
+        self.act = None
+        QtWidgets.QApplication.sendPostedEvents(
+            None, QtCore.QEvent.Type.DeferredDelete)
+
+    def _drain(self):
+        QtWidgets.QApplication.processEvents()
+
+    def test_declares_toggle_with_default(self):
+        self.assertEqual(self.tg.get(self.KEY, True), False)
+
+    def test_menu_toggle_writes_the_store(self):
+        self.act.setChecked(True)
+        self.assertEqual(self.tg.get(self.KEY, False), True)
+        self.act.setChecked(False)
+        self.assertEqual(self.tg.get(self.KEY, True), False)
+
+    def test_store_set_rechecks_without_echo(self):
+        # Count notifications independently: a store-side change must fire
+        # on_change exactly once. The re-check it triggers writes the same
+        # value back, which the no-op guard drops, so there is no echo.
+        fires = []
+        token = self.tg.on_change(self.KEY, lambda: fires.append(1))
+
+        self.act.setChecked(False)  # ensure a real change below
+        fires.clear()
+
+        self.tg.set_bool(self.KEY, True)
+        self._drain()  # deliver the queued setChecked on the UI thread
+
+        self.assertTrue(self.act.isChecked())
+        self.assertEqual(len(fires), 1)
+        del token
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 7 of the toggle unification: a reusable two-way binding between a
checkable pilot menu action and a store toggle, plus the Qt bridge that
delivers a change to the UI thread (the hook deferred from the notification
step).

## Change

- `build_action`/`PilotFeature.add_action` gain an optional `toggle_key`. When
  set, the action is bound two-way to that store toggle through a
  `ToggleActionBridge`: the action's `toggled` writes the toggle, the toggle's
  `on_change` re-checks the action. `RMenuModel` stays the placement layer
  while the store owns the value, so the state persists, round-trips to JSON,
  and can be observed by a solver or a second widget.
- `ToggleActionBridge` is the change hook's Qt bridge: `on_change` fires a
  queued signal to `setChecked`, so a change from a solver thread lands on the
  UI thread. The store's no-op guard plus Qt emitting `toggled` only on a real
  change break the echo, so the `blockSignals` dance is not needed. The bridge
  is parented to its action and drops its subscription when the action is
  destroyed.
- Add `Toggle.clear_change_observers`, registered with `atexit`, so a callback
  holding a Python object is released while the interpreter is still alive
  rather than when the store's static is destroyed after finalization (this
  fixes a shutdown segfault when a bridge subscription outlives the process).

## Verification

- New pilot test drives the binding both ways (menu -> store, store-side set
  -> re-check + exactly-once notification, no echo). Verified locally under
  offscreen Qt; full local suite green (1286 passed incl. pilot) and `make
  gtest` 191/191. Pilot tests skip in CI (no GUI), so CI validates the build,
  the Python import, and the toggle/store changes.
- `clang-tidy` (llvm-22, incl. exception-escape), `cformat`, `cinclude`,
  `flake8`, `checkascii`, `checktws` all clean.

## Scope note

Migrating the existing per-viewer mesh-style checks, the enum-valued
`draw.tool` group, and the dock-visibility panels onto this mechanism is left
as follow-up: each also needs its behavior made store-driven (per-viewer or
Qt-widget state today), which is a per-feature change beyond the shared
binding this PR adds.