### PR TITLE
Add a terminal-style console on a single guarded surface

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonTerminalDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxRules.hpp
@@ -58,6 +59,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RPythonTerminalDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxRules.cpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -53,6 +53,7 @@ RManager & RManager::setUp()
     if (!m_already_setup)
     {
         this->setUpConsole();
+        this->setUpTerminal();
         this->setUpCentral();
         this->primeRhiComposition();
         this->setUpMenu();
@@ -78,6 +79,7 @@ void RManager::reset()
     m_mainWindow = nullptr;
     m_menuModel = nullptr;
     m_pycon = nullptr;
+    m_terminal = nullptr;
     m_mdiArea = nullptr;
     m_rhi_primer = nullptr;
 }
@@ -300,6 +302,33 @@ void RManager::setUpConsole()
     m_pycon = new RPythonConsoleDockWidget(QString("Console"), m_mainWindow);
     m_pycon->setAllowedAreas(Qt::AllDockWidgetAreas);
     m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, m_pycon);
+}
+
+void RManager::toggleTerminal()
+{
+    if (m_terminal)
+    {
+        if (m_terminal->isVisible())
+        {
+            m_terminal->hide();
+        }
+        else
+        {
+            m_terminal->show();
+        }
+    }
+}
+
+void RManager::setUpTerminal()
+{
+    m_terminal = new RPythonTerminalDockWidget(QString("Terminal"), m_mainWindow);
+    m_terminal->setAllowedAreas(Qt::AllDockWidgetAreas);
+    m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, m_terminal);
+
+    // The two consoles share the bottom area as tabs, with the two-pane
+    // console shown first; the terminal is opened from the Window menu.
+    m_mainWindow->tabifyDockWidget(m_pycon, m_terminal);
+    m_terminal->hide();
 }
 
 void RManager::setUpCentral()

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -19,6 +19,7 @@
 #include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/RAction.hpp>
 #include <solvcon/pilot/RPythonConsoleDockWidget.hpp>
+#include <solvcon/pilot/RPythonTerminalDockWidget.hpp>
 
 #include <vector>
 
@@ -74,6 +75,8 @@ public:
 
     RPythonConsoleDockWidget * pycon() { return m_pycon; }
 
+    RPythonTerminalDockWidget * terminal() { return m_terminal; }
+
     QMainWindow * mainWindow() { return m_mainWindow; }
 
     QMdiArea * mdiArea() { return m_mdiArea; }
@@ -90,12 +93,14 @@ public:
     void reset();
 
     void toggleConsole();
+    void toggleTerminal();
 
 private:
 
     RManager();
 
     void setUpConsole();
+    void setUpTerminal();
     void setUpCentral();
     void setUpMenu();
 
@@ -130,6 +135,7 @@ private:
     RMenuModel * m_menuModel = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
+    RPythonTerminalDockWidget * m_terminal = nullptr;
     QMdiArea * m_mdiArea = nullptr;
 
     /// Hidden QRhiWidget that keeps the main window in render-to-texture

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RPythonTerminalDockWidget.hpp>
+
+#include <algorithm>
+
+#include <QFont>
+#include <QKeyEvent>
+#include <QMimeData>
+#include <QPalette>
+#include <QStandardPaths>
+#include <QTextCursor>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// QTextCursor::selectedText separates blocks with the Unicode paragraph
+// separator; turn it back into a plain newline for the interpreter.
+QString toPlainNewlines(QString text)
+{
+    return text.replace(QChar(0x2029), '\n');
+}
+
+} /* end namespace */
+
+void RPythonTerminalTextEdit::startInput(QString const & prompt)
+{
+    QTextCursor cursor = textCursor();
+    cursor.movePosition(QTextCursor::End);
+    m_prompt_start = cursor.position();
+    cursor.insertText(prompt);
+    m_input_start = cursor.position();
+    setTextCursor(cursor);
+    ensureCursorVisible();
+}
+
+QString RPythonTerminalTextEdit::inputText() const
+{
+    QTextCursor cursor(document());
+    cursor.setPosition(m_input_start);
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    return toPlainNewlines(cursor.selectedText());
+}
+
+void RPythonTerminalTextEdit::setInputText(QString const & text)
+{
+    QTextCursor cursor(document());
+    cursor.setPosition(m_input_start);
+    cursor.movePosition(QTextCursor::End, QTextCursor::KeepAnchor);
+    cursor.insertText(text);
+    setTextCursor(cursor);
+    ensureCursorVisible();
+}
+
+void RPythonTerminalTextEdit::appendBeforePrompt(QString const & text)
+{
+    QTextCursor cursor(document());
+    cursor.setPosition(m_prompt_start);
+    cursor.insertText(text);
+
+    int const shift = static_cast<int>(text.length());
+    m_prompt_start += shift;
+    m_input_start += shift;
+}
+
+void RPythonTerminalTextEdit::appendCommitted(QString const & text)
+{
+    QTextCursor cursor(document());
+    cursor.movePosition(QTextCursor::End);
+    cursor.insertText(text);
+}
+
+bool RPythonTerminalTextEdit::cursorInInput() const
+{
+    return textCursor().selectionStart() >= m_input_start;
+}
+
+void RPythonTerminalTextEdit::moveToEnd()
+{
+    QTextCursor cursor = textCursor();
+    cursor.movePosition(QTextCursor::End);
+    setTextCursor(cursor);
+}
+
+void RPythonTerminalTextEdit::keyPressEvent(QKeyEvent * event)
+{
+    int const key = event->key();
+    Qt::KeyboardModifiers const mods = event->modifiers();
+
+    // Enter runs the input; Shift+Enter is a soft newline within it.
+    if (Qt::Key_Return == key || Qt::Key_Enter == key)
+    {
+        if (mods & Qt::ShiftModifier)
+        {
+            if (!cursorInInput())
+            {
+                moveToEnd();
+            }
+            insertPlainText("\n");
+        }
+        else
+        {
+            execute();
+        }
+        return;
+    }
+
+    // Up and Down walk the committed-command history.
+    if (Qt::Key_Up == key)
+    {
+        navigate(/* offset */ -1);
+        return;
+    }
+    if (Qt::Key_Down == key)
+    {
+        navigate(/* offset */ 1);
+        return;
+    }
+
+    // Home lands just after the prompt, not at column zero.
+    if (Qt::Key_Home == key && textCursor().position() >= m_input_start)
+    {
+        QTextCursor::MoveMode const mode = (mods & Qt::ShiftModifier)
+                                               ? QTextCursor::KeepAnchor
+                                               : QTextCursor::MoveAnchor;
+        QTextCursor cursor = textCursor();
+        cursor.setPosition(m_input_start, mode);
+        setTextCursor(cursor);
+        return;
+    }
+
+    // Backspace and Left must not chew into the read-only head.
+    if ((Qt::Key_Backspace == key || Qt::Key_Left == key) && !textCursor().hasSelection() && textCursor().position() <= m_input_start)
+    {
+        return;
+    }
+
+    // Any editing key acting on the read-only head is redirected to the
+    // end of the input region, so a stray click never mutates the
+    // transcript.
+    bool const is_text = !event->text().isEmpty() && event->text().at(0).isPrint();
+    bool const is_delete = Qt::Key_Backspace == key || Qt::Key_Delete == key;
+    if ((is_text || is_delete) && !cursorInInput())
+    {
+        moveToEnd();
+    }
+
+    QTextEdit::keyPressEvent(event);
+}
+
+void RPythonTerminalTextEdit::insertFromMimeData(QMimeData const * source)
+{
+    if (!cursorInInput())
+    {
+        moveToEnd();
+    }
+    if (source->hasText())
+    {
+        insertPlainText(source->text());
+    }
+}
+
+RPythonTerminalDockWidget::RPythonTerminalDockWidget(
+    QString const & title, QWidget * parent, Qt::WindowFlags flags)
+    : QDockWidget(title, parent, flags)
+    , m_edit(new RPythonTerminalTextEdit)
+    , m_python_redirect(Toggle::instance().fixed().get_python_redirect())
+{
+    setWidget(m_edit);
+
+    QPalette palette;
+    palette.setColor(QPalette::Base, Qt::white);
+    palette.setColor(QPalette::Text, Qt::black);
+    m_edit->setPalette(palette);
+    m_edit->setFont(QFont("Courier New"));
+    m_edit->setHorizontalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_edit->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+
+    connect(m_edit, &RPythonTerminalTextEdit::execute, this, &RPythonTerminalDockWidget::executeCommand);
+    connect(m_edit, &RPythonTerminalTextEdit::navigate, this, &RPythonTerminalDockWidget::navigateCommand);
+
+    // Share the persistent history file with the two-pane console, so recall
+    // spans both consoles.
+    QString const config_dir = QStandardPaths::writableLocation(QStandardPaths::GenericConfigLocation);
+    if (!config_dir.isEmpty())
+    {
+        m_history.setFilePath((config_dir + "/solvcon/console_history").toStdString());
+        m_history.load();
+        m_current_command_index = static_cast<int>(m_history.size());
+    }
+
+    m_edit->startInput(">>> ");
+}
+
+QString RPythonTerminalDockWidget::command() const
+{
+    return m_edit->inputText();
+}
+
+void RPythonTerminalDockWidget::setCommand(QString const & value)
+{
+    m_edit->setInputText(value);
+    if (!m_edit->hasFocus())
+    {
+        m_edit->setFocus();
+    }
+}
+
+QWidget * RPythonTerminalDockWidget::textEdit() const
+{
+    return m_edit;
+}
+
+void RPythonTerminalDockWidget::writeToHistory(std::string const & data)
+{
+    m_edit->appendBeforePrompt(QString::fromStdString(data));
+}
+
+void RPythonTerminalDockWidget::executeCommand()
+{
+    QString const input = m_edit->inputText();
+    std::string const command = input.trimmed().toStdString();
+
+    // Freeze the typed line into the transcript by ending it.
+    m_edit->appendCommitted("\n");
+
+    if (command.empty())
+    {
+        m_edit->startInput(">>> ");
+        return;
+    }
+
+    m_history.add(command);
+    m_current_command_index = static_cast<int>(m_history.size());
+
+    auto & interp = solvcon::python::Interpreter::instance();
+    m_python_redirect.activate();
+    interp.exec_code(command);
+    if (m_python_redirect.is_activated())
+    {
+        std::string const out = m_python_redirect.stdout_string();
+        std::string const err = m_python_redirect.stderr_string();
+        if (!out.empty())
+        {
+            m_edit->appendCommitted(QString::fromStdString(out));
+        }
+        if (!err.empty())
+        {
+            m_edit->appendCommitted(QString::fromStdString(err));
+        }
+    }
+    m_python_redirect.deactivate();
+
+    m_edit->startInput(">>> ");
+}
+
+void RPythonTerminalDockWidget::navigateCommand(int offset)
+{
+    int const commands_num = static_cast<int>(m_history.size());
+    if (commands_num == m_current_command_index)
+    {
+        m_draft_command = m_edit->inputText().toStdString();
+    }
+
+    int const new_index = std::clamp(m_current_command_index + offset, 0, commands_num);
+    std::string const & command_to_show = new_index == commands_num
+                                              ? m_draft_command
+                                              : m_history.at(new_index);
+
+    m_current_command_index = new_index;
+    m_edit->setInputText(QString::fromStdString(command_to_show));
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
@@ -1,0 +1,148 @@
+#pragma once
+
+/*
+ * Copyright (c) 2022, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt dock widget that hosts an interactive Python console on a single
+ * terminal surface: one document where the prompt, the typed command, and
+ * the captured output interleave, with the committed transcript read-only
+ * and the current input editable after the prompt.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/python/common.hpp> // must be first.
+
+#include <solvcon/pilot/RPythonConsoleHistory.hpp>
+
+#include <string>
+
+#include <Qt>
+#include <QDockWidget>
+#include <QTextEdit>
+#include <QWidget>
+
+namespace solvcon
+{
+
+/**
+ * The single text surface of the terminal console.
+ *
+ * The document is split by the input-start anchor into a read-only head,
+ * the committed transcript, and an editable tail, the current input that
+ * follows the prompt. The key and mouse handlers keep every edit at or
+ * past the anchor: typing in the head relocates the caret to the end,
+ * Backspace and Left stop at the anchor, and Home lands after the prompt.
+ * Enter emits execute; Up and Down emit navigate for history recall.
+ *
+ * @ingroup group_domain
+ */
+class RPythonTerminalTextEdit
+    : public QTextEdit
+{
+    Q_OBJECT
+
+public:
+
+    /// Write @p prompt as read-only text at the end and open the input
+    /// region just after it.
+    void startInput(QString const & prompt);
+
+    /// The editable text after the prompt.
+    QString inputText() const;
+
+    /// Replace the editable text after the prompt with @p text.
+    void setInputText(QString const & text);
+
+    /// Append @p text to the committed transcript, just before the prompt,
+    /// leaving any in-progress input untouched.
+    void appendBeforePrompt(QString const & text);
+
+    /// Append @p text at the end of the committed transcript.
+    void appendCommitted(QString const & text);
+
+    int inputStart() const { return m_input_start; }
+
+    void keyPressEvent(QKeyEvent * event) override;
+
+protected:
+
+    void insertFromMimeData(QMimeData const * source) override;
+
+signals:
+
+    void execute();
+    void navigate(int offset);
+
+private:
+
+    /// True when the whole selection, or the bare caret, sits in the
+    /// editable input region.
+    bool cursorInInput() const;
+
+    /// Drop any selection and move the caret to the end of the document.
+    void moveToEnd();
+
+    int m_prompt_start = 0;
+    int m_input_start = 0;
+
+}; /* end class RPythonTerminalTextEdit */
+
+/**
+ * The dockable terminal console.
+ *
+ * It runs each submitted command through the embedded interpreter and
+ * writes the captured stdout and stderr back onto the same surface, above
+ * the next prompt. It shares the persistent history file with the two-pane
+ * console, so recall spans both. The two-pane console is unaffected.
+ *
+ * @ingroup group_domain
+ */
+class RPythonTerminalDockWidget
+    : public QDockWidget
+{
+    Q_OBJECT
+
+public:
+
+    explicit RPythonTerminalDockWidget(
+        QString const & title = "Terminal",
+        QWidget * parent = nullptr,
+        Qt::WindowFlags flags = Qt::WindowFlags());
+
+    QString command() const;
+    void setCommand(QString const & value);
+
+    /// The single text surface, for driving from the pilot and tests.
+    QWidget * textEdit() const;
+
+    bool hasPythonRedirect() const { return m_python_redirect.is_enabled(); }
+
+    RPythonTerminalDockWidget & setPythonRedirect(bool enabled)
+    {
+        m_python_redirect.set_enabled(enabled);
+        return *this;
+    }
+
+    void writeToHistory(std::string const & data);
+
+public slots:
+    void executeCommand();
+    void navigateCommand(int offset);
+
+private:
+    RPythonTerminalTextEdit * m_edit = nullptr;
+    std::string m_draft_command;
+    RPythonConsoleHistory m_history;
+    int m_current_command_index = 0;
+
+    python::PythonStreamRedirect m_python_redirect;
+}; /* end class RPythonTerminalDockWidget */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -673,6 +673,53 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPythonConsoleDockWidget
 
 }; /* end class WrapRPythonConsoleDockWidget */
 
+class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRPythonTerminalDockWidget
+    : public WrapBase<WrapRPythonTerminalDockWidget, RPythonTerminalDockWidget>
+{
+
+    friend root_base_type;
+
+    WrapRPythonTerminalDockWidget(pybind11::module & mod, char const * pyname, char const * pydoc)
+        : root_base_type(mod, pyname, pydoc)
+    {
+
+        namespace py = pybind11;
+
+        (*this)
+            .def("writeToHistory", &wrapped_type::writeToHistory)
+            .def("executeCommand", &wrapped_type::executeCommand)
+            .def_property_readonly(
+                "textEdit",
+                [](wrapped_type & self)
+                {
+                    return self.textEdit();
+                })
+            .def_property(
+                "command",
+                [](wrapped_type const & self)
+                {
+                    return self.command().toStdString();
+                },
+                [](wrapped_type & self, std::string const & command)
+                {
+                    return self.setCommand(QString::fromStdString(command));
+                })
+            .def_property(
+                "python_redirect",
+                [](wrapped_type const & self)
+                {
+                    return self.hasPythonRedirect();
+                },
+                [](wrapped_type & self, bool enabled)
+                {
+                    self.setPythonRedirect(enabled);
+                })
+            //
+            ;
+    }
+
+}; /* end class WrapRPythonTerminalDockWidget */
+
 class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRMenuModel
     : public WrapBase<WrapRMenuModel, RMenuModel>
 {
@@ -803,6 +850,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.pycon();
                 })
+            .def_property_readonly(
+                "terminal",
+                [](wrapped_type & self)
+                {
+                    return self.terminal();
+                })
             .def(
                 "add3DWidget",
                 [](wrapped_type & self)
@@ -852,6 +905,12 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.toggleConsole();
+                })
+            .def(
+                "toggleTerminal",
+                [](wrapped_type & self)
+                {
+                    return self.toggleTerminal();
                 })
             //
             ;
@@ -973,6 +1032,7 @@ void wrap_pilot(pybind11::module & mod)
         "saveImage / clipImage.");
     WrapR2DWidget::commit(mod, "R2DWidget", "R2DWidget");
     WrapRPythonConsoleDockWidget::commit(mod, "RPythonConsoleDockWidget", "RPythonConsoleDockWidget");
+    WrapRPythonTerminalDockWidget::commit(mod, "RPythonTerminalDockWidget", "RPythonTerminalDockWidget");
     WrapRMenuModel::commit(
         mod,
         "RMenuModel",

--- a/solvcon/pilot/__init__.py
+++ b/solvcon/pilot/__init__.py
@@ -16,6 +16,7 @@ from ._pilot_core import (  # noqa: F401
     RDomainWidget,
     R2DWidget,
     RPythonConsoleDockWidget,
+    RPythonTerminalDockWidget,
     RManager,
 )
 if enable:

--- a/solvcon/pilot/_gui.py
+++ b/solvcon/pilot/_gui.py
@@ -166,6 +166,13 @@ class _Controller(metaclass=_Singleton):
                 wm.toggleConsole, id="window.console",
                 checkable=True, checked=True),
             50)
+        wm.menu_model.place(
+            "Window",
+            _gui_common.build_action(
+                wm.mainWindow, "Terminal", "Open / Close Terminal",
+                wm.toggleTerminal, id="window.terminal",
+                checkable=True, checked=False),
+            51)
 
 
 controller = _Controller()

--- a/solvcon/pilot/_pilot_core.py
+++ b/solvcon/pilot/_pilot_core.py
@@ -41,6 +41,11 @@ list_of_rpythonconsole = [
     'RPythonConsoleDockWidget',
 ]
 
+# RPythonTerminalDockWidget.hpp/.cpp
+list_of_rpythonterminal = [
+    'RPythonTerminalDockWidget',
+]
+
 # DrawTool.hpp/.cpp
 list_of_drawtool = [
     'draw_tool_names',
@@ -53,6 +58,7 @@ _from_impl = (  # noqa: F822
     list_of_r2dwidget +
     list_of_rmanager +
     list_of_rpythonconsole +
+    list_of_rpythonterminal +
     list_of_drawtool
 )
 
@@ -74,6 +80,7 @@ _load(list_of_rdomainwidget)
 _load(list_of_r2dwidget)
 _load(list_of_rmanager)
 _load(list_of_rpythonconsole)
+_load(list_of_rpythonterminal)
 _load(list_of_drawtool)
 
 del _load

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+"""
+Tests for the terminal-style console, RPythonTerminalDockWidget.
+
+The terminal presents the in-process interpreter on a single surface: one
+document where the prompt, the typed command, and the captured output
+interleave, with the committed transcript read-only and the current input
+editable after the prompt. These drive the widget through synthesized key
+events, so they need the Qt pilot but no on-screen rendering.
+"""
+
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from PySide6 import QtCore
+    from PySide6.QtTest import QTest
+except ImportError:
+    pilot = None
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+class TerminalWidgetTC(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mgr = pilot.RManager.instance.setUp()
+
+    def setUp(self):
+        self.term = self.mgr.terminal
+        self.edit = self.term.textEdit
+        # Start each test from an empty input region after the prompt.
+        self.term.command = ""
+
+    def _type(self, text):
+        QTest.keyClicks(self.edit, text)
+
+    def _key(self, key, mod=QtCore.Qt.NoModifier):
+        QTest.keyClick(self.edit, key, mod)
+
+    def test_terminal_exists_and_shows_prompt(self):
+        self.assertIsNotNone(self.term)
+        self.assertIsNotNone(self.edit)
+        self.assertTrue(self.edit.toPlainText().endswith(">>> "))
+
+    def test_typed_text_becomes_the_input(self):
+        self._type("1 + 1")
+        self.assertEqual(self.term.command, "1 + 1")
+
+    def test_execute_bare_expression_shows_result(self):
+        self.term.command = "6 * 7"
+        self.term.executeCommand()
+        text = self.edit.toPlainText()
+        self.assertIn(">>> 6 * 7", text)
+        self.assertIn("42", text)
+        # A fresh prompt awaits the next command.
+        self.assertTrue(text.endswith(">>> "))
+        self.assertEqual(self.term.command, "")
+
+    def test_state_persists_across_commands(self):
+        self.term.command = "term_x = 5"
+        self.term.executeCommand()
+        self.term.command = "term_x + 100"
+        self.term.executeCommand()
+        self.assertIn("105", self.edit.toPlainText())
+
+    def test_home_lands_after_the_prompt(self):
+        self._type("abc")
+        self._key(QtCore.Qt.Key_Home)
+        cursor = self.edit.textCursor()
+        self.assertEqual(cursor.position(), self.term_input_start())
+        # Typing at Home still edits the input, not the prompt.
+        self._type("Z")
+        self.assertEqual(self.term.command, "Zabc")
+
+    def test_backspace_stops_at_the_prompt(self):
+        self._type("q")
+        self._key(QtCore.Qt.Key_Backspace)
+        self.assertEqual(self.term.command, "")
+        # One more backspace must not eat into the prompt.
+        self._key(QtCore.Qt.Key_Backspace)
+        self.assertTrue(self.edit.toPlainText().endswith(">>> "))
+
+    def test_typing_in_the_readonly_head_relocates_to_input(self):
+        self._type("tail")
+        # Move the caret into the committed head.
+        cursor = self.edit.textCursor()
+        cursor.setPosition(0)
+        self.edit.setTextCursor(cursor)
+        self._type("X")
+        # The character lands in the input region, not the frozen head.
+        self.assertEqual(self.term.command, "tailX")
+
+    def test_history_recall_with_up_and_down(self):
+        self.term.command = "history_one = 1"
+        self.term.executeCommand()
+        self.term.command = "history_two = 2"
+        self.term.executeCommand()
+        self._key(QtCore.Qt.Key_Up)
+        self.assertEqual(self.term.command, "history_two = 2")
+        self._key(QtCore.Qt.Key_Up)
+        self.assertEqual(self.term.command, "history_one = 1")
+        self._key(QtCore.Qt.Key_Down)
+        self.assertEqual(self.term.command, "history_two = 2")
+
+    def test_write_to_history_appends_above_the_prompt(self):
+        self._type("keep")
+        self.term.writeToHistory("external line\n")
+        text = self.edit.toPlainText()
+        self.assertIn("external line", text)
+        # The in-progress input survives the external write.
+        self.assertEqual(self.term.command, "keep")
+
+    def term_input_start(self):
+        """Position just after the current prompt, read off the document."""
+        text = self.edit.toPlainText()
+        return text.rfind(">>> ") + len(">>> ")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -17,13 +17,26 @@ import solvcon
 
 try:
     from solvcon import pilot
-    from PySide6 import QtCore
-    from PySide6.QtTest import QTest
+    from PySide6 import QtCore, QtGui, QtWidgets
 except ImportError:
     pilot = None
 
 
-@unittest.skipUnless(solvcon.HAS_PILOT, "Qt pilot is not built")
+def _send_key(widget, key, text="", mod=None):
+    """Post a synthetic key press and release to ``widget``.
+
+    Built by hand rather than through ``QtTest`` so the tests need only the
+    always-present PySide6 widget modules, matching the other pilot tests.
+    """
+    if mod is None:
+        mod = QtCore.Qt.NoModifier
+    for etype in (QtCore.QEvent.Type.KeyPress, QtCore.QEvent.Type.KeyRelease):
+        event = QtGui.QKeyEvent(etype, key, mod, text)
+        QtWidgets.QApplication.sendEvent(widget, event)
+
+
+@unittest.skipUnless(solvcon.HAS_PILOT and pilot is not None,
+                     "Qt pilot is not built")
 class TerminalWidgetTC(unittest.TestCase):
 
     @classmethod
@@ -37,10 +50,11 @@ class TerminalWidgetTC(unittest.TestCase):
         self.term.command = ""
 
     def _type(self, text):
-        QTest.keyClicks(self.edit, text)
+        for ch in text:
+            _send_key(self.edit, ord(ch.upper()), ch)
 
-    def _key(self, key, mod=QtCore.Qt.NoModifier):
-        QTest.keyClick(self.edit, key, mod)
+    def _key(self, key, mod=None):
+        _send_key(self.edit, key, "", mod)
 
     def test_terminal_exists_and_shows_prompt(self):
         self.assertIsNotNone(self.term)


### PR DESCRIPTION
First step of the terminal-console work: a new console that presents the
in-process interpreter as a terminal, one document where the prompt, the
typed command, and the captured output interleave, with the committed
transcript read-only and the current input editable after the prompt.

## What this adds

- `RPythonTerminalDockWidget` / `RPythonTerminalTextEdit`: the single-surface
  terminal. An input-start anchor splits the document into a read-only head
  and an editable tail. The key and mouse handlers keep every edit at or past
  the anchor: typing or pasting into the head relocates the caret to the end,
  Backspace and Left stop at the anchor, and Home lands after the prompt.
- Execution: Enter runs the input through the shared `Interpreter::exec_code`
  and writes stdout and stderr back above the next prompt. Up and Down recall
  from the history file that both consoles share.
- Integration: the manager builds the terminal next to the two-pane console,
  tabbed and hidden until opened; a "Terminal" item on the Window menu toggles
  it. The existing console is unchanged, so the user chooses either from the
  menu.
- Tests: `tests/test_pilot_terminal.py` drives the widget through synthesized
  key events (prompt, typed input, execution and result, the input boundary,
  and history recall).

## Scope note

This is the foundational widget, so it runs larger than the plan's ~300-line
target: a new Qt dock widget with input-boundary handling plus its test suite
has an irreducible floor. Steps 2 through 4 (prompt-driven multiline,
completion and call tips and highlighting, and output styling with the busy
state) build on this surface and are lighter.

## Verification

- Build clean with `-Werror`.
- `run_pilot_pytest`: full pilot suite green, including the 9 new terminal
  tests.
- `cformat`, `cinclude`, `flake8`, `checkascii`, `checktws`: clean.
- `pilot_clang_tidy_diff` (warnings-as-errors): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)