### PR TITLE
Make the Python console follow the theme

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -329,6 +329,16 @@ void RManager::setUpConsole()
     m_pycon = new RPythonConsoleDockWidget(QString("Console"), m_mainWindow);
     m_pycon->setAllowedAreas(Qt::AllDockWidgetAreas);
     m_mainWindow->addDockWidget(Qt::BottomDockWidgetArea, m_pycon);
+
+    // The console's syntax colors and bracket marker are not QPalette roles, so
+    // drive them from the theme directly. The theme was applied before this
+    // widget existed, so seed it now, then follow later switches.
+    auto applyConsoleTheme = [this](ThemeVariant variant)
+    {
+        m_pycon->applyTheme(syntaxColorsFor(m_themeManager->platform(), variant));
+    };
+    applyConsoleTheme(m_themeManager->currentVariant());
+    QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_pycon, applyConsoleTheme);
 }
 
 void RManager::setUpCentral()

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.cpp
@@ -147,7 +147,7 @@ void RPythonCommandTextEdit::highlightMatchingBracket()
         cursor.setPosition(position + 1, QTextCursor::KeepAnchor);
         QTextEdit::ExtraSelection selection;
         selection.cursor = cursor;
-        selection.format.setBackground(QColor(180, 180, 255));
+        selection.format.setBackground(m_bracket_match_color);
         selections.append(selection);
     };
 
@@ -171,6 +171,12 @@ void RPythonCommandTextEdit::highlightMatchingBracket()
     tryMatch(pos);
     tryMatch(pos - 1);
     setExtraSelections(selections);
+}
+
+void RPythonCommandTextEdit::setBracketMatchColor(QColor const & color)
+{
+    m_bracket_match_color = color;
+    highlightMatchingBracket();
 }
 
 // Tab-triggered auto-completion workflow:
@@ -297,16 +303,12 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     container->setLayout(layout);
     setWidget(container);
 
-    QPalette palette = QPalette();
-    palette.setColor(QPalette::Base, Qt::white);
-    palette.setColor(QPalette::Text, Qt::black);
-    palette.setColor(QPalette::PlaceholderText, Qt::darkGray);
-
+    // Leave the text colors to the application palette so the console follows
+    // the active light or dark theme instead of forcing black-on-white.
     m_history_edit->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_history_edit->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_history_edit->setFont(QFont("Courier New"));
     m_history_edit->setReadOnly(true);
-    m_history_edit->setPalette(palette);
     layout->addWidget(m_history_edit, /*stretch=*/1);
 
     constexpr int commandEditMinHeight = 40;
@@ -314,7 +316,6 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     m_command_edit->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_command_edit->setFont(QFont("Courier New"));
     m_command_edit->setFixedHeight(commandEditMinHeight);
-    m_command_edit->setPalette(palette);
     m_command_edit->setPlaceholderText("Shift+Enter to create new line. Enter to execute.");
     layout->addWidget(m_command_edit, /*stretch=*/0);
 
@@ -377,6 +378,13 @@ RPythonConsoleDockWidget::RPythonConsoleDockWidget(const QString & title, QWidge
     connect(m_command_edit, &RPythonCommandTextEdit::completionRequested, this, &RPythonConsoleDockWidget::handleCompletionRequest);
     connect(m_command_edit, &RPythonCommandTextEdit::callTipRequested, this, &RPythonConsoleDockWidget::handleCallTipRequest);
     connect(m_command_edit, &QTextEdit::textChanged, this, &RPythonConsoleDockWidget::updateCompletionPrefix);
+}
+
+void RPythonConsoleDockWidget::applyTheme(SyntaxColors const & colors)
+{
+    m_highlighter->applyColors(colors);
+    m_command_edit->setBracketMatchColor(
+        QColor(colors.bracket_match.r, colors.bracket_match.g, colors.bracket_match.b));
 }
 
 QString RPythonConsoleDockWidget::command() const

--- a/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
+++ b/cpp/solvcon/pilot/RPythonConsoleDockWidget.hpp
@@ -23,6 +23,7 @@
 #include <stdexcept>
 
 #include <Qt>
+#include <QColor>
 #include <QCompleter>
 #include <QDockWidget>
 #include <QStringListModel>
@@ -55,6 +56,10 @@ public:
     QString completionPrefix() const;
     QString callableExpression() const;
 
+    /// Set the wash painted behind a matched bracket pair and repaint it, so
+    /// the marker follows a light or dark theme switch.
+    void setBracketMatchColor(QColor const & color);
+
     void keyPressEvent(QKeyEvent * event) override;
 
 signals:
@@ -80,6 +85,10 @@ private:
 
     QCompleter * m_completer = nullptr;
     bool m_searching = false;
+
+    /// Background wash behind a matched bracket pair; the light table's value
+    /// until a theme is applied.
+    QColor m_bracket_match_color = QColor(180, 180, 255);
 
 }; /* end class RPythonCommandTextEdit */
 
@@ -135,6 +144,11 @@ public:
     }
 
     void writeToHistory(std::string const & data) const;
+
+    /// Point the syntax highlighter and the bracket marker at a theme's syntax
+    /// colors. The text itself follows the application palette; these are the
+    /// extra colors the palette does not cover.
+    void applyTheme(SyntaxColors const & colors);
 
 public slots:
     void executeCommand();

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.cpp
@@ -15,13 +15,24 @@ namespace solvcon
 RPythonSyntaxHighlighter::RPythonSyntaxHighlighter(QTextDocument * parent)
     : QSyntaxHighlighter(parent)
 {
-    m_keyword_format.setForeground(QColor(0, 0, 180));
+    // The weight and slant are constant across themes; only the colors follow
+    // the light or dark table, so set them here and defer color to applyColors.
     m_keyword_format.setFontWeight(QFont::Bold);
-    m_builtin_format.setForeground(QColor(0, 110, 110));
-    m_string_format.setForeground(QColor(160, 0, 0));
-    m_comment_format.setForeground(QColor(128, 128, 128));
     m_comment_format.setFontItalic(true);
-    m_number_format.setForeground(QColor(140, 0, 140));
+    applyColors(lightSyntaxColors());
+}
+
+void RPythonSyntaxHighlighter::applyColors(SyntaxColors const & colors)
+{
+    auto qc = [](ThemeColor c)
+    { return QColor(c.r, c.g, c.b); };
+
+    m_keyword_format.setForeground(qc(colors.keyword));
+    m_builtin_format.setForeground(qc(colors.builtin));
+    m_string_format.setForeground(qc(colors.string));
+    m_comment_format.setForeground(qc(colors.comment));
+    m_number_format.setForeground(qc(colors.number));
+    rehighlight();
 }
 
 void RPythonSyntaxHighlighter::highlightBlock(QString const & text)

--- a/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
+++ b/cpp/solvcon/pilot/RPythonSyntaxHighlighter.hpp
@@ -13,6 +13,8 @@
  * @ingroup group_domain
  */
 
+#include <solvcon/pilot/RTheme.hpp>
+
 #include <QSyntaxHighlighter>
 #include <QTextCharFormat>
 
@@ -34,6 +36,10 @@ class RPythonSyntaxHighlighter
 public:
 
     explicit RPythonSyntaxHighlighter(QTextDocument * parent);
+
+    /// Recolor every token category from a theme's syntax table and repaint,
+    /// so the console highlighting follows a light or dark switch.
+    void applyColors(SyntaxColors const & colors);
 
 protected:
 

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -115,4 +115,51 @@ class ThemeMenuTC(unittest.TestCase):
         self.assertEqual(checked.objectName(), "theme.mode_dark")
 
 
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeConsoleTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the default mode to
+        # keep the tests independent of the order they run in.
+        self.mgr.set_theme("system")
+
+    def _console_edits(self):
+        # The console's transcript and command editors are the QTextEdit
+        # instances in the pilot. Deliver the posted palette-change events and
+        # polish each so its palette resolves against the current application
+        # palette before it is read.
+        self.app.processEvents()
+        edits = [w for w in self.app.allWidgets()
+                 if isinstance(w, QtWidgets.QTextEdit)]
+        for edit in edits:
+            edit.ensurePolished()
+        return edits
+
+    def test_console_does_not_force_its_own_text_palette(self):
+        # The crux of the change: the console dropped its hardcoded
+        # black-on-white palette, so it never overrides the Text or Base brush
+        # and follows the application theme like every other widget.
+        active = QPalette.Active
+        for edit in self._console_edits():
+            palette = edit.palette()
+            self.assertFalse(palette.isBrushSet(active, QPalette.Text))
+            self.assertFalse(palette.isBrushSet(active, QPalette.Base))
+
+    def test_console_text_is_light_under_the_dark_theme(self):
+        self.mgr.set_theme("dark")
+        for edit in self._console_edits():
+            self.assertGreater(
+                edit.palette().color(QPalette.Text).lightness(), 150)
+
+    def test_console_text_is_dark_under_the_light_theme(self):
+        self.mgr.set_theme("light")
+        for edit in self._console_edits():
+            self.assertLess(
+                edit.palette().color(QPalette.Text).lightness(), 100)
+
+
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Fourth step of the pilot theme system. The application follows the theme,
but the Python console was the one widget left behind. Stacked on
wip/theme-step3.

## The problem

The console forced a black-on-white palette and a single set of syntax
colors tuned for a light background. So it glared white under a dark
window, and its tokens sank into the dark base after a switch.

## What this changes

- **Drop the console's hardcoded palette** so its text follows the
  application palette like every other widget.
- The syntax colors and the matching-bracket wash are not `QPalette`
  roles, so they are driven directly: the highlighter gains
  `applyColors()` to recolor every token category from a theme's syntax
  table, the command editor gains a settable bracket color, and the
  console gains `applyTheme()` that points both at the resolved variant's
  `SyntaxColors`.
- `RManager` seeds the console theme when the widget is built and
  refreshes it on every `themeChanged`.

## Tests

`test_pilot_theme.py` gains console coverage: the console no longer
overrides the Text or Base brush, and its editors resolve light text
under the dark theme and dark text under the light theme. Full Python
suite green (1416 passed).