### PR TITLE
Add the View > Theme menu and follow it on the backdrop

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -18,6 +18,7 @@
 #include <QMenu>
 #include <QAction>
 #include <QActionGroup>
+#include <QColor>
 #include <QKeySequence>
 #include <QVBoxLayout>
 #include <QWidget>
@@ -340,6 +341,20 @@ void RManager::setUpCentral()
     // single Painter toolbox always drives whichever canvas has focus.
     QObject::connect(m_mdiArea, &QMdiArea::subWindowActivated, m_mdiArea, [this](QMdiSubWindow *)
                      { applyDrawTool(); });
+
+    // The MDI area paints its own backdrop instead of reading the palette, so
+    // drive it from the theme's window color and follow theme changes;
+    // otherwise a stale slab shows through under the dark theme. Take the color
+    // from the theme model, not m_mainWindow->palette(): when themeChanged fires
+    // the freshly set application palette has not yet propagated to the window,
+    // so palette() would lag one switch behind.
+    auto paintBackdrop = [this](ThemeVariant variant)
+    {
+        ThemeColor const c = themePaletteFor(m_themeManager->platform(), variant).window;
+        m_mdiArea->setBackground(QColor(c.r, c.g, c.b));
+    };
+    paintBackdrop(m_themeManager->currentVariant());
+    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, paintBackdrop);
 }
 
 void RManager::primeRhiComposition()
@@ -380,6 +395,7 @@ void RManager::setUpMenu()
     m_menuModel->menu("Window", 70);
 
     setUpEditMenuItems();
+    setUpThemeMenuItems();
     // Code for controlling camera is not exposed to Python yet.
     setUpCameraControllersMenuItems();
     setUpCameraMovementMenuItems();
@@ -408,6 +424,81 @@ void RManager::setUpEditMenuItems() const
 
     m_menuModel->place("Edit", undo_action, 10);
     m_menuModel->place("Edit", redo_action, 20);
+}
+
+void RManager::setUpThemeMenuItems() const
+{
+    struct ThemeItem
+    {
+        ThemeMode mode;
+        QString tip;
+    };
+    std::vector<ThemeItem> const items = {
+        {ThemeMode::System, QString("Follow the operating system light or dark setting")},
+        {ThemeMode::Light, QString("Use the light palette")},
+        {ThemeMode::Dark, QString("Use the dark palette")},
+    };
+
+    // A mode the running platform cannot honor is shown greyed rather than
+    // hidden, so the interface never offers a switch that does nothing and the
+    // reason stays visible.
+    ThemeCapabilities const caps = m_themeManager->capabilities();
+    auto honored = [&caps](ThemeMode mode)
+    {
+        switch (mode)
+        {
+        case ThemeMode::System:
+            return caps.can_follow_system;
+        case ThemeMode::Light:
+        case ThemeMode::Dark:
+        default:
+            return caps.can_force_variant;
+        }
+    };
+
+    // The group owns the exclusive mode, held by the model under a group id so
+    // Python can query the checked action, mirroring the camera controllers.
+    auto * themeGroup = m_menuModel->group("theme.mode");
+    int weight = 10;
+    for (auto const & item : items)
+    {
+        ThemeMode const mode = item.mode;
+        bool const enabled = honored(mode);
+        QString const tip = enabled
+                                ? item.tip
+                                : item.tip + QString(" (not available on this platform)");
+        auto * action = new RAction(
+            QString(themeModeLabel(mode)), tip, [this, mode]()
+            { m_themeManager->setMode(mode); },
+            m_menuModel);
+        action->setObjectName(QString("theme.mode_") + themeModeId(mode));
+        action->setCheckable(true);
+        action->setEnabled(enabled);
+        themeGroup->addAction(action);
+        m_menuModel->place("View/Theme", action, weight);
+        weight += 10;
+    }
+
+    // Keep the radio check in step with the manager whichever way the theme
+    // moves: a menu click, a console set_theme(), or an operating-system change
+    // while following the system. Parent the connection to the model so it dies
+    // with the menu.
+    QObject::connect(
+        m_themeManager,
+        &RThemeManager::themeChanged,
+        m_menuModel,
+        [this](ThemeVariant)
+        {
+            if (QAction * current = m_menuModel->action("theme.mode_" + m_themeManager->modeId()))
+            {
+                current->setChecked(true);
+            }
+        });
+
+    if (QAction * current = m_menuModel->action("theme.mode_" + m_themeManager->modeId()))
+    {
+        current->setChecked(true);
+    }
 }
 
 void RManager::setUpCameraControllersMenuItems() const

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -112,6 +112,7 @@ private:
     void applyDrawTool();
 
     void setUpEditMenuItems() const;
+    void setUpThemeMenuItems() const;
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementMenuItems() const;
 

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -59,4 +59,60 @@ class ThemeManagerTC(unittest.TestCase):
         self.assertEqual(self.mgr.theme_mode, "system")
 
 
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeMenuTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    def _window_lightness(self):
+        app = QtWidgets.QApplication.instance()
+        return app.palette().color(QPalette.Window).lightness()
+
+    def test_theme_menu_lists_the_three_modes(self):
+        items = [a.text() for a in self.model.menu("View/Theme").actions()]
+        self.assertEqual(items, ["Follow system", "Light", "Dark"])
+
+    def test_theme_group_is_exclusive_and_defaults_to_system(self):
+        group = self.model.group("theme.mode")
+        self.assertEqual(len(group.actions()), 3)
+        self.assertTrue(group.isExclusive())
+        checked = group.checkedAction()
+        self.assertIsNotNone(checked)
+        self.assertEqual(checked.objectName(), "theme.mode_system")
+
+    def test_honored_modes_are_enabled_on_this_platform(self):
+        # Linux, macOS, and Windows all follow the system and can force a
+        # variant, so every mode is offered rather than greyed.
+        for mode in ("system", "light", "dark"):
+            action = self.model.action("theme.mode_" + mode)
+            self.assertTrue(action.isEnabled())
+
+    def test_dark_action_paints_a_dark_window(self):
+        self.model.action("theme.mode_dark").trigger()
+        self.assertEqual(self.mgr.theme_mode, "dark")
+        self.assertEqual(self.mgr.theme_variant, "dark")
+        self.assertLess(self._window_lightness(), 100)
+
+    def test_light_action_paints_a_light_window(self):
+        self.model.action("theme.mode_light").trigger()
+        self.assertEqual(self.mgr.theme_mode, "light")
+        self.assertEqual(self.mgr.theme_variant, "light")
+        self.assertGreater(self._window_lightness(), 150)
+
+    def test_set_theme_keeps_the_menu_check_in_step(self):
+        self.mgr.set_theme("dark")
+        group = self.model.group("theme.mode")
+        # Scripting the theme should move the radio check too, so the menu
+        # never disagrees with the applied palette.
+        checked = group.checkedAction()
+        self.assertEqual(checked.objectName(), "theme.mode_dark")
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Third step of the pilot theme system. The manager can apply a theme;
this step gives the user a control for it. Stacked on wip/theme-step2.

## What this adds

- An exclusive **View > Theme** group: Follow system, Light, Dark. Each
  entry drives the manager, and a `themeChanged` connection keeps the
  radio check in step however the theme moves (a menu click, a console
  `set_theme()`, or an OS light/dark change while following the system).
- **Capability gating**: a mode the running platform cannot honor is
  shown greyed with a note rather than hidden, so the interface never
  offers a switch that does nothing. Every platform currently follows
  the system and can force a variant, so all three are offered.
- The **MDI backdrop** now follows the theme. It paints its own backdrop
  instead of reading the palette, so it is driven from the theme's
  window color and repainted on each switch; the color comes from the
  theme model rather than the window palette, which has not yet caught
  up when `themeChanged` fires.

## Tests

`test_pilot_theme.py` gains menu coverage: the three modes are listed in
order, the group is exclusive and defaults to Follow system, every
honored mode is enabled on this platform, triggering Dark/Light paints
the window and moves the check, and scripting `set_theme` keeps the menu
in step. Full Python suite green (1413 passed).