### PR TITLE
Give the terminal completion, call tips, search, and highlighting

### DIFF
--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
@@ -8,6 +8,7 @@
 #include <solvcon/pilot/RPythonSyntaxRules.hpp>
 
 #include <QColor>
+#include <QTextBlock>
 
 namespace solvcon
 {
@@ -26,6 +27,19 @@ RPythonSyntaxHighlighter::RPythonSyntaxHighlighter(QTextDocument * parent)
 
 void RPythonSyntaxHighlighter::highlightBlock(QString const & text)
 {
+    // In a shared document, leave the committed transcript above the input
+    // region uncolored. The input's block starts at the prompt, before the
+    // input anchor, so a block is committed only when it ends at or before
+    // the anchor.
+    if (m_input_start_provider)
+    {
+        QTextBlock const block = currentBlock();
+        if (block.position() + block.length() <= m_input_start_provider())
+        {
+            return;
+        }
+    }
+
     for (SyntaxSpan const & span : tokenizePython(text.toStdString()))
     {
         QTextCharFormat const * format = nullptr;

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
@@ -13,6 +13,8 @@
  * @ingroup group_domain
  */
 
+#include <functional>
+
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
 
@@ -35,12 +37,21 @@ public:
 
     explicit RPythonSyntaxHighlighter(QTextDocument * parent);
 
+    /// Restrict painting to blocks at or after the position the provider
+    /// returns, so a shared document (such as the terminal's) keeps its
+    /// committed transcript uncolored. Unset means paint every block.
+    void setInputStartProvider(std::function<int()> provider)
+    {
+        m_input_start_provider = std::move(provider);
+    }
+
 protected:
 
     void highlightBlock(QString const & text) override;
 
 private:
 
+    std::function<int()> m_input_start_provider;
     QTextCharFormat m_keyword_format;
     QTextCharFormat m_builtin_format;
     QTextCharFormat m_string_format;

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
@@ -9,12 +9,17 @@
 
 #include <algorithm>
 
+#include <QAbstractItemView>
+#include <QColor>
 #include <QFont>
 #include <QKeyEvent>
 #include <QMimeData>
 #include <QPalette>
+#include <QScrollBar>
 #include <QStandardPaths>
+#include <QTextBlock>
 #include <QTextCursor>
+#include <QToolTip>
 
 namespace solvcon
 {
@@ -90,10 +95,181 @@ void RPythonTerminalTextEdit::moveToEnd()
     setTextCursor(cursor);
 }
 
+void RPythonTerminalTextEdit::setCompleter(QCompleter * completer)
+{
+    if (m_completer)
+    {
+        m_completer->disconnect(this);
+    }
+    m_completer = completer;
+    if (!m_completer)
+    {
+        return;
+    }
+    m_completer->setWidget(this);
+    m_completer->setCompletionMode(QCompleter::PopupCompletion);
+    m_completer->setCaseSensitivity(Qt::CaseSensitive);
+    connect(
+        m_completer,
+        QOverload<QString const &>::of(&QCompleter::activated),
+        this,
+        &RPythonTerminalTextEdit::insertCompletion);
+}
+
+QString RPythonTerminalTextEdit::completionPrefix() const
+{
+    QTextCursor const tc = textCursor();
+    QString const block_text = tc.block().text();
+    int const pos = tc.positionInBlock();
+
+    int start = pos - 1;
+    while (start >= 0)
+    {
+        QChar const ch = block_text[start];
+        if (ch.isLetterOrNumber() || ch == '_' || ch == '.')
+        {
+            --start;
+        }
+        else
+        {
+            break;
+        }
+    }
+    QString prefix = block_text.mid(start + 1, pos - start - 1);
+    while (prefix.startsWith('.'))
+    {
+        prefix = prefix.mid(1);
+    }
+    return prefix;
+}
+
+QString RPythonTerminalTextEdit::callableExpression() const
+{
+    QTextCursor const tc = textCursor();
+    QString const block_text = tc.block().text();
+    int const pos = tc.positionInBlock();
+
+    if (pos < 2 || block_text[pos - 1] != '(')
+    {
+        return QString();
+    }
+    int const end = pos - 1;
+    int start = end - 1;
+    while (start >= 0)
+    {
+        QChar const ch = block_text[start];
+        if (ch.isLetterOrNumber() || ch == '_' || ch == '.')
+        {
+            --start;
+        }
+        else
+        {
+            break;
+        }
+    }
+    QString expr = block_text.mid(start + 1, end - start - 1);
+    while (expr.startsWith('.'))
+    {
+        expr = expr.mid(1);
+    }
+    return expr;
+}
+
+void RPythonTerminalTextEdit::insertCompletion(QString const & completion)
+{
+    if (!m_completer || m_completer->widget() != this)
+    {
+        return;
+    }
+    QTextCursor tc = textCursor();
+    int const prefix_len = m_completer->completionPrefix().length();
+    tc.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor, prefix_len);
+    tc.insertText(completion);
+    setTextCursor(tc);
+}
+
+void RPythonTerminalTextEdit::highlightMatchingBracket()
+{
+    QList<QTextEdit::ExtraSelection> selections;
+    std::string const text = toPlainText().toStdString();
+    int const pos = textCursor().position();
+
+    auto addSelection = [&](int position)
+    {
+        QTextCursor cursor(document());
+        cursor.setPosition(position);
+        cursor.setPosition(position + 1, QTextCursor::KeepAnchor);
+        QTextEdit::ExtraSelection selection;
+        selection.cursor = cursor;
+        selection.format.setBackground(QColor(180, 180, 255));
+        selections.append(selection);
+    };
+
+    auto tryMatch = [&](int bracket_pos)
+    {
+        if (bracket_pos < 0 || bracket_pos >= static_cast<int>(text.size()))
+        {
+            return;
+        }
+        std::size_t const other = matchBracket(text, static_cast<std::size_t>(bracket_pos));
+        if (syntax_npos == other)
+        {
+            return;
+        }
+        addSelection(bracket_pos);
+        addSelection(static_cast<int>(other));
+    };
+
+    tryMatch(pos);
+    tryMatch(pos - 1);
+    setExtraSelections(selections);
+}
+
+bool RPythonTerminalTextEdit::isModifierKey(int key)
+{
+    return Qt::Key_Control == key || Qt::Key_Shift == key || Qt::Key_Alt == key || Qt::Key_Meta == key;
+}
+
 void RPythonTerminalTextEdit::keyPressEvent(QKeyEvent * event)
 {
     int const key = event->key();
     Qt::KeyboardModifiers const mods = event->modifiers();
+
+    bool const popup_visible = m_completer && m_completer->popup()->isVisible();
+
+    // While the completion popup is visible, let it consume the navigation
+    // keys instead of the editor.
+    if (popup_visible)
+    {
+        switch (key)
+        {
+        case Qt::Key_Escape:
+            m_completer->popup()->hide();
+            return;
+        case Qt::Key_Enter:
+        case Qt::Key_Return:
+        case Qt::Key_Tab:
+        case Qt::Key_Backtab:
+            event->ignore();
+            return;
+        default:
+            break;
+        }
+    }
+
+    // Ctrl-R drives reverse incremental search over the history; any editing
+    // key ends the session, while a bare modifier keeps it alive.
+    if (Qt::Key_R == key && (mods & Qt::ControlModifier))
+    {
+        m_searching = true;
+        searchHistory();
+        return;
+    }
+    if (m_searching && !isModifierKey(key))
+    {
+        m_searching = false;
+        searchHistoryReset();
+    }
 
     // Enter runs the input; Shift+Enter is a soft newline within it.
     if (Qt::Key_Return == key || Qt::Key_Enter == key)
@@ -137,6 +313,26 @@ void RPythonTerminalTextEdit::keyPressEvent(QKeyEvent * event)
         return;
     }
 
+    // Tab requests completion for the identifier prefix behind the caret, or
+    // inserts a literal tab when there is no prefix.
+    if (Qt::Key_Tab == key && !(mods & Qt::ShiftModifier))
+    {
+        if (!cursorInInput())
+        {
+            moveToEnd();
+        }
+        QString const prefix = completionPrefix();
+        if (!prefix.isEmpty())
+        {
+            completionRequested(prefix);
+        }
+        else
+        {
+            insertPlainText("\t");
+        }
+        return;
+    }
+
     // Backspace and Left must not chew into the read-only head.
     if ((Qt::Key_Backspace == key || Qt::Key_Left == key) && !textCursor().hasSelection() && textCursor().position() <= m_input_start)
     {
@@ -154,6 +350,16 @@ void RPythonTerminalTextEdit::keyPressEvent(QKeyEvent * event)
     }
 
     QTextEdit::keyPressEvent(event);
+
+    // A '(' just typed after a callable asks for its signature tip.
+    if (event->text() == "(")
+    {
+        QString const expr = callableExpression();
+        if (!expr.isEmpty())
+        {
+            callTipRequested(expr);
+        }
+    }
 }
 
 void RPythonTerminalTextEdit::insertFromMimeData(QMimeData const * source)
@@ -186,6 +392,49 @@ RPythonTerminalDockWidget::RPythonTerminalDockWidget(
 
     connect(m_edit, &RPythonTerminalTextEdit::execute, this, &RPythonTerminalDockWidget::executeCommand);
     connect(m_edit, &RPythonTerminalTextEdit::navigate, this, &RPythonTerminalDockWidget::navigateCommand);
+    connect(m_edit, &RPythonTerminalTextEdit::searchHistory, this, &RPythonTerminalDockWidget::searchHistoryBackward);
+    connect(m_edit, &RPythonTerminalTextEdit::searchHistoryReset, this, &RPythonTerminalDockWidget::endHistorySearch);
+
+    // Keep the latest output in view and hide a stale completion popup when
+    // the caret moves.
+    connect(
+        m_edit->document(),
+        &QTextDocument::contentsChanged,
+        this,
+        [this]()
+        {
+            QScrollBar * sb = m_edit->verticalScrollBar();
+            sb->setValue(sb->maximum());
+        });
+    connect(
+        m_edit,
+        &RPythonTerminalTextEdit::cursorPositionChanged,
+        this,
+        [this]()
+        {
+            if (m_completer && m_completer->popup()->isVisible())
+            {
+                m_completer->popup()->hide();
+            }
+        });
+    connect(
+        m_edit,
+        &RPythonTerminalTextEdit::cursorPositionChanged,
+        m_edit,
+        &RPythonTerminalTextEdit::highlightMatchingBracket);
+
+    // Paint Python in the input region only; the committed transcript above
+    // stays uncolored.
+    m_highlighter = new RPythonSyntaxHighlighter(m_edit->document());
+    m_highlighter->setInputStartProvider([this]()
+                                         { return m_edit->inputStart(); });
+
+    m_completer_model = new QStringListModel(this);
+    m_completer = new QCompleter(m_completer_model, this);
+    m_edit->setCompleter(m_completer);
+    connect(m_edit, &RPythonTerminalTextEdit::completionRequested, this, &RPythonTerminalDockWidget::handleCompletionRequest);
+    connect(m_edit, &RPythonTerminalTextEdit::callTipRequested, this, &RPythonTerminalDockWidget::handleCallTipRequest);
+    connect(m_edit, &QTextEdit::textChanged, this, &RPythonTerminalDockWidget::updateCompletionPrefix);
 
     // Share the persistent history file with the two-pane console, so recall
     // spans both consoles.
@@ -233,6 +482,7 @@ void RPythonTerminalDockWidget::executeCommand()
 
     QString const input = m_edit->inputText();
     QStringList const lines = input.split('\n');
+    endHistorySearch();
 
     // Freeze the typed line into the transcript by ending it.
     m_edit->appendCommitted("\n");
@@ -294,6 +544,10 @@ void RPythonTerminalDockWidget::executeCommand()
         m_pending_statement.clear();
         m_edit->startInput(">>> ");
     }
+
+    // The output just appended was colored while it was momentarily the tail;
+    // re-evaluate so only the fresh input region stays highlighted.
+    m_highlighter->rehighlight();
 }
 
 void RPythonTerminalDockWidget::resetInput()
@@ -301,10 +555,12 @@ void RPythonTerminalDockWidget::resetInput()
     // Abandon a partly entered block and return to a fresh primary prompt.
     pybind11::gil_scoped_acquire const gil;
     solvcon::python::Interpreter::instance().reset_console();
+    endHistorySearch();
     m_pending_statement.clear();
     m_edit->setInputText("");
     m_edit->appendCommitted("\n");
     m_edit->startInput(">>> ");
+    m_highlighter->rehighlight();
 }
 
 void RPythonTerminalDockWidget::navigateCommand(int offset)
@@ -329,6 +585,142 @@ void RPythonTerminalDockWidget::navigateCommand(int offset)
 
     m_current_command_index = new_index;
     m_edit->setInputText(QString::fromStdString(command_to_show));
+}
+
+void RPythonTerminalDockWidget::searchHistoryBackward()
+{
+    if (m_history.empty())
+    {
+        return;
+    }
+    // A fresh session takes the current input as the query and starts at the
+    // newest entry; a continuing session resumes just past the last match so
+    // repeated Ctrl-R walks toward older commands.
+    if (!m_history_search_active)
+    {
+        m_history_search_active = true;
+        m_history_search_query = m_edit->inputText().toStdString();
+        m_history_search_next = m_history.size() - 1;
+    }
+    if (RPythonConsoleHistory::npos == m_history_search_next)
+    {
+        return;
+    }
+
+    std::size_t const found = m_history.searchBackward(m_history_search_query, m_history_search_next);
+    if (RPythonConsoleHistory::npos == found)
+    {
+        return;
+    }
+
+    m_edit->setInputText(QString::fromStdString(m_history.at(found)));
+    m_history_search_next = (0 == found) ? RPythonConsoleHistory::npos : found - 1;
+}
+
+void RPythonTerminalDockWidget::endHistorySearch()
+{
+    m_history_search_active = false;
+    m_history_search_query.clear();
+    m_history_search_next = 0;
+}
+
+void RPythonTerminalDockWidget::handleCompletionRequest(QString const & prefix)
+{
+    pybind11::gil_scoped_acquire const gil;
+    auto & interp = solvcon::python::Interpreter::instance();
+    std::vector<std::string> const completions = interp.get_completions(prefix.toStdString());
+    if (completions.empty())
+    {
+        return;
+    }
+
+    // Split the prefix at the last dot so the popup shows only the attribute
+    // being completed, while the root is remembered for reinsertion.
+    int const last_dot = prefix.lastIndexOf('.');
+    m_completer_root_prefix = (last_dot >= 0) ? prefix.left(last_dot + 1) : QString();
+    QString const short_prefix = (last_dot >= 0) ? prefix.mid(last_dot + 1) : prefix;
+
+    QStringList display_completions;
+    for (auto const & c : completions)
+    {
+        QString const qc = QString::fromStdString(c);
+        if (!m_completer_root_prefix.isEmpty() && qc.startsWith(m_completer_root_prefix))
+        {
+            display_completions << qc.mid(m_completer_root_prefix.length());
+        }
+        else
+        {
+            display_completions << qc;
+        }
+    }
+
+    if (display_completions.size() == 1)
+    {
+        QTextCursor tc = m_edit->textCursor();
+        tc.movePosition(QTextCursor::Left, QTextCursor::KeepAnchor, short_prefix.length());
+        tc.insertText(display_completions.first());
+        m_edit->setTextCursor(tc);
+        return;
+    }
+
+    m_completer_model->setStringList(display_completions);
+    m_completer->setCompletionPrefix(short_prefix);
+    m_completer->popup()->setCurrentIndex(m_completer->completionModel()->index(0, 0));
+
+    QRect cr = m_edit->cursorRect();
+    cr.setWidth(
+        m_completer->popup()->sizeHintForColumn(0) + m_completer->popup()->verticalScrollBar()->sizeHint().width());
+    m_completer->complete(cr);
+}
+
+void RPythonTerminalDockWidget::handleCallTipRequest(QString const & expression)
+{
+    pybind11::gil_scoped_acquire const gil;
+    auto & interp = solvcon::python::Interpreter::instance();
+    std::string const tip = interp.get_call_tip(expression.toStdString());
+    if (tip.empty())
+    {
+        return;
+    }
+    QPoint const anchor = m_edit->mapToGlobal(m_edit->cursorRect().bottomRight());
+    QToolTip::showText(anchor, QString::fromStdString(tip), m_edit);
+}
+
+void RPythonTerminalDockWidget::updateCompletionPrefix()
+{
+    if (!m_completer || !m_completer->popup()->isVisible())
+    {
+        return;
+    }
+
+    QString const full_prefix = m_edit->completionPrefix();
+    int const last_dot = full_prefix.lastIndexOf('.');
+    QString const current_root = (last_dot >= 0) ? full_prefix.left(last_dot + 1) : QString();
+
+    if (current_root != m_completer_root_prefix)
+    {
+        m_completer->popup()->hide();
+        return;
+    }
+
+    QString const short_prefix = full_prefix.mid(m_completer_root_prefix.length());
+    // A shortened prefix (backspace) may have dropped valid matches from the
+    // cached list, so dismiss rather than show a stale set.
+    if (short_prefix.length() < m_completer->completionPrefix().length())
+    {
+        m_completer->popup()->hide();
+        return;
+    }
+
+    m_completer->setCompletionPrefix(short_prefix);
+    if (0 == m_completer->completionCount())
+    {
+        m_completer->popup()->hide();
+    }
+    else
+    {
+        m_completer->popup()->setCurrentIndex(m_completer->completionModel()->index(0, 0));
+    }
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
@@ -18,11 +18,15 @@
 #include <solvcon/python/common.hpp> // must be first.
 
 #include <solvcon/pilot/RPythonConsoleHistory.hpp>
+#include <solvcon/pilot/RPythonSyntaxHighlighter.hpp>
 
+#include <cstddef>
 #include <string>
 
 #include <Qt>
+#include <QCompleter>
 #include <QDockWidget>
+#include <QStringListModel>
 #include <QTextEdit>
 #include <QWidget>
 
@@ -67,6 +71,16 @@ public:
 
     int inputStart() const { return m_input_start; }
 
+    void setCompleter(QCompleter * completer);
+    QCompleter * completer() const { return m_completer; }
+
+    /// The identifier prefix behind the caret, for completion.
+    QString completionPrefix() const;
+
+    /// The callable identifier chain just before a '(' at the caret, for a
+    /// call tip.
+    QString callableExpression() const;
+
     void keyPressEvent(QKeyEvent * event) override;
 
 protected:
@@ -77,8 +91,22 @@ signals:
 
     void execute();
     void navigate(int offset);
+    void completionRequested(QString const & prefix);
+    void callTipRequested(QString const & expression);
+    void searchHistory();
+    void searchHistoryReset();
+
+public slots:
+
+    void highlightMatchingBracket();
+
+private slots:
+
+    void insertCompletion(QString const & completion);
 
 private:
+
+    static bool isModifierKey(int key);
 
     /// True when the whole selection, or the bare caret, sits in the
     /// editable input region.
@@ -89,6 +117,9 @@ private:
 
     int m_prompt_start = 0;
     int m_input_start = 0;
+
+    QCompleter * m_completer = nullptr;
+    bool m_searching = false;
 
 }; /* end class RPythonTerminalTextEdit */
 
@@ -134,6 +165,13 @@ public slots:
     void executeCommand();
     void navigateCommand(int offset);
     void resetInput();
+    void searchHistoryBackward();
+    void endHistorySearch();
+
+private slots:
+    void handleCompletionRequest(QString const & prefix);
+    void handleCallTipRequest(QString const & expression);
+    void updateCompletionPrefix();
 
 private:
     RPythonTerminalTextEdit * m_edit = nullptr;
@@ -145,7 +183,16 @@ private:
     // continuation prompts until the interpreter reports it complete.
     std::string m_pending_statement;
 
+    bool m_history_search_active = false;
+    std::string m_history_search_query;
+    std::size_t m_history_search_next = 0;
+
     python::PythonStreamRedirect m_python_redirect;
+
+    QCompleter * m_completer = nullptr;
+    QStringListModel * m_completer_model = nullptr;
+    QString m_completer_root_prefix;
+    RPythonSyntaxHighlighter * m_highlighter = nullptr;
 }; /* end class RPythonTerminalDockWidget */
 
 } /* end namespace solvcon */

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -164,6 +164,52 @@ class TerminalWidgetTC(unittest.TestCase):
         # The in-progress input survives the external write.
         self.assertEqual(self.term.command, "keep")
 
+    def test_tab_completes_a_single_match(self):
+        # A uniquely named handle leaves exactly one completion, which is
+        # inserted directly without a popup.
+        self.term.command = "terminal_unique_handle = 1"
+        self.term.executeCommand()
+        self._type("terminal_unique_han")
+        self._key(QtCore.Qt.Key_Tab)
+        self.assertEqual(self.term.command, "terminal_unique_handle")
+
+    def test_ctrl_r_recalls_a_matching_command(self):
+        self.term.command = "apricot_value = 1"
+        self.term.executeCommand()
+        self.term.command = "cherry_value = 2"
+        self.term.executeCommand()
+        self._type("apri")
+        _send_key(self.edit, QtCore.Qt.Key_R, "r",
+                  QtCore.Qt.ControlModifier)
+        self.assertEqual(self.term.command, "apricot_value = 1")
+
+    def test_call_tip_on_open_paren_does_not_disturb_input(self):
+        # Typing a call opening keeps the input intact; the tip is advisory.
+        self._type("range(")
+        self.assertEqual(self.term.command, "range(")
+
+    def test_input_is_highlighted(self):
+        self._type("while")
+        # The keyword blue defined by the highlighter paints the input block.
+        pos = self.edit.toPlainText().rfind("while")
+        self.assertIn((0, 0, 180), self._layout_colors(pos))
+
+    def test_committed_transcript_is_not_highlighted(self):
+        self.term.command = "pass"
+        self.term.executeCommand()
+        # The committed keyword carries no highlight after it scrolls up.
+        pos = self.edit.toPlainText().find("pass")
+        self.assertNotIn((0, 0, 180), self._layout_colors(pos))
+
+    def _layout_colors(self, index):
+        """Foreground colors the highlighter laid on the block at ``index``."""
+        block = self.edit.document().findBlock(index)
+        colors = []
+        for rng in block.layout().formats():
+            color = rng.format.foreground().color()
+            colors.append((color.red(), color.green(), color.blue()))
+        return colors
+
     def term_input_start(self):
         """Position just after the current prompt, read off the document."""
         text = self.edit.toPlainText()


### PR DESCRIPTION
Third step of the terminal console: the editing comforts, wired onto the
bounded input region and reusing the same backends as the two-pane console.

## What this adds

- **Tab completion** over the live namespace through `get_completions`: a
  single match inserts directly, several show a popup.
- **Call tips** on `(` after a callable through `get_call_tip`.
- **Ctrl-R reverse search** over the shared history, walking toward older
  matches on repeated presses.
- **Bracket matching** in the input region.
- **Scoped syntax highlighting**: the highlighter takes an input-start
  provider and skips any block ending at or before the anchor, so only the
  input region is painted and the committed transcript stays uncolored.
  `executeCommand` and `resetInput` rehighlight after the anchor moves. The
  two-pane console leaves the provider unset and still paints every block.
- The completion and call-tip handlers take the GIL, since they run from the
  Qt event dispatch (the same reason `executeCommand` does).

## Scope note

This step runs over the ~300-line target because it ports the completion,
call-tip, and reverse-search machinery onto the new surface. It deliberately
mirrors the two-pane console's proven logic rather than sharing a base class;
unifying the two consoles is a worthwhile follow-up but a larger, riskier
change than this feature step should carry.

## Verification

- Build clean with `-Werror`.
- `make pytest BUILD_QT=ON` and `run_pilot_pytest`: full suite green,
  including new tests for single-match completion, reverse search, the
  call-tip trigger, and input-only highlighting.
- `cformat`, `cinclude`, `flake8`, `checkascii`, `checktws`: clean.
- `pilot_clang_tidy_diff` (warnings-as-errors): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)