### PR TITLE
Add a light and dark theme to the pilot

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -24,6 +24,8 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
@@ -57,6 +59,8 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -311,6 +311,13 @@ void RManager::setUpConsole()
     m_pycon = new RPythonConsoleDockWidget(QString("Console"), m_mainWindow);
     m_pycon->setAllowedAreas(Qt::AllDockWidgetAreas);
     m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, m_pycon);
+
+    // The console's syntax colors and bracket marker are not QPalette roles, so
+    // drive them from the theme directly. The theme was applied before this
+    // widget existed, so seed it now, then follow later switches.
+    m_pycon->applyTheme(m_themeManager->currentVariant());
+    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_pycon, [this](ThemeVariant variant)
+                     { m_pycon->applyTheme(variant); });
 }
 
 void RManager::setUpCentral()
@@ -325,13 +332,18 @@ void RManager::setUpCentral()
                      { applyDrawTool(); });
 
     // The MDI area paints its own backdrop instead of reading the palette, so
-    // drive it from the window color and follow theme changes; otherwise a
-    // stale mid-grey slab shows through under the dark theme.
-    auto matchBackdrop = [this]()
-    { m_mdiArea->setBackground(m_mainWindow->palette().color(QPalette::Window)); };
-    matchBackdrop();
-    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, [matchBackdrop](ThemeVariant)
-                     { matchBackdrop(); });
+    // drive it from the theme's window color and follow theme changes;
+    // otherwise a stale mid-grey slab shows through under the dark theme. Take
+    // the color from the theme model, not m_mainWindow->palette(): when
+    // themeChanged fires the freshly set application palette has not yet
+    // propagated to the window, so palette() would lag one switch behind.
+    auto paintBackdrop = [this](ThemeVariant variant)
+    {
+        ThemeColor const c = themePaletteFor(variant).window;
+        m_mdiArea->setBackground(QColor(c.r, c.g, c.b));
+    };
+    paintBackdrop(m_themeManager->currentVariant());
+    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, paintBackdrop);
 }
 
 void RManager::primeRhiComposition()

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -12,12 +12,15 @@
 #include <solvcon/pilot/DrawTool.hpp>
 #include <solvcon/pilot/RAction.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RThemeManager.hpp>
 #include <Qt>
 #include <QMenuBar>
 #include <QMenu>
 #include <QAction>
 #include <QActionGroup>
 #include <QKeySequence>
+#include <QColor>
+#include <QPalette>
 #include <QVBoxLayout>
 #include <QWidget>
 
@@ -44,6 +47,10 @@ RManager::RManager()
 
     m_mainWindow = new QMainWindow;
     m_mainWindow->setWindowIcon(QIcon(QString(":/icon.ico")));
+    // The theme controller is parented to the manager, not the window, so its
+    // OS color-scheme connection survives a window rebuild. The palette is
+    // applied in setUp(), before any widget is created.
+    m_themeManager = new RThemeManager(this);
     // Do not call setUp() from the constructor.  Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
 }
@@ -52,6 +59,9 @@ RManager & RManager::setUp()
 {
     if (!m_already_setup)
     {
+        // Paint the base style and palette before any widget exists, so every
+        // widget below is created already themed.
+        this->m_themeManager->apply();
         this->setUpConsole();
         this->setUpCentral();
         this->primeRhiComposition();
@@ -77,6 +87,7 @@ void RManager::reset()
     m_core.reset();
     m_mainWindow = nullptr;
     m_menuModel = nullptr;
+    m_themeManager = nullptr;
     m_pycon = nullptr;
     m_mdiArea = nullptr;
     m_rhi_primer = nullptr;
@@ -312,6 +323,15 @@ void RManager::setUpCentral()
     // single Painter toolbox always drives whichever canvas has focus.
     QObject::connect(m_mdiArea, &QMdiArea::subWindowActivated, m_mdiArea, [this](QMdiSubWindow *)
                      { applyDrawTool(); });
+
+    // The MDI area paints its own backdrop instead of reading the palette, so
+    // drive it from the window color and follow theme changes; otherwise a
+    // stale mid-grey slab shows through under the dark theme.
+    auto matchBackdrop = [this]()
+    { m_mdiArea->setBackground(m_mainWindow->palette().color(QPalette::Window)); };
+    matchBackdrop();
+    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, [matchBackdrop](ThemeVariant)
+                     { matchBackdrop(); });
 }
 
 void RManager::primeRhiComposition()
@@ -352,6 +372,7 @@ void RManager::setUpMenu()
     m_menuModel->menu("Window", 70);
 
     setUpEditMenuItems();
+    setUpThemeMenuItems();
     // Code for controlling camera is not exposed to Python yet.
     setUpCameraControllersMenuItems();
     setUpCameraMovementMenuItems();
@@ -380,6 +401,59 @@ void RManager::setUpEditMenuItems() const
 
     m_menuModel->place("Edit", undo_action, 10);
     m_menuModel->place("Edit", redo_action, 20);
+}
+
+void RManager::setUpThemeMenuItems() const
+{
+    struct ThemeItem
+    {
+        ThemeMode mode;
+        QString tip;
+    };
+    std::vector<ThemeItem> const items = {
+        {ThemeMode::System, QString("Follow the operating system light or dark setting")},
+        {ThemeMode::Light, QString("Use the light palette")},
+        {ThemeMode::Dark, QString("Use the dark palette")},
+    };
+
+    // The group owns the exclusive mode, held by the model under a group id so
+    // Python can query the checked action, mirroring the camera controllers.
+    auto * themeGroup = m_menuModel->group("theme.mode");
+    int weight = 10;
+    for (auto const & item : items)
+    {
+        ThemeMode const mode = item.mode;
+        auto * action = new RAction(
+            QString(themeModeLabel(mode)), item.tip, [this, mode]()
+            { m_themeManager->setMode(mode); },
+            m_menuModel);
+        action->setObjectName(QString("theme.mode_") + themeModeId(mode));
+        action->setCheckable(true);
+        themeGroup->addAction(action);
+        m_menuModel->place("View/Theme", action, weight);
+        weight += 10;
+    }
+
+    // Keep the radio check in step with the manager whichever way the theme
+    // moves: a menu click, a console set_theme(), or an operating-system change
+    // while following the system. Parent the connection to the model so it dies
+    // with the menu.
+    QObject::connect(
+        m_themeManager,
+        &RThemeManager::themeChanged,
+        m_menuModel,
+        [this](ThemeVariant)
+        {
+            if (QAction * current = m_menuModel->action("theme.mode_" + m_themeManager->modeId()))
+            {
+                current->setChecked(true);
+            }
+        });
+
+    if (QAction * follow = m_menuModel->action("theme.mode_system"))
+    {
+        follow->setChecked(true);
+    }
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -32,6 +32,7 @@ namespace solvcon
 {
 
 class RMenuModel;
+class RThemeManager;
 
 /**
  * @brief Singleton that owns the pilot main window and coordinates its
@@ -84,6 +85,9 @@ public:
     /// The live model of the menu bar, addressable by path from Python.
     RMenuModel * menuModel() { return m_menuModel; }
 
+    /// The application-wide theme controller, scriptable from Python.
+    RThemeManager * themeManager() { return m_themeManager; }
+
     void quit() { m_core->quit(); }
 
     /// Only call reset() when the program is to be stopped.
@@ -108,6 +112,7 @@ private:
     void applyDrawTool();
 
     void setUpEditMenuItems() const;
+    void setUpThemeMenuItems() const;
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementMenuItems() const;
 
@@ -128,6 +133,10 @@ private:
 
     /// Live menu model owned by the widget tree (parented to the main window).
     RMenuModel * m_menuModel = nullptr;
+
+    /// Application-wide theme controller, parented to the manager so it and its
+    /// OS color-scheme connection outlive each rebuild of the main window.
+    RThemeManager * m_themeManager = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -147,7 +147,7 @@ void RPythonCommandTextEdit::highlightMatchingBracket()
         cursor.setPosition(position + 1, QTextCursor::KeepAnchor);
         QTextEdit::ExtraSelection selection;
         selection.cursor = cursor;
-        selection.format.setBackground(QColor(180, 180, 255));
+        selection.format.setBackground(m_bracket_match_color);
         selections.append(selection);
     };
 
@@ -171,6 +171,12 @@ void RPythonCommandTextEdit::highlightMatchingBracket()
     tryMatch(pos);
     tryMatch(pos - 1);
     setExtraSelections(selections);
+}
+
+void RPythonCommandTextEdit::setBracketMatchColor(QColor const & color)
+{
+    m_bracket_match_color = color;
+    highlightMatchingBracket();
 }
 
 // Tab-triggered auto-completion workflow:
@@ -372,6 +378,14 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     connect(m_command_edit, &RPythonCommandTextEdit::completionRequested, this, &RPythonConsoleDockWidget::handleCompletionRequest);
     connect(m_command_edit, &RPythonCommandTextEdit::callTipRequested, this, &RPythonConsoleDockWidget::handleCallTipRequest);
     connect(m_command_edit, &QTextEdit::textChanged, this, &RPythonConsoleDockWidget::updateCompletionPrefix);
+}
+
+void RPythonConsoleDockWidget::applyTheme(ThemeVariant variant)
+{
+    SyntaxColors const & colors = syntaxColorsFor(variant);
+    m_highlighter->applyColors(colors);
+    m_command_edit->setBracketMatchColor(
+        QColor(colors.bracket_match.r, colors.bracket_match.g, colors.bracket_match.b));
 }
 
 QString RPythonConsoleDockWidget::command() const

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -297,16 +297,12 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     container->setLayout(layout);
     setWidget(container);
 
-    QPalette palette = QPalette();
-    palette.setColor(QPalette::Base, Qt::white);
-    palette.setColor(QPalette::Text, Qt::black);
-    palette.setColor(QPalette::PlaceholderText, Qt::darkGray);
-
+    // Leave the text colors to the application palette so the console follows
+    // the active light or dark theme instead of forcing black-on-white.
     m_history_edit->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_history_edit->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_history_edit->setFont(QFont("Courier New"));
     m_history_edit->setReadOnly(true);
-    m_history_edit->setPalette(palette);
     layout->addWidget(m_history_edit, /*stretch=*/1);
 
     constexpr int commandEditMinHeight = 40;
@@ -314,7 +310,6 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     m_command_edit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_command_edit->setFont(QFont("Courier New"));
     m_command_edit->setFixedHeight(commandEditMinHeight);
-    m_command_edit->setPalette(palette);
     m_command_edit->setPlaceholderText("Shift+Enter to create new line. Enter to execute.");
     layout->addWidget(m_command_edit, /*stretch=*/0);
 

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 
 #include <Qt>
+#include <QColor>
 #include <QCompleter>
 #include <QDockWidget>
 #include <QStringListModel>
@@ -55,6 +56,10 @@ public:
     QString completionPrefix() const;
     QString callableExpression() const;
 
+    /// Set the wash painted behind a matched bracket pair and repaint it, so
+    /// the marker follows a light or dark theme switch.
+    void setBracketMatchColor(QColor const & color);
+
     void keyPressEvent(QKeyEvent * event) override;
 
 signals:
@@ -80,6 +85,10 @@ private:
 
     QCompleter * m_completer = nullptr;
     bool m_searching = false;
+
+    /// Background wash behind a matched bracket pair; the light table's value
+    /// until a theme is applied.
+    QColor m_bracket_match_color = QColor(180, 180, 255);
 
 }; /* end class RPythonCommandTextEdit */
 
@@ -135,6 +144,11 @@ public:
     }
 
     void writeToHistory(std::string const & data) const;
+
+    /// Point the syntax highlighter and the bracket marker at the theme
+    /// variant's syntax colors. The text itself follows the application
+    /// palette; these are the extra colors the palette does not cover.
+    void applyTheme(ThemeVariant variant);
 
 public slots:
     void executeCommand();

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
@@ -15,13 +15,24 @@ namespace solvcon
 RPythonSyntaxHighlighter::RPythonSyntaxHighlighter(QTextDocument * parent)
     : QSyntaxHighlighter(parent)
 {
-    m_keyword_format.setForeground(QColor(0, 0, 180));
+    // The weight and slant are constant across themes; only the colors follow
+    // the light or dark table, so set them here and defer color to applyColors.
     m_keyword_format.setFontWeight(QFont::Bold);
-    m_builtin_format.setForeground(QColor(0, 110, 110));
-    m_string_format.setForeground(QColor(160, 0, 0));
-    m_comment_format.setForeground(QColor(128, 128, 128));
     m_comment_format.setFontItalic(true);
-    m_number_format.setForeground(QColor(140, 0, 140));
+    applyColors(lightSyntaxColors());
+}
+
+void RPythonSyntaxHighlighter::applyColors(SyntaxColors const & colors)
+{
+    auto qc = [](ThemeColor c)
+    { return QColor(c.r, c.g, c.b); };
+
+    m_keyword_format.setForeground(qc(colors.keyword));
+    m_builtin_format.setForeground(qc(colors.builtin));
+    m_string_format.setForeground(qc(colors.string));
+    m_comment_format.setForeground(qc(colors.comment));
+    m_number_format.setForeground(qc(colors.number));
+    rehighlight();
 }
 
 void RPythonSyntaxHighlighter::highlightBlock(QString const & text)

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
@@ -13,6 +13,8 @@
  * @ingroup group_domain
  */
 
+#include <solvcon/pilot/RTheme.hpp>
+
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
 
@@ -34,6 +36,10 @@ class RPythonSyntaxHighlighter
 public:
 
     explicit RPythonSyntaxHighlighter(QTextDocument * parent);
+
+    /// Recolor every token category from a theme's syntax table and repaint,
+    /// so the console highlighting follows a light or dark switch.
+    void applyColors(SyntaxColors const & colors);
 
 protected:
 

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <cstring>
+
+namespace solvcon
+{
+
+// The palettes below are neutral, low-saturation greys lifted a step off pure
+// black and pure white so large fills do not glare, paired with one calm blue
+// accent shared by both variants. The values track the conventions of
+// well-regarded cross-platform themes (KDE Breeze, Fusion dark) rather than any
+// single platform, which is what keeps the pilot looking of a piece on Linux
+// and macOS.
+
+static ThemePalette makeLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xf2, 0xf2, 0xf3};
+    p.window_text = {0x1c, 0x1e, 0x21};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf6, 0xf6, 0xf7};
+    p.text = {0x1c, 0x1e, 0x21};
+    p.button = {0xea, 0xea, 0xec};
+    p.button_text = {0x1c, 0x1e, 0x21};
+    p.bright_text = {0xd3, 0x2f, 0x2f};
+    p.highlight = {0x35, 0x74, 0xf0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xfa, 0xfa, 0xfb};
+    p.tool_tip_text = {0x1c, 0x1e, 0x21};
+    p.placeholder_text = {0x9a, 0xa0, 0xa6};
+    p.link = {0x1a, 0x5f, 0xb4};
+    p.link_visited = {0x7e, 0x4f, 0xb0};
+    p.disabled_text = {0xa6, 0xa8, 0xac};
+    p.disabled_button_text = {0xa6, 0xa8, 0xac};
+    p.disabled_window_text = {0xa6, 0xa8, 0xac};
+    p.disabled_highlight = {0xc8, 0xcb, 0xcf};
+    return p;
+}
+
+static ThemePalette makeDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x2d, 0x2f, 0x33};
+    p.window_text = {0xe6, 0xe6, 0xe7};
+    p.base = {0x23, 0x24, 0x27};
+    p.alternate_base = {0x2b, 0x2d, 0x31};
+    p.text = {0xe6, 0xe6, 0xe7};
+    p.button = {0x35, 0x37, 0x3b};
+    p.button_text = {0xe6, 0xe6, 0xe7};
+    p.bright_text = {0xff, 0x6b, 0x68};
+    p.highlight = {0x3d, 0x82, 0xe0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0x35, 0x37, 0x3b};
+    p.tool_tip_text = {0xe6, 0xe6, 0xe7};
+    p.placeholder_text = {0x80, 0x84, 0x89};
+    p.link = {0x3d, 0xae, 0xe9};
+    p.link_visited = {0xb1, 0x86, 0xd8};
+    p.disabled_text = {0x6b, 0x6e, 0x73};
+    p.disabled_button_text = {0x6b, 0x6e, 0x73};
+    p.disabled_window_text = {0x6b, 0x6e, 0x73};
+    p.disabled_highlight = {0x3a, 0x3d, 0x42};
+    return p;
+}
+
+ThemePalette const & lightThemePalette()
+{
+    static ThemePalette const palette = makeLightPalette();
+    return palette;
+}
+
+ThemePalette const & darkThemePalette()
+{
+    static ThemePalette const palette = makeDarkPalette();
+    return palette;
+}
+
+ThemePalette const & themePaletteFor(ThemeVariant variant)
+{
+    return variant == ThemeVariant::Dark ? darkThemePalette() : lightThemePalette();
+}
+
+ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return ThemeVariant::Light;
+    case ThemeMode::Dark:
+        return ThemeVariant::Dark;
+    case ThemeMode::System:
+    default:
+        return os_prefers_dark ? ThemeVariant::Dark : ThemeVariant::Light;
+    }
+}
+
+char const * themeModeId(ThemeMode mode)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return "light";
+    case ThemeMode::Dark:
+        return "dark";
+    case ThemeMode::System:
+    default:
+        return "system";
+    }
+}
+
+char const * themeModeLabel(ThemeMode mode)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return "Light";
+    case ThemeMode::Dark:
+        return "Dark";
+    case ThemeMode::System:
+    default:
+        return "Follow system";
+    }
+}
+
+ThemeMode themeModeFromId(char const * id)
+{
+    if (id != nullptr)
+    {
+        if (0 == std::strcmp(id, "light"))
+        {
+            return ThemeMode::Light;
+        }
+        if (0 == std::strcmp(id, "dark"))
+        {
+            return ThemeMode::Dark;
+        }
+    }
+    return ThemeMode::System;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -67,6 +67,35 @@ static ThemePalette makeDarkPalette()
     return p;
 }
 
+// The syntax colors keep the light table's familiar hues (a blue keyword, a
+// teal builtin, a red string, a magenta number) and lift each to a brighter,
+// lower-saturation tint for the dark table so the tokens read clearly on the
+// dark base instead of sinking into it.
+
+static SyntaxColors makeLightSyntaxColors()
+{
+    SyntaxColors c;
+    c.keyword = {0x00, 0x00, 0xb4};
+    c.builtin = {0x00, 0x6e, 0x6e};
+    c.string = {0xa0, 0x00, 0x00};
+    c.comment = {0x80, 0x80, 0x80};
+    c.number = {0x8c, 0x00, 0x8c};
+    c.bracket_match = {0xb4, 0xb4, 0xff};
+    return c;
+}
+
+static SyntaxColors makeDarkSyntaxColors()
+{
+    SyntaxColors c;
+    c.keyword = {0x6a, 0xb7, 0xff};
+    c.builtin = {0x4e, 0xc9, 0xb0};
+    c.string = {0xe5, 0x92, 0x8b};
+    c.comment = {0x80, 0x84, 0x89};
+    c.number = {0xd6, 0xa4, 0xe0};
+    c.bracket_match = {0x3d, 0x50, 0x6b};
+    return c;
+}
+
 ThemePalette const & lightThemePalette()
 {
     static ThemePalette const palette = makeLightPalette();
@@ -82,6 +111,23 @@ ThemePalette const & darkThemePalette()
 ThemePalette const & themePaletteFor(ThemeVariant variant)
 {
     return variant == ThemeVariant::Dark ? darkThemePalette() : lightThemePalette();
+}
+
+SyntaxColors const & lightSyntaxColors()
+{
+    static SyntaxColors const colors = makeLightSyntaxColors();
+    return colors;
+}
+
+SyntaxColors const & darkSyntaxColors()
+{
+    static SyntaxColors const colors = makeDarkSyntaxColors();
+    return colors;
+}
+
+SyntaxColors const & syntaxColorsFor(ThemeVariant variant)
+{
+    return variant == ThemeVariant::Dark ? darkSyntaxColors() : lightSyntaxColors();
 }
 
 ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark)

--- a/cpp/solvcon/pilot/RTheme.hpp
+++ b/cpp/solvcon/pilot/RTheme.hpp
@@ -1,0 +1,127 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt-free theme model: the curated light and dark color tables and the rule
+ * that resolves a requested mode against the operating system color scheme.
+ *
+ * Keeping the tables and the resolution rule free of Qt lets them be unit
+ * tested without a GUI; the Qt adapter (RThemeManager) turns a table into a
+ * QPalette by a straight field-by-field copy.
+ *
+ * @ingroup group_domain
+ */
+
+#include <cstdint>
+
+namespace solvcon
+{
+
+/**
+ * @brief The source a theme draws its variant from.
+ *
+ * System follows the operating system color scheme and tracks changes to it;
+ * Light and Dark pin the palette regardless of the operating system.
+ */
+enum class ThemeMode
+{
+    System,
+    Light,
+    Dark,
+};
+
+/// The two concrete palettes a mode resolves to.
+enum class ThemeVariant
+{
+    Light,
+    Dark,
+};
+
+/**
+ * @brief One sRGB color, a byte per channel.
+ *
+ * Deliberately free of Qt so the color tables can live in a translation unit
+ * that compiles and tests without QtGui.
+ */
+struct ThemeColor
+{
+    std::uint8_t r = 0;
+    std::uint8_t g = 0;
+    std::uint8_t b = 0;
+
+    constexpr ThemeColor() = default;
+
+    constexpr ThemeColor(std::uint8_t red, std::uint8_t green, std::uint8_t blue)
+        : r(red)
+        , g(green)
+        , b(blue)
+    {
+    }
+};
+
+/**
+ * @brief The colors a palette assigns to the widget roles the pilot uses.
+ *
+ * Each field is named after the QPalette::ColorRole it maps to, so the Qt
+ * adapter copies the struct into a QPalette one field at a time. The trailing
+ * disabled_* fields feed the QPalette::Disabled color group, which keeps
+ * greyed-out text legible in both variants.
+ */
+struct ThemePalette
+{
+    ThemeColor window;
+    ThemeColor window_text;
+    ThemeColor base;
+    ThemeColor alternate_base;
+    ThemeColor text;
+    ThemeColor button;
+    ThemeColor button_text;
+    ThemeColor bright_text;
+    ThemeColor highlight;
+    ThemeColor highlighted_text;
+    ThemeColor tool_tip_base;
+    ThemeColor tool_tip_text;
+    ThemeColor placeholder_text;
+    ThemeColor link;
+    ThemeColor link_visited;
+    ThemeColor disabled_text;
+    ThemeColor disabled_button_text;
+    ThemeColor disabled_window_text;
+    ThemeColor disabled_highlight;
+};
+
+/// The curated light palette.
+ThemePalette const & lightThemePalette();
+
+/// The curated dark palette.
+ThemePalette const & darkThemePalette();
+
+/// The palette backing a resolved variant.
+ThemePalette const & themePaletteFor(ThemeVariant variant);
+
+/**
+ * @brief Resolve a requested mode to a concrete variant.
+ *
+ * In System mode the choice follows @p os_prefers_dark; Light and Dark ignore
+ * it and return their own variant.
+ */
+ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark);
+
+/// The stable identifier for a mode, used as the menu action object name, at
+/// the Python boundary, and in tests ("system", "light", "dark").
+char const * themeModeId(ThemeMode mode);
+
+/// The human-readable menu label for a mode.
+char const * themeModeLabel(ThemeMode mode);
+
+/// The mode named by @p id, or ThemeMode::System when @p id matches none.
+ThemeMode themeModeFromId(char const * id);
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RTheme.hpp
+++ b/cpp/solvcon/pilot/RTheme.hpp
@@ -95,6 +95,26 @@ struct ThemePalette
     ThemeColor disabled_highlight;
 };
 
+/**
+ * @brief The colors the console's Python highlighter and its matching-bracket
+ * marker draw with.
+ *
+ * These are not QPalette roles, so they live apart from ThemePalette; the
+ * console reads them directly. Like the palette they come in a light and a
+ * dark table so the highlighted code stays legible under either variant, which
+ * the hardcoded single set could not do once the console followed the theme.
+ * bracket_match is a background wash behind a matched pair of brackets.
+ */
+struct SyntaxColors
+{
+    ThemeColor keyword;
+    ThemeColor builtin;
+    ThemeColor string;
+    ThemeColor comment;
+    ThemeColor number;
+    ThemeColor bracket_match;
+};
+
 /// The curated light palette.
 ThemePalette const & lightThemePalette();
 
@@ -103,6 +123,15 @@ ThemePalette const & darkThemePalette();
 
 /// The palette backing a resolved variant.
 ThemePalette const & themePaletteFor(ThemeVariant variant);
+
+/// The console syntax colors tuned for a light background.
+SyntaxColors const & lightSyntaxColors();
+
+/// The console syntax colors tuned for a dark background.
+SyntaxColors const & darkSyntaxColors();
+
+/// The syntax colors backing a resolved variant.
+SyntaxColors const & syntaxColorsFor(ThemeVariant variant);
 
 /**
  * @brief Resolve a requested mode to a concrete variant.

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RThemeManager.hpp> // Must be the first include.
+
+#include <QApplication>
+#include <QColor>
+#include <QGuiApplication>
+#include <QStyleFactory>
+#include <QStyleHints>
+#include <QTimer>
+#include <Qt>
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+RThemeManager::RThemeManager(QObject * parent)
+    : QObject(parent)
+{
+    // Track live operating-system color-scheme changes while in System mode.
+    // The style-hints object is owned by the application and outlives the
+    // manager, so the connection stays valid for the manager's lifetime.
+    if (QStyleHints * hints = QGuiApplication::styleHints())
+    {
+        connect(
+            hints,
+            &QStyleHints::colorSchemeChanged,
+            this,
+            [this](Qt::ColorScheme)
+            {
+                // When this signal fires the old palette is still in effect, so
+                // defer the re-apply to the next event-loop turn rather than
+                // repainting against a palette about to change.
+                if (m_mode == ThemeMode::System)
+                {
+                    QTimer::singleShot(0, this, [this]()
+                                       { apply(); });
+                }
+            });
+    }
+}
+
+void RThemeManager::apply()
+{
+    // Fusion draws from the same code on every platform, so the curated
+    // palette lands identically on Linux and macOS. Install it once; later
+    // calls only repaint the palette.
+    if (!m_style_installed)
+    {
+        QApplication::setStyle(QStyleFactory::create(QStringLiteral("Fusion")));
+        m_style_installed = true;
+    }
+
+    ThemeVariant const variant = currentVariant();
+    QApplication::setPalette(buildPalette(themePaletteFor(variant)));
+    emit themeChanged(variant);
+}
+
+void RThemeManager::setMode(ThemeMode mode)
+{
+    m_mode = mode;
+    syncOsColorScheme();
+    apply();
+}
+
+void RThemeManager::setModeById(std::string const & id)
+{
+    setMode(themeModeFromId(id.c_str()));
+}
+
+ThemeVariant RThemeManager::currentVariant() const
+{
+    return resolveThemeVariant(m_mode, osPrefersDark());
+}
+
+std::string RThemeManager::modeId() const
+{
+    return themeModeId(m_mode);
+}
+
+std::string RThemeManager::variantId() const
+{
+    return currentVariant() == ThemeVariant::Dark ? "dark" : "light";
+}
+
+bool RThemeManager::osPrefersDark() const
+{
+    QStyleHints * hints = QGuiApplication::styleHints();
+    return hints != nullptr && hints->colorScheme() == Qt::ColorScheme::Dark;
+}
+
+void RThemeManager::syncOsColorScheme()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    QStyleHints * hints = QGuiApplication::styleHints();
+    if (hints == nullptr)
+    {
+        return;
+    }
+    switch (m_mode)
+    {
+    case ThemeMode::Light:
+        hints->setColorScheme(Qt::ColorScheme::Light);
+        break;
+    case ThemeMode::Dark:
+        hints->setColorScheme(Qt::ColorScheme::Dark);
+        break;
+    case ThemeMode::System:
+    default:
+        hints->unsetColorScheme();
+        break;
+    }
+#endif
+}
+
+QPalette RThemeManager::buildPalette(ThemePalette const & spec) const
+{
+    auto color = [](ThemeColor c)
+    { return QColor(c.r, c.g, c.b); };
+
+    QPalette pal;
+    pal.setColor(QPalette::Window, color(spec.window));
+    pal.setColor(QPalette::WindowText, color(spec.window_text));
+    pal.setColor(QPalette::Base, color(spec.base));
+    pal.setColor(QPalette::AlternateBase, color(spec.alternate_base));
+    pal.setColor(QPalette::Text, color(spec.text));
+    pal.setColor(QPalette::Button, color(spec.button));
+    pal.setColor(QPalette::ButtonText, color(spec.button_text));
+    pal.setColor(QPalette::BrightText, color(spec.bright_text));
+    pal.setColor(QPalette::Highlight, color(spec.highlight));
+    pal.setColor(QPalette::HighlightedText, color(spec.highlighted_text));
+    pal.setColor(QPalette::ToolTipBase, color(spec.tool_tip_base));
+    pal.setColor(QPalette::ToolTipText, color(spec.tool_tip_text));
+    pal.setColor(QPalette::PlaceholderText, color(spec.placeholder_text));
+    pal.setColor(QPalette::Link, color(spec.link));
+    pal.setColor(QPalette::LinkVisited, color(spec.link_visited));
+
+    // The disabled group keeps greyed-out controls legible instead of letting
+    // Fusion derive a washed-out shade from the enabled colors.
+    pal.setColor(QPalette::Disabled, QPalette::Text, color(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::WindowText, color(spec.disabled_window_text));
+    pal.setColor(QPalette::Disabled, QPalette::ButtonText, color(spec.disabled_button_text));
+    pal.setColor(QPalette::Disabled, QPalette::HighlightedText, color(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::Highlight, color(spec.disabled_highlight));
+    return pal;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -1,0 +1,104 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Applies a theme to the running QApplication and keeps it in step with the
+ * operating system color scheme.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <string>
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <QObject>
+#include <QPalette>
+
+namespace solvcon
+{
+
+/**
+ * @brief Drives the pilot's look: a consistent cross-platform base style plus
+ * a curated light or dark palette applied to the whole application.
+ *
+ * @ingroup group_domain
+ *
+ * The manager standardizes on the Fusion style so Linux and macOS render from
+ * the same drawing code, then paints a curated QPalette over it. The palette
+ * is the single lever for light and dark, so one setMode() call restyles every
+ * widget at once. In System mode the manager reads the operating system color
+ * scheme and follows changes to it live; Light and Dark pin the palette.
+ * themeChanged() fires after each application so widgets that cache colors can
+ * refresh.
+ */
+class RThemeManager
+    : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    explicit RThemeManager(QObject * parent = nullptr);
+
+    /// Install the base style if needed and paint the current mode's palette
+    /// onto the QApplication. Safe to call before any widget exists.
+    void apply();
+
+    /// Switch the requested mode and re-apply. A no-op re-application is still
+    /// cheap, so callers need not compare against the current mode first.
+    void setMode(ThemeMode mode);
+
+    /// Switch mode by its string id ("system", "light", "dark"); an unknown id
+    /// falls back to System. Convenience for the Python console and menu.
+    void setModeById(std::string const & id);
+
+    ThemeMode mode() const { return m_mode; }
+
+    /// The concrete variant the current mode resolves to right now.
+    ThemeVariant currentVariant() const;
+
+    /// String id of the current mode, for the Python boundary.
+    std::string modeId() const;
+
+    /// "light" or "dark" for the current variant, for the Python boundary.
+    std::string variantId() const;
+
+signals:
+
+    /// Emitted after a palette is applied, carrying the resolved variant.
+    void themeChanged(ThemeVariant variant);
+
+private:
+
+    /// True when the operating system reports a dark color scheme. Unknown is
+    /// read as light, the conventional default.
+    bool osPrefersDark() const;
+
+    /// Hint the platform color scheme so native chrome (the macOS titlebar and
+    /// traffic lights) tracks a forced mode. A no-op on Qt below 6.8 and on
+    /// desktops that do not honor the request, such as most Linux ones, where
+    /// the applied palette carries the theme by itself.
+    void syncOsColorScheme();
+
+    /// Build a QPalette from a Qt-free color table, filling the normal and
+    /// disabled color groups.
+    QPalette buildPalette(ThemePalette const & spec) const;
+
+    ThemeMode m_mode = ThemeMode::System;
+
+    /// Guards the one-time Fusion style install, so repeated apply() calls do
+    /// not rebuild the style object.
+    bool m_style_installed = false;
+}; /* end class RThemeManager */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -10,6 +10,7 @@
 
 #include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RThemeManager.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
 #include <QAction>
@@ -876,6 +877,25 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.menuModel();
+                })
+            .def(
+                "set_theme",
+                [](wrapped_type & self, std::string const & mode)
+                {
+                    self.themeManager()->setModeById(mode);
+                },
+                py::arg("mode"))
+            .def_property_readonly(
+                "theme_mode",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->modeId();
+                })
+            .def_property_readonly(
+                "theme_variant",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->variantId();
                 })
             .def(
                 "quit",

--- a/doc/source/devplan/beautify/index.md
+++ b/doc/source/devplan/beautify/index.md
@@ -1,0 +1,297 @@
+# Elegant cross-platform theming for the pilot
+
+A development plan for giving the pilot GUI a polished, consistent look on both
+Linux and macOS, with a light and a dark theme the user can switch at runtime.
+
+## Problem
+
+The pilot rides whatever style and palette the platform hands it. On Linux it
+inherits the desktop's default; on macOS it renders through a different native
+style; and one widget, the Python console, hardcodes black text on a white
+background. The result is threefold:
+
+- The application looks different on each platform, and neither look is under
+  our control.
+- There is no way to choose a light or a dark appearance.
+- The hardcoded console glares white and cannot follow any theme, so even if
+  the rest of the window went dark the console would stay bright.
+
+The goal is a single, curated look that renders the same on Linux and macOS,
+offers light and dark, and switches at runtime, including following the
+operating system's own light or dark setting.
+
+## Approach
+
+The design standardizes on Qt's **Fusion** style and drives every color from a
+curated **QPalette**, one for light and one for dark, applied to the whole
+application. Fusion draws from the same code on every platform and honors a
+custom palette, so the palette becomes the single lever for the entire look.
+A small menu, **View > Theme**, offers three modes:
+
+- **Follow system** tracks the operating system's color scheme and changes with
+  it live.
+- **Light** and **Dark** pin the palette regardless of the operating system.
+
+This mirrors the recommendation that emerged from surveying current Qt practice:
+Fusion plus a palette is the low-maintenance path to reliable, identical
+theming on Linux and macOS, and it is the approach that actually works on Linux,
+where Qt's own `setColorScheme` override is a no-op on most desktops.[^fusion]
+[^colorscheme]
+
+## Where the code lives
+
+The pilot is coordinated by a single manager and a live menu model:
+
+- `RManager` (`cpp/solvcon/pilot/RManager.hpp`) is the singleton that owns the
+  `QApplication` and the `QMainWindow`, and builds the menus in `setUpMenu()`.
+  Its constructor is where the application object is created, so it is the
+  natural place to install a style and paint a palette before any widget
+  exists.
+- `RMenuModel` (`cpp/solvcon/pilot/RMenuModel.hpp`) is the slash-path menu model.
+  The **View** menu already exists (weight 20), and the exclusive
+  `QActionGroup` used for the camera controllers is a ready template for a
+  Light/Dark/System radio group.
+- `RPythonConsoleDockWidget` (`cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp`)
+  is the one widget that forced its own light palette and had to be reconciled.
+- The gtest seam (`gtests/CMakeLists.txt`, `test_nopython`) compiles individual
+  Qt-free pilot sources directly, so a Qt-free color model can be unit tested
+  without a GUI, the same way `RPythonSyntaxRules` is.
+
+## Design
+
+The work splits into a Qt-free model that can be tested headlessly and a thin
+Qt adapter that applies it, wired into the manager.
+
+```{raw} html
+<figure style="margin:1.5em 0;">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Three-layer theme architecture" style="max-width:100%;height:auto;font-family:sans-serif;">
+  <style>
+    .box{rx:8;stroke-width:1.5;}
+    .lbl{font-size:14px;font-weight:600;}
+    .sub{font-size:11px;fill:#555;}
+    .arr{stroke:#888;stroke-width:1.5;marker-end:url(#ah);fill:none;}
+  </style>
+  <defs>
+    <marker id="ah" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto">
+      <path d="M0,0 L6,3 L0,6 Z" fill="#888"/>
+    </marker>
+  </defs>
+  <rect x="20" y="30" width="200" height="190" rx="8" fill="#eef3fb" stroke="#3574f0"/>
+  <text x="120" y="52" text-anchor="middle" class="lbl">RTheme</text>
+  <text x="120" y="70" text-anchor="middle" class="sub">Qt-free model</text>
+  <text x="120" y="98" text-anchor="middle" class="sub">ThemeMode / ThemeVariant</text>
+  <text x="120" y="116" text-anchor="middle" class="sub">light &amp; dark color tables</text>
+  <text x="120" y="134" text-anchor="middle" class="sub">resolveThemeVariant()</text>
+  <text x="120" y="168" text-anchor="middle" class="sub" style="font-style:italic;">unit tested by</text>
+  <text x="120" y="184" text-anchor="middle" class="sub" style="font-style:italic;">test_nopython (no GUI)</text>
+
+  <rect x="270" y="30" width="200" height="190" rx="8" fill="#eef3fb" stroke="#3574f0"/>
+  <text x="370" y="52" text-anchor="middle" class="lbl">RThemeManager</text>
+  <text x="370" y="70" text-anchor="middle" class="sub">Qt adapter (QObject)</text>
+  <text x="370" y="98" text-anchor="middle" class="sub">installs Fusion once</text>
+  <text x="370" y="116" text-anchor="middle" class="sub">builds a QPalette</text>
+  <text x="370" y="134" text-anchor="middle" class="sub">follows the OS scheme</text>
+  <text x="370" y="152" text-anchor="middle" class="sub">emits themeChanged</text>
+
+  <rect x="520" y="30" width="180" height="190" rx="8" fill="#f3f3f4" stroke="#888"/>
+  <text x="610" y="52" text-anchor="middle" class="lbl">RManager</text>
+  <text x="610" y="70" text-anchor="middle" class="sub">coordinator</text>
+  <text x="610" y="98" text-anchor="middle" class="sub">applies before widgets</text>
+  <text x="610" y="116" text-anchor="middle" class="sub">View &gt; Theme menu</text>
+  <text x="610" y="134" text-anchor="middle" class="sub">MDI backdrop follows</text>
+  <text x="610" y="152" text-anchor="middle" class="sub">menu check follows</text>
+
+  <line x1="220" y1="110" x2="270" y2="110" class="arr"/>
+  <line x1="470" y1="110" x2="520" y2="110" class="arr"/>
+</svg>
+<figcaption style="font-size:12px;color:#555;">The Qt-free <code>RTheme</code> holds the color
+tables and the resolution rule; <code>RThemeManager</code> turns them into a live QPalette;
+<code>RManager</code> wires it to the menu and the widgets.</figcaption>
+</figure>
+```
+
+### The Qt-free model: `RTheme`
+
+`RTheme` keeps everything that does not need Qt: the `ThemeMode` (System, Light,
+Dark) and `ThemeVariant` (Light, Dark) enums, a plain `ThemeColor` (three bytes)
+and a `ThemePalette` table of the color roles the pilot uses, the curated light
+and dark tables, and the rule `resolveThemeVariant(mode, os_prefers_dark)` that
+maps a requested mode to a concrete variant. Because it never mentions Qt, it
+compiles into `test_nopython` and is unit tested without a display.
+
+### The Qt adapter: `RThemeManager`
+
+`RThemeManager` installs Fusion once, copies a `ThemePalette` field-by-field into
+a `QPalette` (including the disabled color group, so greyed-out controls stay
+legible), and applies it to the `QApplication`. In **Follow system** mode it
+reads `QStyleHints::colorScheme()` and re-applies on `colorSchemeChanged`,
+deferring the repaint by one event-loop turn because the old palette is still in
+effect when that signal fires.[^signal] On Qt 6.8 and newer it also hints the
+platform scheme with `setColorScheme`, so the native macOS titlebar tracks a
+forced Light or Dark choice; the applied palette carries the theme on Linux,
+where that hint does nothing. Each application emits `themeChanged`, so widgets
+that cache colors can refresh.
+
+### Wiring in `RManager`
+
+`RManager` applies the theme at the top of `setUp()`, before any widget is
+built, so every widget is created already themed. It adds the exclusive
+**View > Theme** group, and it connects `themeChanged` to two follow-ups: it
+repaints the `QMdiArea` backdrop (which paints itself from its own brush rather
+than the palette) with the window color, and it keeps the menu's radio check in
+step with the manager however the theme moves, a menu click, a console
+`set_theme()`, or an operating-system change.
+
+### The palette
+
+Both variants are neutral, low-saturation greys lifted a step off pure black and
+pure white so large fills do not glare, sharing one calm blue accent. The values
+track the conventions of well-regarded cross-platform themes rather than any
+single platform.
+
+| Role | Light | Dark |
+| --- | --- | --- |
+| Window | `#f2f2f3` | `#2d2f33` |
+| Window text | `#1c1e21` | `#e6e6e7` |
+| Base (inputs) | `#ffffff` | `#232427` |
+| Alternate base | `#f6f6f7` | `#2b2d31` |
+| Button | `#eaeaec` | `#35373b` |
+| Highlight (accent) | `#3574f0` | `#3d82e0` |
+| Placeholder text | `#9aa0a6` | `#808489` |
+| Link | `#1a5fb4` | `#3daee9` |
+
+```{raw} html
+<figure style="margin:1.5em 0;">
+<svg viewBox="0 0 720 250" xmlns="http://www.w3.org/2000/svg" role="img"
+     aria-label="Pilot window mockup in light and dark" style="max-width:100%;height:auto;font-family:sans-serif;">
+  <!-- Light window -->
+  <g>
+    <rect x="10" y="20" width="330" height="210" rx="6" fill="#f2f2f3" stroke="#c8cbcf"/>
+    <rect x="10" y="20" width="330" height="24" rx="6" fill="#eaeaec"/>
+    <text x="26" y="37" font-size="11" fill="#1c1e21">File  Edit  View  Mesh  Canvas</text>
+    <rect x="24" y="58" width="150" height="120" fill="#111417" stroke="#c8cbcf"/>
+    <line x1="99" y1="58" x2="99" y2="178" stroke="#c9b458" stroke-width="1"/>
+    <line x1="24" y1="118" x2="174" y2="118" stroke="#c9b458" stroke-width="1"/>
+    <rect x="24" y="58" width="150" height="16" fill="#3574f0"/>
+    <text x="32" y="70" font-size="9" fill="#ffffff">2D canvas</text>
+    <rect x="24" y="190" width="306" height="30" fill="#ffffff" stroke="#c8cbcf"/>
+    <text x="30" y="209" font-size="10" fill="#9aa0a6" font-family="monospace">Enter to execute.</text>
+    <text x="175" y="248" text-anchor="middle" font-size="12" fill="#555">Light</text>
+  </g>
+  <!-- Dark window -->
+  <g>
+    <rect x="380" y="20" width="330" height="210" rx="6" fill="#2d2f33" stroke="#1c1d20"/>
+    <rect x="380" y="20" width="330" height="24" rx="6" fill="#35373b"/>
+    <text x="396" y="37" font-size="11" fill="#e6e6e7">File  Edit  View  Mesh  Canvas</text>
+    <rect x="394" y="58" width="150" height="120" fill="#111417" stroke="#1c1d20"/>
+    <line x1="469" y1="58" x2="469" y2="178" stroke="#c9b458" stroke-width="1"/>
+    <line x1="394" y1="118" x2="544" y2="118" stroke="#c9b458" stroke-width="1"/>
+    <rect x="394" y="58" width="150" height="16" fill="#3d82e0"/>
+    <text x="402" y="70" font-size="9" fill="#ffffff">2D canvas</text>
+    <rect x="394" y="190" width="306" height="30" fill="#232427" stroke="#1c1d20"/>
+    <text x="400" y="209" font-size="10" fill="#808489" font-family="monospace">Enter to execute.</text>
+    <text x="545" y="248" text-anchor="middle" font-size="12" fill="#555">Dark</text>
+  </g>
+</svg>
+<figcaption style="font-size:12px;color:#555;">The same window under both palettes. The menu
+bar, the console strip (previously forced white), and the MDI backdrop all switch together;
+the accent tints the active sub-window title.</figcaption>
+</figure>
+```
+
+## Implementation
+
+New files:
+
+- `cpp/solvcon/pilot/RTheme.hpp`, `RTheme.cpp`: the Qt-free model and the two
+  curated color tables.
+- `cpp/solvcon/pilot/RThemeManager.hpp`, `RThemeManager.cpp`: the Qt adapter.
+- `gtests/test_nopython_pilot_theme.cpp`: unit tests for the model.
+- `tests/test_pilot_theme.py`: end-to-end tests through the menu and palette.
+
+Changed files:
+
+- `RManager.hpp`, `RManager.cpp`: own the manager, apply before widgets, add the
+  **View > Theme** group, follow the theme for the MDI backdrop and the menu
+  check.
+- `RPythonConsoleDockWidget.cpp`: drop the forced light palette so the console
+  follows the theme.
+- `wrap_pilot.cpp`: expose `set_theme(mode)`, `theme_mode`, and `theme_variant`
+  so the theme is scriptable from the console.
+- `cpp/solvcon/pilot/CMakeLists.txt`, `gtests/CMakeLists.txt`: build the new
+  sources, and compile the Qt-free `RTheme.cpp` into `test_nopython`.
+
+## Verification
+
+- **Unit (C++, no GUI):** seven `PilotTheme*` cases in `test_nopython` cover the
+  resolution rule, the id round-trip and fallback, the labels, and that the
+  light and dark tables differ and are not swapped. Runs under CI's headless
+  build.
+- **End-to-end (Python):** six `ThemeMenuTC` cases build the menu bar, trigger
+  the Light and Dark actions, and assert the live `QApplication` palette turns
+  dark or light, plus the scriptable `set_theme` API and the menu-check follow.
+- **Headless render:** the pilot was driven under `QT_QPA_PLATFORM=offscreen`
+  to grab the window in each theme and confirm the console, menu bar, and MDI
+  backdrop all switch.
+- **Lint:** `flake8`, ASCII, trailing-whitespace, `clang-format`, include
+  order, and a diff-scoped `clang-tidy` all pass.
+
+## Cross-platform notes
+
+- **Linux:** forcing a scheme through `QStyleHints::setColorScheme` is a no-op on
+  most desktops, so the manual Light/Dark override is carried entirely by the
+  applied palette, which does work.[^colorscheme]
+- **macOS:** on Qt 6.8 and newer the `setColorScheme` hint lets the native
+  titlebar follow a forced mode. The app should not set
+  `NSRequiresAquaSystemAppearance` to true in its `Info.plist`, or the titlebar
+  would opt out of dark mode.[^macos]
+
+## Out of scope
+
+Deliberately left for later so the prototype stays small:
+
+- The `QPalette::Accent` role (Qt 6.6) and a thin supplemental stylesheet for a
+  tooltip border and focus ring.
+- Teaching the console syntax highlighter and any custom `paintEvent` colors to
+  recolor from `themeChanged`.
+- Persisting the chosen theme across sessions.
+
+## Delivery status
+
+- **Branch:** `feat/beautify`.
+- **Tests:** 7 gtest cases, 6 pytest cases, all green; full suites unaffected.
+- **CI:** a draft pull request exercises the matrix.
+- **Preview:** this page is served for review while the work is in progress.
+
+## Appendix: development history
+
+The prompts that drove this work and what each produced:
+
+- *"Research the most elegant UI widget design on both Linux and Mac using Qt,
+  support switching light and dark theme, make a prototype."* Set the goal:
+  survey current Qt theming practice, then build a Fusion-plus-palette theme
+  with a light/dark/follow-system switch. Produced `RTheme`, `RThemeManager`,
+  the **View > Theme** menu, and the console reconciliation.
+- *"Make a new devplan and serve; include the devplan in the PR."* Produced this
+  page and its figures, added to the served documentation and to the pull
+  request.
+
+[^fusion]: Qt documentation, *Fusion Style*: platform-agnostic, uses the system
+    palette, and honors a custom palette on every platform.
+    <https://doc.qt.io/qt-6/qtquickcontrols-fusion.html>
+
+[^colorscheme]: `QStyleHints::setColorScheme` is documented as not supported on
+    all platforms, and is a no-op on most Linux desktops.
+    <https://doc.qt.io/qt-6/qstylehints.html>,
+    <https://bugreports.qt.io/browse/QTBUG-129917>
+
+[^signal]: Qt documentation, `QStyleHints`: when `colorSchemeChanged` is emitted
+    the old palette is still in effect, so a custom palette should be re-applied
+    after the signal returns. <https://doc.qt.io/qt-6/qstylehints.html>
+
+[^macos]: Apple, *NSAppearance*: build against a current SDK and leave
+    `NSRequiresAquaSystemAppearance` unset (or false) to follow the system
+    appearance. <https://developer.apple.com/documentation/AppKit/NSAppearance>
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/devplan/index.md
+++ b/doc/source/devplan/index.md
@@ -4,6 +4,8 @@ Design and implementation plans for public review and discussions.
 
 ```{toctree}
 :maxdepth: 1
+
+beautify/index
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -38,8 +38,10 @@ add_executable(
     test_nopython_multidim.cpp
     test_nopython_pilot_history.cpp
     test_nopython_pilot_syntax.cpp
+    test_nopython_pilot_theme.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonConsoleHistory.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonSyntaxRules.cpp
+    ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RTheme.cpp
     ${SOLVCON_TOGGLE_SOURCES}
     ${SOLVCON_PROFILING_SOURCES}
     ${SOLVCON_BUFFER_SOURCES}

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using solvcon::darkThemePalette;
+using solvcon::lightThemePalette;
+using solvcon::resolveThemeVariant;
+using solvcon::ThemeMode;
+using solvcon::themeModeFromId;
+using solvcon::themeModeId;
+using solvcon::themeModeLabel;
+using solvcon::themePaletteFor;
+using solvcon::ThemeVariant;
+
+TEST(PilotThemeResolve, ForcedModesIgnoreTheOs)
+{
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Light, true), ThemeVariant::Light);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Light, false), ThemeVariant::Light);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Dark, true), ThemeVariant::Dark);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Dark, false), ThemeVariant::Dark);
+}
+
+TEST(PilotThemeResolve, SystemFollowsTheOs)
+{
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::System, true), ThemeVariant::Dark);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::System, false), ThemeVariant::Light);
+}
+
+TEST(PilotThemeId, RoundTripsThroughItsId)
+{
+    EXPECT_EQ(std::string("system"), themeModeId(ThemeMode::System));
+    EXPECT_EQ(std::string("light"), themeModeId(ThemeMode::Light));
+    EXPECT_EQ(std::string("dark"), themeModeId(ThemeMode::Dark));
+
+    EXPECT_EQ(themeModeFromId("system"), ThemeMode::System);
+    EXPECT_EQ(themeModeFromId("light"), ThemeMode::Light);
+    EXPECT_EQ(themeModeFromId("dark"), ThemeMode::Dark);
+}
+
+TEST(PilotThemeId, UnknownIdFallsBackToSystem)
+{
+    EXPECT_EQ(themeModeFromId("solarized"), ThemeMode::System);
+    EXPECT_EQ(themeModeFromId(nullptr), ThemeMode::System);
+}
+
+TEST(PilotThemeId, EveryModeHasALabel)
+{
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::System)).size(), 0U);
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::Light)).size(), 0U);
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::Dark)).size(), 0U);
+}
+
+TEST(PilotThemePalette, LightAndDarkDifferAndAreConsistent)
+{
+    auto const & light = lightThemePalette();
+    auto const & dark = darkThemePalette();
+
+    // The two variants must actually differ, or the switch is cosmetic only.
+    EXPECT_NE(light.window.r, dark.window.r);
+
+    // A light window is brighter than a dark one; its text is darker. This
+    // guards against the two tables being swapped.
+    EXPECT_GT(light.window.g, dark.window.g);
+    EXPECT_LT(light.text.g, dark.text.g);
+
+    // themePaletteFor selects the matching table.
+    EXPECT_EQ(themePaletteFor(ThemeVariant::Light).window.r, light.window.r);
+    EXPECT_EQ(themePaletteFor(ThemeVariant::Dark).window.r, dark.window.r);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -9,9 +9,12 @@
 
 #include <gtest/gtest.h>
 
+using solvcon::darkSyntaxColors;
 using solvcon::darkThemePalette;
+using solvcon::lightSyntaxColors;
 using solvcon::lightThemePalette;
 using solvcon::resolveThemeVariant;
+using solvcon::syntaxColorsFor;
 using solvcon::ThemeMode;
 using solvcon::themeModeFromId;
 using solvcon::themeModeId;
@@ -73,6 +76,29 @@ TEST(PilotThemePalette, LightAndDarkDifferAndAreConsistent)
     // themePaletteFor selects the matching table.
     EXPECT_EQ(themePaletteFor(ThemeVariant::Light).window.r, light.window.r);
     EXPECT_EQ(themePaletteFor(ThemeVariant::Dark).window.r, dark.window.r);
+}
+
+TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)
+{
+    auto const & light = lightSyntaxColors();
+    auto const & dark = darkSyntaxColors();
+
+    auto sum = [](solvcon::ThemeColor c)
+    { return int(c.r) + int(c.g) + int(c.b); };
+
+    // The two tables must differ, or the console cannot follow the theme.
+    EXPECT_NE(sum(light.keyword), sum(dark.keyword));
+
+    // Dark tokens sit on a dark base, so each category is lifted brighter than
+    // its light-table counterpart; this guards against the tables being
+    // swapped.
+    EXPECT_GT(sum(dark.keyword), sum(light.keyword));
+    EXPECT_GT(sum(dark.string), sum(light.string));
+    EXPECT_GT(sum(dark.number), sum(light.number));
+
+    // syntaxColorsFor selects the matching table.
+    EXPECT_EQ(syntaxColorsFor(ThemeVariant::Light).keyword.b, light.keyword.b);
+    EXPECT_EQ(syntaxColorsFor(ThemeVariant::Dark).keyword.b, dark.keyword.b);
 }
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from PySide6 import QtWidgets
+    from PySide6.QtGui import QPalette
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeMenuTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    def _window_lightness(self):
+        app = QtWidgets.QApplication.instance()
+        return app.palette().color(QPalette.Window).lightness()
+
+    def test_theme_menu_lists_the_three_modes(self):
+        items = [a.text() for a in self.model.menu("View/Theme").actions()]
+        self.assertEqual(items, ["Follow system", "Light", "Dark"])
+
+    def test_theme_group_is_exclusive_and_defaults_to_system(self):
+        group = self.model.group("theme.mode")
+        self.assertEqual(len(group.actions()), 3)
+        self.assertTrue(group.isExclusive())
+        checked = group.checkedAction()
+        self.assertIsNotNone(checked)
+        self.assertEqual(checked.objectName(), "theme.mode_system")
+
+    def test_dark_action_paints_a_dark_window(self):
+        self.model.action("theme.mode_dark").trigger()
+        self.assertEqual(self.mgr.theme_mode, "dark")
+        self.assertEqual(self.mgr.theme_variant, "dark")
+        self.assertLess(self._window_lightness(), 100)
+
+    def test_light_action_paints_a_light_window(self):
+        self.model.action("theme.mode_light").trigger()
+        self.assertEqual(self.mgr.theme_mode, "light")
+        self.assertEqual(self.mgr.theme_variant, "light")
+        self.assertGreater(self._window_lightness(), 150)
+
+    def test_switching_back_and_forth_repaints_each_time(self):
+        self.mgr.set_theme("dark")
+        dark = self._window_lightness()
+        self.mgr.set_theme("light")
+        light = self._window_lightness()
+        self.assertLess(dark, light)
+
+    def test_set_theme_keeps_the_menu_check_in_step(self):
+        self.mgr.set_theme("dark")
+        group = self.model.group("theme.mode")
+        # Scripting the theme should move the radio check too, so the menu
+        # never disagrees with the applied palette.
+        checked = group.checkedAction()
+        self.assertEqual(checked.objectName(), "theme.mode_dark")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Give the pilot a polished, consistent look on Linux and macOS with a light and a dark theme the user can switch at runtime.

## What and why

The pilot previously rode whatever style and palette each platform supplied: it looked different on Linux and macOS, offered no light or dark choice, and the Python console forced black-on-white that no theme could touch. This standardizes on Qt's Fusion style and drives every color from a curated light or dark QPalette applied to the whole application, so one palette is the single lever for the look and it renders the same on both platforms.

A new View > Theme menu offers Follow system, Light, and Dark. Follow system reads the operating system color scheme and tracks changes to it live; Light and Dark pin the palette, which is the override that works on Linux where the platform scheme cannot be forced. On Qt 6.8 and newer a forced mode also hints the native macOS titlebar so the window chrome follows.

## Design

The work splits into a Qt-free RTheme, holding the color tables and the mode-resolution rule so it unit tests without a GUI, and an RThemeManager that builds the QPalette, follows the operating system via QStyleHints, and emits themeChanged. RManager applies the theme before any widget is built, adds the exclusive menu group, and follows theme changes for the MDI backdrop and the menu radio check. The console's forced palette is dropped so it follows along, and set_theme, theme_mode, and theme_variant are exposed to Python for scripting and tests.

## Verification

Seven Qt-free gtest cases in test_nopython cover the resolution rule and the palettes; six pytest cases build the menu and assert the live QApplication palette turns light or dark. The pilot was also driven under QT_QPA_PLATFORM=offscreen to grab the window in each theme and confirm the menu bar, console, and MDI backdrop switch together. flake8, ASCII, trailing-whitespace, clang-format, include order, and a diff-scoped clang-tidy all pass.

## Development plan

A development plan with figures and the palette values is included in this branch under doc/source/devplan/beautify/ and is served for review at http://100.116.60.62:8767/devplan/beautify/index.html while the work is in progress.

This is a draft to exercise CI.
