### PR TITLE
Apply the theme through a per-platform backend seam

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -25,6 +25,8 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.hpp
@@ -59,6 +61,8 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonSyntaxHighlighter.cpp

--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -12,6 +12,7 @@
 #include <solvcon/pilot/DrawTool.hpp>
 #include <solvcon/pilot/RAction.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RThemeManager.hpp>
 #include <Qt>
 #include <QMenuBar>
 #include <QMenu>
@@ -50,6 +51,10 @@ RManager::RManager()
 
     m_mainWindow = new QMainWindow;
     m_mainWindow->setWindowIcon(QIcon(QString(":/icon.ico")));
+    // The theme controller is parented to the manager, not the window, so its
+    // OS color-scheme connection survives a window rebuild. The palette is
+    // applied in setUp(), before any widget is created.
+    m_themeManager = new RThemeManager(this);
     // Do not call setUp() from the constructor.  Windows may crash with
     // "exited with code -1073740791".  The reason is not yet clarified.
 }
@@ -58,6 +63,17 @@ RManager & RManager::setUp()
 {
     if (!m_already_setup)
     {
+        // A prior reset() tears the manager down with the application it drove;
+        // rebuild it here so a fresh setUp on the singleton starts clean.
+        if (m_themeManager == nullptr)
+        {
+            m_themeManager = new RThemeManager(this);
+        }
+        // Paint the style and palette before any widget exists, so every widget
+        // below is created already themed, and let native chrome follow the
+        // main window.
+        this->m_themeManager->setWindow(m_mainWindow);
+        this->m_themeManager->apply();
         this->setUpConsole();
         this->setUpCentral();
         this->primeRhiComposition();
@@ -80,6 +96,11 @@ void RManager::reset()
     {
         m_menuModel->clear();
     }
+    // Tear the theme controller down before the application it connected to, so
+    // its OS color-scheme connection unwinds while that application is alive. It
+    // is parented to this long-lived singleton, so it must be deleted by hand.
+    delete m_themeManager;
+    m_themeManager = nullptr;
     m_owned_core.reset(); // Deletes the application only if the pilot made it.
     m_core = nullptr;
     m_mainWindow = nullptr;

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -32,6 +32,7 @@ namespace solvcon
 {
 
 class RMenuModel;
+class RThemeManager;
 
 /**
  * @brief Singleton that owns the pilot main window and coordinates its
@@ -84,6 +85,9 @@ public:
     /// The live model of the menu bar, addressable by path from Python.
     RMenuModel * menuModel() { return m_menuModel; }
 
+    /// The application-wide theme controller, scriptable from Python.
+    RThemeManager * themeManager() { return m_themeManager; }
+
     void quit() { m_core->quit(); }
 
     /// Only call reset() when the program is to be stopped.
@@ -132,6 +136,10 @@ private:
 
     /// Live menu model owned by the widget tree (parented to the main window).
     RMenuModel * m_menuModel = nullptr;
+
+    /// Application-wide theme controller, parented to the manager so it and its
+    /// OS color-scheme connection outlive each rebuild of the main window.
+    RThemeManager * m_themeManager = nullptr;
 
     RPythonConsoleDockWidget * m_pycon = nullptr;
     QMdiArea * m_mdiArea = nullptr;

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+namespace
+{
+
+/**
+ * @brief The fallback backend: it keeps the platform's own default style and
+ * pulls no native levers.
+ *
+ * Every platform starts here and is replaced by its furnished room in a later
+ * step. Keeping the default style already gives each platform its native
+ * widgets; the room adds the accent, the title bar, and an explicit style
+ * choice on top.
+ */
+class DefaultThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    explicit DefaultThemeBackend(PlatformId platform)
+        : m_platform(platform)
+    {
+    }
+
+    PlatformId platform() const override { return m_platform; }
+
+    std::string styleName() const override { return {}; }
+
+    std::optional<ThemeColor> accentColor(ThemeVariant /*variant*/) const override
+    {
+        return std::nullopt;
+    }
+
+    void applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/) override {}
+
+    ThemeCapabilities capabilities() const override
+    {
+        return themeCapabilitiesFor(m_platform);
+    }
+
+private:
+
+    PlatformId m_platform;
+
+}; /* end class DefaultThemeBackend */
+
+} /* end namespace */
+
+std::unique_ptr<RThemeBackend> makeThemeBackend()
+{
+#if defined(Q_OS_MACOS)
+    return std::make_unique<DefaultThemeBackend>(PlatformId::Mac);
+#elif defined(Q_OS_WIN)
+    return std::make_unique<DefaultThemeBackend>(PlatformId::Windows);
+#else
+    return std::make_unique<DefaultThemeBackend>(PlatformId::Linux);
+#endif
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RThemeBackend.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The backend seam: the Qt-and-native half of a theme that a color table
+ * cannot express.
+ *
+ * A backend furnishes one platform's native look. It names the widget style to
+ * install, reads the operating system accent, and applies window-manager chrome
+ * a palette cannot reach. The makeThemeBackend() factory is the only place a
+ * platform preprocessor branch appears, so only the running platform's backend
+ * is compiled into the binary while the color tables it reads compile
+ * everywhere through the Qt-free core.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RTheme.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+
+class QWidget;
+
+namespace solvcon
+{
+
+/**
+ * @brief One platform's native theme levers, behind an interface so the
+ * manager drives every platform the same way.
+ *
+ * @ingroup group_domain
+ */
+class RThemeBackend
+{
+
+public:
+
+    RThemeBackend() = default;
+    virtual ~RThemeBackend() = default;
+
+    RThemeBackend(RThemeBackend const &) = delete;
+    RThemeBackend & operator=(RThemeBackend const &) = delete;
+    RThemeBackend(RThemeBackend &&) = delete;
+    RThemeBackend & operator=(RThemeBackend &&) = delete;
+
+    /// The platform this backend furnishes, naming the color table to read.
+    virtual PlatformId platform() const = 0;
+
+    /// The widget style to install, or an empty string to keep the platform's
+    /// default style.
+    virtual std::string styleName() const = 0;
+
+    /// The operating-system accent for a variant, or an empty optional to keep
+    /// the curated highlight from the color table.
+    virtual std::optional<ThemeColor> accentColor(ThemeVariant variant) const = 0;
+
+    /// Apply window-manager chrome no palette can reach, such as the Windows
+    /// immersive dark title bar. A backend without such chrome does nothing.
+    virtual void applyNativeChrome(QWidget * window, ThemeVariant variant) = 0;
+
+    /// What this platform's theme can honor.
+    virtual ThemeCapabilities capabilities() const = 0;
+
+}; /* end class RThemeBackend */
+
+/**
+ * @brief Build the backend for the running platform.
+ *
+ * The single site of a platform preprocessor branch. Until a platform's room is
+ * furnished it gets the default backend, which keeps the platform's own style.
+ */
+std::unique_ptr<RThemeBackend> makeThemeBackend();
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RThemeManager.hpp> // Must be the first include.
+
+#include <QApplication>
+#include <QColor>
+#include <QGuiApplication>
+#include <QStyleFactory>
+#include <QStyleHints>
+#include <QString>
+#include <QTimer>
+#include <QWidget>
+#include <Qt>
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+RThemeManager::RThemeManager(QObject * parent)
+    : QObject(parent)
+    , m_backend(makeThemeBackend())
+{
+    // Track live operating-system color-scheme changes while in System mode.
+    // The style-hints object is owned by the application and outlives the
+    // manager, so the connection stays valid for the manager's lifetime.
+    if (QStyleHints * hints = QGuiApplication::styleHints())
+    {
+        connect(
+            hints,
+            &QStyleHints::colorSchemeChanged,
+            this,
+            [this](Qt::ColorScheme)
+            {
+                // When this signal fires the old palette is still in effect, so
+                // defer the re-apply to the next event-loop turn rather than
+                // repainting against a palette about to change.
+                if (m_mode == ThemeMode::System)
+                {
+                    QTimer::singleShot(0, this, [this]()
+                                       { apply(); });
+                }
+            });
+    }
+}
+
+RThemeManager::~RThemeManager() = default;
+
+void RThemeManager::apply()
+{
+    // Install the platform style once; the default backend leaves the style
+    // empty to keep the platform's own, and later calls only repaint.
+    if (!m_style_installed)
+    {
+        std::string const style = m_backend->styleName();
+        if (!style.empty())
+        {
+            QApplication::setStyle(
+                QStyleFactory::create(QString::fromStdString(style)));
+        }
+        m_style_installed = true;
+    }
+
+    ThemeVariant const variant = currentVariant();
+    QApplication::setPalette(
+        buildPalette(themePaletteFor(m_backend->platform(), variant), variant));
+    if (m_window != nullptr)
+    {
+        m_backend->applyNativeChrome(m_window, variant);
+    }
+    emit themeChanged(variant);
+}
+
+void RThemeManager::setWindow(QWidget * window)
+{
+    m_window = window;
+    if (m_window != nullptr)
+    {
+        m_backend->applyNativeChrome(m_window, currentVariant());
+    }
+}
+
+void RThemeManager::setMode(ThemeMode mode)
+{
+    m_mode = mode;
+    syncOsColorScheme();
+    apply();
+}
+
+void RThemeManager::setModeById(std::string const & id)
+{
+    setMode(themeModeFromId(id.c_str()));
+}
+
+ThemeVariant RThemeManager::currentVariant() const
+{
+    return resolveThemeVariant(m_mode, osPrefersDark());
+}
+
+PlatformId RThemeManager::platform() const
+{
+    return m_backend->platform();
+}
+
+ThemeCapabilities RThemeManager::capabilities() const
+{
+    return m_backend->capabilities();
+}
+
+std::string RThemeManager::modeId() const
+{
+    return themeModeId(m_mode);
+}
+
+std::string RThemeManager::variantId() const
+{
+    return currentVariant() == ThemeVariant::Dark ? "dark" : "light";
+}
+
+bool RThemeManager::osPrefersDark() const
+{
+    QStyleHints * hints = QGuiApplication::styleHints();
+    return hints != nullptr && hints->colorScheme() == Qt::ColorScheme::Dark;
+}
+
+void RThemeManager::syncOsColorScheme()
+{
+#if QT_VERSION >= QT_VERSION_CHECK(6, 8, 0)
+    QStyleHints * hints = QGuiApplication::styleHints();
+    if (hints == nullptr)
+    {
+        return;
+    }
+    switch (m_mode)
+    {
+    case ThemeMode::Light:
+        hints->setColorScheme(Qt::ColorScheme::Light);
+        break;
+    case ThemeMode::Dark:
+        hints->setColorScheme(Qt::ColorScheme::Dark);
+        break;
+    case ThemeMode::System:
+    default:
+        hints->unsetColorScheme();
+        break;
+    }
+#endif
+}
+
+QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant variant) const
+{
+    auto color = [](ThemeColor c)
+    { return QColor(c.r, c.g, c.b); };
+
+    // A native accent, when the backend reads one, overrides the curated
+    // highlight so the pilot picks up the user's chosen system color.
+    QColor highlight = color(spec.highlight);
+    if (std::optional<ThemeColor> const accent = m_backend->accentColor(variant))
+    {
+        highlight = color(*accent);
+    }
+
+    QPalette pal;
+    pal.setColor(QPalette::Window, color(spec.window));
+    pal.setColor(QPalette::WindowText, color(spec.window_text));
+    pal.setColor(QPalette::Base, color(spec.base));
+    pal.setColor(QPalette::AlternateBase, color(spec.alternate_base));
+    pal.setColor(QPalette::Text, color(spec.text));
+    pal.setColor(QPalette::Button, color(spec.button));
+    pal.setColor(QPalette::ButtonText, color(spec.button_text));
+    pal.setColor(QPalette::BrightText, color(spec.bright_text));
+    pal.setColor(QPalette::Highlight, highlight);
+    pal.setColor(QPalette::HighlightedText, color(spec.highlighted_text));
+    pal.setColor(QPalette::ToolTipBase, color(spec.tool_tip_base));
+    pal.setColor(QPalette::ToolTipText, color(spec.tool_tip_text));
+    pal.setColor(QPalette::PlaceholderText, color(spec.placeholder_text));
+    pal.setColor(QPalette::Link, color(spec.link));
+    pal.setColor(QPalette::LinkVisited, color(spec.link_visited));
+
+    // The disabled group keeps greyed-out controls legible instead of letting
+    // the style derive a washed-out shade from the enabled colors.
+    pal.setColor(QPalette::Disabled, QPalette::Text, color(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::WindowText, color(spec.disabled_window_text));
+    pal.setColor(QPalette::Disabled, QPalette::ButtonText, color(spec.disabled_button_text));
+    pal.setColor(QPalette::Disabled, QPalette::HighlightedText, color(spec.disabled_text));
+    pal.setColor(QPalette::Disabled, QPalette::Highlight, color(spec.disabled_highlight));
+    return pal;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -1,0 +1,128 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * Applies a theme to the running QApplication and keeps it in step with the
+ * operating system color scheme.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/common_detail.hpp> // Must be the first include.
+
+#include <memory>
+#include <string>
+
+#include <solvcon/pilot/RTheme.hpp>
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <QObject>
+#include <QPalette>
+
+class QWidget;
+
+namespace solvcon
+{
+
+/**
+ * @brief Drives the pilot's look: the running platform's native style with a
+ * curated light or dark palette painted over it.
+ *
+ * @ingroup group_domain
+ *
+ * The manager owns the backend the factory built for the running platform. It
+ * installs that backend's style, builds a QPalette from the platform's own
+ * color table, folds in the platform accent when the backend exposes one, and
+ * applies native window chrome. In System mode it reads the operating system
+ * color scheme and follows changes to it live; Light and Dark pin the variant,
+ * carried by the palette where the platform cannot force it natively.
+ * themeChanged() fires after each application so widgets that cache colors can
+ * refresh.
+ */
+class RThemeManager
+    : public QObject
+{
+    Q_OBJECT
+
+public:
+
+    explicit RThemeManager(QObject * parent = nullptr);
+
+    ~RThemeManager() override;
+
+    /// Install the style if needed and paint the current mode's palette onto
+    /// the QApplication. Safe to call before any widget exists.
+    void apply();
+
+    /// Track the main window so native chrome can follow the theme. Applying
+    /// chrome at once keeps a window created before the first switch in step.
+    void setWindow(QWidget * window);
+
+    /// Switch the requested mode and re-apply. A no-op re-application is still
+    /// cheap, so callers need not compare against the current mode first.
+    void setMode(ThemeMode mode);
+
+    /// Switch mode by its string id ("system", "light", "dark"); an unknown id
+    /// falls back to System. Convenience for the Python console and menu.
+    void setModeById(std::string const & id);
+
+    ThemeMode mode() const { return m_mode; }
+
+    /// The concrete variant the current mode resolves to right now.
+    ThemeVariant currentVariant() const;
+
+    /// The running platform, naming the color table the theme draws from.
+    PlatformId platform() const;
+
+    /// What the running platform's theme can honor, for the interface to gate
+    /// the menu against.
+    ThemeCapabilities capabilities() const;
+
+    /// String id of the current mode, for the Python boundary.
+    std::string modeId() const;
+
+    /// "light" or "dark" for the current variant, for the Python boundary.
+    std::string variantId() const;
+
+signals:
+
+    /// Emitted after a palette is applied, carrying the resolved variant.
+    void themeChanged(ThemeVariant variant);
+
+private:
+
+    /// True when the operating system reports a dark color scheme. Unknown is
+    /// read as light, the conventional default.
+    bool osPrefersDark() const;
+
+    /// Hint the platform color scheme so native chrome tracks a forced mode. A
+    /// no-op on Qt below 6.8 and on desktops that do not honor the request,
+    /// such as most Linux ones, where the applied palette carries the theme.
+    void syncOsColorScheme();
+
+    /// Build a QPalette from a Qt-free color table, folding in the platform
+    /// accent when the backend supplies one, and filling the disabled group.
+    QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
+
+    ThemeMode m_mode = ThemeMode::System;
+
+    /// The running platform's backend, the only object that touches native
+    /// levers. Never null after construction.
+    std::unique_ptr<RThemeBackend> m_backend;
+
+    /// The main window, for native chrome. Non-owning; null until set.
+    QWidget * m_window = nullptr;
+
+    /// Guards the one-time style install, so repeated apply() calls do not
+    /// rebuild the style object.
+    bool m_style_installed = false;
+}; /* end class RThemeManager */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -10,6 +10,7 @@
 
 #include <solvcon/pilot/R2DWidget.hpp>
 #include <solvcon/pilot/RMenuModel.hpp>
+#include <solvcon/pilot/RThemeManager.hpp>
 #include <solvcon/pilot/pilot.hpp>
 
 #include <QAction>
@@ -884,6 +885,31 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 [](wrapped_type & self)
                 {
                     return self.menuModel();
+                })
+            .def(
+                "set_theme",
+                [](wrapped_type & self, std::string const & mode)
+                {
+                    self.themeManager()->setModeById(mode);
+                },
+                py::arg("mode"))
+            .def_property_readonly(
+                "theme_mode",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->modeId();
+                })
+            .def_property_readonly(
+                "theme_variant",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->variantId();
+                })
+            .def_property_readonly(
+                "theme_platform",
+                [](wrapped_type & self)
+                {
+                    return std::string(platformIdName(self.themeManager()->platform()));
                 })
             .def(
                 "quit",

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+import os
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from PySide6 import QtWidgets
+    from PySide6.QtGui import QPalette
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeManagerTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    def _window_lightness(self):
+        app = QtWidgets.QApplication.instance()
+        return app.palette().color(QPalette.Window).lightness()
+
+    def test_platform_is_recognized(self):
+        self.assertIn(self.mgr.theme_platform, ("linux", "mac", "windows"))
+
+    def test_dark_mode_paints_a_dark_window(self):
+        self.mgr.set_theme("dark")
+        self.assertEqual(self.mgr.theme_mode, "dark")
+        self.assertEqual(self.mgr.theme_variant, "dark")
+        self.assertLess(self._window_lightness(), 100)
+
+    def test_light_mode_paints_a_light_window(self):
+        self.mgr.set_theme("light")
+        self.assertEqual(self.mgr.theme_mode, "light")
+        self.assertEqual(self.mgr.theme_variant, "light")
+        self.assertGreater(self._window_lightness(), 150)
+
+    def test_switching_back_and_forth_repaints_each_time(self):
+        self.mgr.set_theme("dark")
+        dark = self._window_lightness()
+        self.mgr.set_theme("light")
+        light = self._window_lightness()
+        self.assertLess(dark, light)
+
+    def test_unknown_mode_falls_back_to_system(self):
+        self.mgr.set_theme("solarized")
+        self.assertEqual(self.mgr.theme_mode, "system")
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Second step of the pilot theme system. The Qt-free core is in place; this
step turns a color table into a running look and lays the seam each
platform's room plugs into. Stacked on wip/theme-step1.

## What this adds

- **`RThemeBackend`** interface: the Qt-and-native half a table cannot
  express, with one method each for the widget style to install, the OS
  accent to fold into the highlight, the window chrome no palette can
  reach, and the capability record. `makeThemeBackend()` is the single
  site of a platform preprocessor branch.
- **`DefaultThemeBackend`**: the fallback every platform starts on. It
  keeps the platform's own style and pulls no native levers, so the
  furnished rooms in later steps are pure additions.
- **`RThemeManager`** (the roof): owns the backend, installs its style,
  builds a `QPalette` from the running platform's table, folds in the
  accent when present, follows the OS color scheme, applies native
  chrome, and emits `themeChanged`. It exposes `platform()` and
  `capabilities()` for later steps to gate the menu against.
- **`RManager`** builds the manager before any widget exists and applies
  the theme up front, so every widget is created already themed; it
  tears the manager down before the application it drove.

## Scripting seam

`set_theme`, `theme_mode`, `theme_variant`, and `theme_platform` are
exposed to Python. The View menu, the MDI backdrop, and the console
follow in later steps.

## Tests

`test_pilot_theme.py` drives the manager end to end: the platform is
recognized, Light and Dark paint the window light and dark, switching
repaints each time, and an unknown mode falls back to Follow system.
Python suite and `make gtest` are green.