### PR TITLE
Style terminal output and show a busy state

### DIFF
--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 
 #include <QAbstractItemView>
+#include <QApplication>
 #include <QColor>
 #include <QFont>
 #include <QKeyEvent>
@@ -81,6 +82,18 @@ void RPythonTerminalTextEdit::appendCommitted(QString const & text)
     QTextCursor cursor(document());
     cursor.movePosition(QTextCursor::End);
     cursor.insertText(text);
+}
+
+void RPythonTerminalTextEdit::appendOutput(QString const & text, bool is_error)
+{
+    QTextCursor cursor(document());
+    cursor.movePosition(QTextCursor::End);
+
+    QTextCharFormat format;
+    // stderr in red, stdout in a near-black that stays distinct from the
+    // syntax-colored input echo above it.
+    format.setForeground(is_error ? QColor(170, 0, 0) : QColor(30, 30, 30));
+    cursor.insertText(text, format);
 }
 
 bool RPythonTerminalTextEdit::cursorInInput() const
@@ -494,6 +507,11 @@ void RPythonTerminalDockWidget::executeCommand()
     bool more = false;
     std::string last_line;
     auto & interp = solvcon::python::Interpreter::instance();
+
+    // The command runs on the GUI thread, so a slow one freezes the window.
+    // Show a busy cursor for the duration; run_worker in the console offloads
+    // heavy work to a worker thread when responsiveness matters.
+    QApplication::setOverrideCursor(Qt::WaitCursor);
     m_python_redirect.activate();
     for (QString const & line : lines)
     {
@@ -510,14 +528,15 @@ void RPythonTerminalDockWidget::executeCommand()
         std::string const err = m_python_redirect.stderr_string();
         if (!out.empty())
         {
-            m_edit->appendCommitted(QString::fromStdString(out));
+            m_edit->appendOutput(QString::fromStdString(out), /*is_error=*/false);
         }
         if (!err.empty())
         {
-            m_edit->appendCommitted(QString::fromStdString(err));
+            m_edit->appendOutput(QString::fromStdString(err), /*is_error=*/true);
         }
     }
     m_python_redirect.deactivate();
+    QApplication::restoreOverrideCursor();
 
     if (!m_pending_statement.empty())
     {

--- a/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonTerminalDockWidget.hpp
@@ -69,6 +69,10 @@ public:
     /// Append @p text at the end of the committed transcript.
     void appendCommitted(QString const & text);
 
+    /// Append captured output at the end of the transcript, colored to tell
+    /// stderr from stdout.
+    void appendOutput(QString const & text, bool is_error);
+
     int inputStart() const { return m_input_start; }
 
     void setCompleter(QCompleter * completer);

--- a/tests/test_pilot_terminal.py
+++ b/tests/test_pilot_terminal.py
@@ -201,6 +201,29 @@ class TerminalWidgetTC(unittest.TestCase):
         pos = self.edit.toPlainText().find("pass")
         self.assertNotIn((0, 0, 180), self._layout_colors(pos))
 
+    def test_stderr_output_is_red(self):
+        self.term.command = "1 / 0"
+        self.term.executeCommand()
+        text = self.edit.toPlainText()
+        color = self._doc_color_at(text.find("ZeroDivisionError"))
+        self.assertEqual((color.red(), color.green(), color.blue()),
+                         (170, 0, 0))
+
+    def test_stdout_output_has_its_own_format(self):
+        self.term.command = "print('marker_out')"
+        self.term.executeCommand()
+        text = self.edit.toPlainText()
+        # rfind lands on the captured output, not the input echo above it.
+        color = self._doc_color_at(text.rfind("marker_out"))
+        self.assertEqual((color.red(), color.green(), color.blue()),
+                         (30, 30, 30))
+
+    def _doc_color_at(self, index):
+        """The stored foreground of the character at ``index``."""
+        cursor = QtGui.QTextCursor(self.edit.document())
+        cursor.setPosition(index + 1)
+        return cursor.charFormat().foreground().color()
+
     def _layout_colors(self, index):
         """Foreground colors the highlighter laid on the block at ``index``."""
         block = self.edit.document().findBlock(index)


### PR DESCRIPTION
Fourth and final step of the terminal console: output styling and honest
long-command behavior.

## What this adds

- **Distinct output formats** in the one document: stderr in red and stdout in
  a near-black that stands off from the syntax-colored input echo above it.
  `appendOutput` stores the format on the transcript as it appends, rather than
  laying it on as a transient highlight.
- **Busy state**: execution is wrapped in a wait cursor, since the command runs
  on the GUI thread and a slow one blocks the window. `run_worker`, already
  seeded in the shared namespace, offloads heavy work to a worker thread when
  responsiveness matters, so it works in the terminal as in the two-pane
  console.

## Verification

- Build clean with `-Werror`.
- `make pytest BUILD_QT=ON` and `run_pilot_pytest`: full suite green,
  including new tests for the stderr and stdout formats.
- `cformat`, `cinclude`, `flake8`, `checkascii`, `checktws`: clean.
- `pilot_clang_tidy_diff` (warnings-as-errors): clean.

With this step the terminal-style console is feature-complete against the plan:
a single guarded surface, prompt-driven multiline, the editing comforts, and
styled output with a busy state, all alongside the unchanged two-pane console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)