### PR TITLE
Build the Qt-free theme foundation for the pilot

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -24,6 +24,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
@@ -57,6 +58,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RWorldRenderer2d.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -1,0 +1,267 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <cstring>
+
+namespace solvcon
+{
+
+// The curated palettes below are neutral, low-saturation greys lifted a step
+// off pure black and pure white so large fills do not glare, paired with one
+// calm blue accent shared by both variants. They are the shared fallback: every
+// platform table starts from these values, and a platform room later tunes its
+// own copy toward the native look without touching the others.
+
+static ThemePalette makeLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xf2, 0xf2, 0xf3};
+    p.window_text = {0x1c, 0x1e, 0x21};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf6, 0xf6, 0xf7};
+    p.text = {0x1c, 0x1e, 0x21};
+    p.button = {0xea, 0xea, 0xec};
+    p.button_text = {0x1c, 0x1e, 0x21};
+    p.bright_text = {0xd3, 0x2f, 0x2f};
+    p.highlight = {0x35, 0x74, 0xf0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xfa, 0xfa, 0xfb};
+    p.tool_tip_text = {0x1c, 0x1e, 0x21};
+    p.placeholder_text = {0x9a, 0xa0, 0xa6};
+    p.link = {0x1a, 0x5f, 0xb4};
+    p.link_visited = {0x7e, 0x4f, 0xb0};
+    p.disabled_text = {0xa6, 0xa8, 0xac};
+    p.disabled_button_text = {0xa6, 0xa8, 0xac};
+    p.disabled_window_text = {0xa6, 0xa8, 0xac};
+    p.disabled_highlight = {0xc8, 0xcb, 0xcf};
+    return p;
+}
+
+static ThemePalette makeDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x2d, 0x2f, 0x33};
+    p.window_text = {0xe6, 0xe6, 0xe7};
+    p.base = {0x23, 0x24, 0x27};
+    p.alternate_base = {0x2b, 0x2d, 0x31};
+    p.text = {0xe6, 0xe6, 0xe7};
+    p.button = {0x35, 0x37, 0x3b};
+    p.button_text = {0xe6, 0xe6, 0xe7};
+    p.bright_text = {0xff, 0x6b, 0x68};
+    p.highlight = {0x3d, 0x82, 0xe0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0x35, 0x37, 0x3b};
+    p.tool_tip_text = {0xe6, 0xe6, 0xe7};
+    p.placeholder_text = {0x80, 0x84, 0x89};
+    p.link = {0x3d, 0xae, 0xe9};
+    p.link_visited = {0xb1, 0x86, 0xd8};
+    p.disabled_text = {0x6b, 0x6e, 0x73};
+    p.disabled_button_text = {0x6b, 0x6e, 0x73};
+    p.disabled_window_text = {0x6b, 0x6e, 0x73};
+    p.disabled_highlight = {0x3a, 0x3d, 0x42};
+    return p;
+}
+
+// The syntax colors keep the light table's familiar hues (a blue keyword, a
+// teal builtin, a red string, a magenta number) and lift each to a brighter,
+// lower-saturation tint for the dark table so the tokens read clearly on the
+// dark base instead of sinking into it.
+
+static SyntaxColors makeLightSyntaxColors()
+{
+    SyntaxColors c;
+    c.keyword = {0x00, 0x00, 0xb4};
+    c.builtin = {0x00, 0x6e, 0x6e};
+    c.string = {0xa0, 0x00, 0x00};
+    c.comment = {0x80, 0x80, 0x80};
+    c.number = {0x8c, 0x00, 0x8c};
+    c.bracket_match = {0xb4, 0xb4, 0xff};
+    return c;
+}
+
+static SyntaxColors makeDarkSyntaxColors()
+{
+    SyntaxColors c;
+    c.keyword = {0x6a, 0xb7, 0xff};
+    c.builtin = {0x4e, 0xc9, 0xb0};
+    c.string = {0xe5, 0x92, 0x8b};
+    c.comment = {0x80, 0x84, 0x89};
+    c.number = {0xd6, 0xa4, 0xe0};
+    c.bracket_match = {0x3d, 0x50, 0x6b};
+    return c;
+}
+
+// The capability records state what each platform's theme can honor. macOS and
+// Windows own their title bar and pin a variant through the native color-scheme
+// hint, so both flags are set; Linux carries a pinned variant with the curated
+// palette instead and does not reach the title bar. These seed values are
+// refined as each room is furnished.
+
+static ThemeCapabilities makeLinuxCapabilities()
+{
+    ThemeCapabilities c;
+    c.can_follow_system = true;
+    c.can_force_variant = true;
+    c.has_native_accent = true;
+    c.controls_titlebar = false;
+    c.has_native_style = true;
+    return c;
+}
+
+static ThemeCapabilities makeMacCapabilities()
+{
+    ThemeCapabilities c;
+    c.can_follow_system = true;
+    c.can_force_variant = true;
+    c.has_native_accent = true;
+    c.controls_titlebar = true;
+    c.has_native_style = true;
+    return c;
+}
+
+static ThemeCapabilities makeWindowsCapabilities()
+{
+    ThemeCapabilities c;
+    c.can_follow_system = true;
+    c.can_force_variant = true;
+    c.has_native_accent = true;
+    c.controls_titlebar = true;
+    c.has_native_style = true;
+    return c;
+}
+
+ThemePalette const & lightThemePalette()
+{
+    static ThemePalette const palette = makeLightPalette();
+    return palette;
+}
+
+ThemePalette const & darkThemePalette()
+{
+    static ThemePalette const palette = makeDarkPalette();
+    return palette;
+}
+
+ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant)
+{
+    // Every platform seeds from the curated tables; the platform rooms furnished
+    // in later steps replace this with their own tuned copies.
+    (void)platform;
+    return variant == ThemeVariant::Dark ? darkThemePalette() : lightThemePalette();
+}
+
+SyntaxColors const & lightSyntaxColors()
+{
+    static SyntaxColors const colors = makeLightSyntaxColors();
+    return colors;
+}
+
+SyntaxColors const & darkSyntaxColors()
+{
+    static SyntaxColors const colors = makeDarkSyntaxColors();
+    return colors;
+}
+
+SyntaxColors const & syntaxColorsFor(PlatformId platform, ThemeVariant variant)
+{
+    (void)platform;
+    return variant == ThemeVariant::Dark ? darkSyntaxColors() : lightSyntaxColors();
+}
+
+ThemeCapabilities const & themeCapabilitiesFor(PlatformId platform)
+{
+    static ThemeCapabilities const linux_caps = makeLinuxCapabilities();
+    static ThemeCapabilities const mac_caps = makeMacCapabilities();
+    static ThemeCapabilities const windows_caps = makeWindowsCapabilities();
+
+    switch (platform)
+    {
+    case PlatformId::Mac:
+        return mac_caps;
+    case PlatformId::Windows:
+        return windows_caps;
+    case PlatformId::Linux:
+    default:
+        return linux_caps;
+    }
+}
+
+ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return ThemeVariant::Light;
+    case ThemeMode::Dark:
+        return ThemeVariant::Dark;
+    case ThemeMode::System:
+    default:
+        return os_prefers_dark ? ThemeVariant::Dark : ThemeVariant::Light;
+    }
+}
+
+char const * themeModeId(ThemeMode mode)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return "light";
+    case ThemeMode::Dark:
+        return "dark";
+    case ThemeMode::System:
+    default:
+        return "system";
+    }
+}
+
+char const * themeModeLabel(ThemeMode mode)
+{
+    switch (mode)
+    {
+    case ThemeMode::Light:
+        return "Light";
+    case ThemeMode::Dark:
+        return "Dark";
+    case ThemeMode::System:
+    default:
+        return "Follow system";
+    }
+}
+
+ThemeMode themeModeFromId(char const * id)
+{
+    if (id != nullptr)
+    {
+        if (0 == std::strcmp(id, "light"))
+        {
+            return ThemeMode::Light;
+        }
+        if (0 == std::strcmp(id, "dark"))
+        {
+            return ThemeMode::Dark;
+        }
+    }
+    return ThemeMode::System;
+}
+
+char const * platformIdName(PlatformId platform)
+{
+    switch (platform)
+    {
+    case PlatformId::Mac:
+        return "mac";
+    case PlatformId::Windows:
+        return "windows";
+    case PlatformId::Linux:
+    default:
+        return "linux";
+    }
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RTheme.hpp
+++ b/cpp/solvcon/pilot/RTheme.hpp
@@ -1,0 +1,206 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Qt-free theme foundation: the color-role vocabulary, the light and dark
+ * color tables carried on a per-platform axis, the rule that resolves a
+ * requested mode against the operating system color scheme, and the record of
+ * what each platform's theme can honor.
+ *
+ * Nothing here mentions Qt, so the whole foundation compiles into the
+ * no-GUI test target and every platform's tables are checked on every CI
+ * runner. The Qt adapter (RThemeManager) turns a table into a QPalette by a
+ * straight field-by-field copy, and the per-platform backends read the
+ * capability record to decide what native levers to pull.
+ *
+ * @ingroup group_domain
+ */
+
+#include <cstdint>
+
+namespace solvcon
+{
+
+/**
+ * @brief The source a theme draws its variant from.
+ *
+ * System follows the operating system color scheme and tracks changes to it;
+ * Light and Dark pin the palette regardless of the operating system.
+ */
+enum class ThemeMode
+{
+    System,
+    Light,
+    Dark,
+};
+
+/// The two concrete palettes a mode resolves to.
+enum class ThemeVariant
+{
+    Light,
+    Dark,
+};
+
+/**
+ * @brief The platform a color table and a capability record are written for.
+ *
+ * The palette lookup carries this axis so each platform's look is tuned in its
+ * own table without disturbing the others. Detecting the running platform is a
+ * thin Qt call made in the adapter and passed in here, which keeps this
+ * foundation free of Qt.
+ */
+enum class PlatformId
+{
+    Linux,
+    Mac,
+    Windows,
+};
+
+/**
+ * @brief One sRGB color, a byte per channel.
+ *
+ * Deliberately free of Qt so the color tables can live in a translation unit
+ * that compiles and tests without QtGui.
+ */
+struct ThemeColor
+{
+    std::uint8_t r = 0;
+    std::uint8_t g = 0;
+    std::uint8_t b = 0;
+
+    constexpr ThemeColor() = default;
+
+    constexpr ThemeColor(std::uint8_t red, std::uint8_t green, std::uint8_t blue)
+        : r(red)
+        , g(green)
+        , b(blue)
+    {
+    }
+};
+
+/**
+ * @brief The colors a palette assigns to the widget roles the pilot uses.
+ *
+ * Each field is named after the QPalette::ColorRole it maps to, so the Qt
+ * adapter copies the struct into a QPalette one field at a time. The trailing
+ * disabled_* fields feed the QPalette::Disabled color group, which keeps
+ * greyed-out text legible in both variants.
+ */
+struct ThemePalette
+{
+    ThemeColor window;
+    ThemeColor window_text;
+    ThemeColor base;
+    ThemeColor alternate_base;
+    ThemeColor text;
+    ThemeColor button;
+    ThemeColor button_text;
+    ThemeColor bright_text;
+    ThemeColor highlight;
+    ThemeColor highlighted_text;
+    ThemeColor tool_tip_base;
+    ThemeColor tool_tip_text;
+    ThemeColor placeholder_text;
+    ThemeColor link;
+    ThemeColor link_visited;
+    ThemeColor disabled_text;
+    ThemeColor disabled_button_text;
+    ThemeColor disabled_window_text;
+    ThemeColor disabled_highlight;
+};
+
+/**
+ * @brief The colors the console's Python highlighter and its matching-bracket
+ * marker draw with.
+ *
+ * These are not QPalette roles, so they live apart from ThemePalette; the
+ * console reads them directly. Like the palette they come in a light and a
+ * dark table so the highlighted code stays legible under either variant, which
+ * the hardcoded single set could not do once the console followed the theme.
+ * bracket_match is a background wash behind a matched pair of brackets.
+ */
+struct SyntaxColors
+{
+    ThemeColor keyword;
+    ThemeColor builtin;
+    ThemeColor string;
+    ThemeColor comment;
+    ThemeColor number;
+    ThemeColor bracket_match;
+};
+
+/**
+ * @brief What a platform's theme is able to honor.
+ *
+ * A plain record of yes-or-no facts, kept in the Qt-free core so it is data a
+ * test can read rather than behavior a display is needed to observe. The
+ * adapter exposes it to the interface, which greys out any menu choice the
+ * running platform cannot deliver, so the pilot never offers a switch that
+ * does nothing.
+ */
+struct ThemeCapabilities
+{
+    /// Can track the operating system light-or-dark setting and follow it live.
+    bool can_follow_system = false;
+    /// Can pin Light or Dark against the operating system's own preference.
+    bool can_force_variant = false;
+    /// Supplies a platform accent color read from the operating system.
+    bool has_native_accent = false;
+    /// Can theme the window's title bar, not just its client area.
+    bool controls_titlebar = false;
+    /// Installs a platform-native widget style rather than a portable one.
+    bool has_native_style = false;
+};
+
+/// The curated light palette, the shared fallback every platform table seeds
+/// from until its room is furnished.
+ThemePalette const & lightThemePalette();
+
+/// The curated dark palette.
+ThemePalette const & darkThemePalette();
+
+/// The palette a platform draws a resolved variant with.
+ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant);
+
+/// The console syntax colors tuned for a light background.
+SyntaxColors const & lightSyntaxColors();
+
+/// The console syntax colors tuned for a dark background.
+SyntaxColors const & darkSyntaxColors();
+
+/// The syntax colors a platform draws a resolved variant with.
+SyntaxColors const & syntaxColorsFor(PlatformId platform, ThemeVariant variant);
+
+/// The capability record for a platform.
+ThemeCapabilities const & themeCapabilitiesFor(PlatformId platform);
+
+/**
+ * @brief Resolve a requested mode to a concrete variant.
+ *
+ * In System mode the choice follows @p os_prefers_dark; Light and Dark ignore
+ * it and return their own variant.
+ */
+ThemeVariant resolveThemeVariant(ThemeMode mode, bool os_prefers_dark);
+
+/// The stable identifier for a mode, used as the menu action object name, at
+/// the Python boundary, and in tests ("system", "light", "dark").
+char const * themeModeId(ThemeMode mode);
+
+/// The human-readable menu label for a mode.
+char const * themeModeLabel(ThemeMode mode);
+
+/// The mode named by @p id, or ThemeMode::System when @p id matches none.
+ThemeMode themeModeFromId(char const * id);
+
+/// The stable identifier for a platform ("linux", "mac", "windows"), used at
+/// the Python boundary and in tests.
+char const * platformIdName(PlatformId platform);
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -38,8 +38,10 @@ add_executable(
     test_nopython_multidim.cpp
     test_nopython_pilot_history.cpp
     test_nopython_pilot_syntax.cpp
+    test_nopython_pilot_theme.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonConsoleHistory.cpp
     ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RPythonSyntaxRules.cpp
+    ${SOLVCON_INCLUDE_DIR}/solvcon/pilot/RTheme.cpp
     ${SOLVCON_TOGGLE_SOURCES}
     ${SOLVCON_PROFILING_SOURCES}
     ${SOLVCON_BUFFER_SOURCES}

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <string>
+
+#include <gtest/gtest.h>
+
+using solvcon::darkSyntaxColors;
+using solvcon::darkThemePalette;
+using solvcon::lightSyntaxColors;
+using solvcon::lightThemePalette;
+using solvcon::PlatformId;
+using solvcon::platformIdName;
+using solvcon::resolveThemeVariant;
+using solvcon::syntaxColorsFor;
+using solvcon::themeCapabilitiesFor;
+using solvcon::ThemeMode;
+using solvcon::themeModeFromId;
+using solvcon::themeModeId;
+using solvcon::themeModeLabel;
+using solvcon::themePaletteFor;
+using solvcon::ThemeVariant;
+
+TEST(PilotThemeResolve, ForcedModesIgnoreTheOs)
+{
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Light, true), ThemeVariant::Light);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Light, false), ThemeVariant::Light);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Dark, true), ThemeVariant::Dark);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::Dark, false), ThemeVariant::Dark);
+}
+
+TEST(PilotThemeResolve, SystemFollowsTheOs)
+{
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::System, true), ThemeVariant::Dark);
+    EXPECT_EQ(resolveThemeVariant(ThemeMode::System, false), ThemeVariant::Light);
+}
+
+TEST(PilotThemeId, RoundTripsThroughItsId)
+{
+    EXPECT_EQ(std::string("system"), themeModeId(ThemeMode::System));
+    EXPECT_EQ(std::string("light"), themeModeId(ThemeMode::Light));
+    EXPECT_EQ(std::string("dark"), themeModeId(ThemeMode::Dark));
+
+    EXPECT_EQ(themeModeFromId("system"), ThemeMode::System);
+    EXPECT_EQ(themeModeFromId("light"), ThemeMode::Light);
+    EXPECT_EQ(themeModeFromId("dark"), ThemeMode::Dark);
+}
+
+TEST(PilotThemeId, UnknownIdFallsBackToSystem)
+{
+    EXPECT_EQ(themeModeFromId("solarized"), ThemeMode::System);
+    EXPECT_EQ(themeModeFromId(nullptr), ThemeMode::System);
+}
+
+TEST(PilotThemeId, EveryModeHasALabel)
+{
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::System)).size(), 0U);
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::Light)).size(), 0U);
+    EXPECT_GT(std::string(themeModeLabel(ThemeMode::Dark)).size(), 0U);
+}
+
+TEST(PilotThemePlatform, EveryPlatformHasAName)
+{
+    EXPECT_EQ(std::string("linux"), platformIdName(PlatformId::Linux));
+    EXPECT_EQ(std::string("mac"), platformIdName(PlatformId::Mac));
+    EXPECT_EQ(std::string("windows"), platformIdName(PlatformId::Windows));
+}
+
+TEST(PilotThemePalette, LightAndDarkDifferAndAreConsistent)
+{
+    auto const & light = lightThemePalette();
+    auto const & dark = darkThemePalette();
+
+    // The two variants must actually differ, or the switch is cosmetic only.
+    EXPECT_NE(light.window.r, dark.window.r);
+
+    // A light window is brighter than a dark one; its text is darker. This
+    // guards against the two tables being swapped.
+    EXPECT_GT(light.window.g, dark.window.g);
+    EXPECT_LT(light.text.g, dark.text.g);
+}
+
+TEST(PilotThemePalette, EveryPlatformSelectsTheVariantTable)
+{
+    // The platform axis is seeded from the curated tables, so every platform
+    // resolves a variant to the same base table until its room is furnished.
+    // The lookup must still select the requested variant on each platform.
+    for (PlatformId platform : {PlatformId::Linux, PlatformId::Mac, PlatformId::Windows})
+    {
+        EXPECT_GT(themePaletteFor(platform, ThemeVariant::Light).window.g,
+                  themePaletteFor(platform, ThemeVariant::Dark).window.g);
+        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Light).window.r,
+                  lightThemePalette().window.r);
+        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Dark).window.r,
+                  darkThemePalette().window.r);
+    }
+}
+
+TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)
+{
+    auto const & light = lightSyntaxColors();
+    auto const & dark = darkSyntaxColors();
+
+    auto sum = [](solvcon::ThemeColor c)
+    { return static_cast<int>(c.r) + static_cast<int>(c.g) + static_cast<int>(c.b); };
+
+    // The two tables must differ, or the console cannot follow the theme.
+    EXPECT_NE(sum(light.keyword), sum(dark.keyword));
+
+    // Dark tokens sit on a dark base, so each category is lifted brighter than
+    // its light-table counterpart; this guards against the tables being
+    // swapped.
+    EXPECT_GT(sum(dark.keyword), sum(light.keyword));
+    EXPECT_GT(sum(dark.string), sum(light.string));
+    EXPECT_GT(sum(dark.number), sum(light.number));
+
+    // syntaxColorsFor selects the matching table on every platform.
+    for (PlatformId platform : {PlatformId::Linux, PlatformId::Mac, PlatformId::Windows})
+    {
+        EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Light).keyword.b, light.keyword.b);
+        EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Dark).keyword.b, dark.keyword.b);
+    }
+}
+
+TEST(PilotThemeCapabilities, DifferByPlatform)
+{
+    auto const & linux_caps = themeCapabilitiesFor(PlatformId::Linux);
+    auto const & mac_caps = themeCapabilitiesFor(PlatformId::Mac);
+    auto const & windows_caps = themeCapabilitiesFor(PlatformId::Windows);
+
+    // Every platform follows the system and can pin a variant, whether through
+    // the native hint or a carried palette.
+    EXPECT_TRUE(linux_caps.can_follow_system);
+    EXPECT_TRUE(mac_caps.can_follow_system);
+    EXPECT_TRUE(windows_caps.can_follow_system);
+    EXPECT_TRUE(linux_caps.can_force_variant);
+    EXPECT_TRUE(mac_caps.can_force_variant);
+    EXPECT_TRUE(windows_caps.can_force_variant);
+
+    // macOS and Windows own their title bar; Linux does not, so the record
+    // genuinely distinguishes the platforms.
+    EXPECT_TRUE(mac_caps.controls_titlebar);
+    EXPECT_TRUE(windows_caps.controls_titlebar);
+    EXPECT_FALSE(linux_caps.controls_titlebar);
+}
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
First step of a pilot theme system that aims to feel native on Linux,
macOS, and Windows from one shared foundation. This step builds that
foundation and nothing else, so the pilot's behavior is unchanged.

## What this adds

`RTheme`, a Qt-free core holding:

- the color-role vocabulary: `ThemePalette` for the widget roles and
  `SyntaxColors` for the console highlighter;
- the `ThemeMode` (Follow system, Light, Dark) and `ThemeVariant`
  (Light, Dark) enums, and `resolveThemeVariant()` mapping a requested
  mode against the operating system color scheme;
- a `PlatformId` axis so each platform's colors live in their own
  table, reached through `themePaletteFor(platform, variant)` and the
  syntax equivalent;
- a `ThemeCapabilities` record stating, per platform, what the theme
  can honor (follow the system, force a variant, native accent,
  titlebar control, native style).

Every platform table is seeded from one curated light/dark set; the
per-platform rooms tune their own copies in later steps.

## Why Qt-free

Nothing here mentions Qt, so it compiles into the no-GUI `test_nopython`
target and every platform's tables are checked on every runner. A later
Qt adapter turns a table into a `QPalette` by a field-by-field copy.

## Tests

`test_nopython_pilot_theme.cpp` covers the resolution rule, the mode
identifiers, the per-platform palette and syntax lookups, and the
capability record. `make gtest` is green (201 tests).