### PR TITLE
Furnish the macOS room

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -62,6 +63,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RMenuModel.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/RMacThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RMacThemeBackend.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RMacThemeBackend.hpp>
+
+#include <QtGlobal>
+
+// The whole room is native to macOS, so the body compiles only there. On other
+// platforms this is an empty translation unit and the factory never names the
+// class.
+#if defined(Q_OS_MACOS)
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QColor>
+#include <QPalette>
+#include <QStyle>
+
+namespace solvcon
+{
+
+PlatformId RMacThemeBackend::platform() const
+{
+    return PlatformId::Mac;
+}
+
+std::string RMacThemeBackend::styleName() const
+{
+    return "macos";
+}
+
+std::optional<ThemeColor> RMacThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // The macos style's standard palette carries the user's system accent in
+    // the Accent role (Qt 6.6+), falling back to Highlight. Reading it from the
+    // style rather than the application palette keeps it independent of the
+    // curated palette the manager later applies over the top.
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RMacThemeBackend::applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/)
+{
+    // The color-scheme hint the manager sets flips the whole native appearance
+    // on Qt 6.8 and newer, title bar included, so there is no extra chrome to
+    // apply here.
+}
+
+ThemeCapabilities RMacThemeBackend::capabilities() const
+{
+    ThemeCapabilities caps = themeCapabilitiesFor(PlatformId::Mac);
+#if QT_VERSION < QT_VERSION_CHECK(6, 8, 0)
+    // Without the color-scheme hint the native appearance cannot be pinned, so
+    // a forced variant is carried only by the curated palette and the title bar
+    // stays on the operating system setting.
+    caps.controls_titlebar = false;
+#endif
+    return caps;
+}
+
+} /* end namespace solvcon */
+
+#endif /* defined(Q_OS_MACOS) */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RMacThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RMacThemeBackend.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The macOS room: the native theme backend for macOS.
+ *
+ * Installs the native macos style, reads the user's system accent, and leans
+ * on the color-scheme hint the manager sets to pin a variant, title bar
+ * included, on Qt 6.8 and newer. Only linked into the macOS build; the factory
+ * in RThemeBackend.cpp is the sole site that selects it.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The macOS native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RMacThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RMacThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -66,6 +66,62 @@ static ThemePalette makeDarkPalette()
     return p;
 }
 
+// The macOS tables follow the Aqua conventions: a near-white light window and
+// a deep neutral dark window, both a touch cooler than the shared curated
+// greys, paired with the system blue the platform defaults to. A running mac
+// backend replaces the highlight with the user's chosen accent; these values
+// are the fallback when no accent is read.
+
+static ThemePalette makeMacLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xec, 0xec, 0xec};
+    p.window_text = {0x1c, 0x1c, 0x1e};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf4, 0xf5, 0xf5};
+    p.text = {0x1c, 0x1c, 0x1e};
+    p.button = {0xf6, 0xf6, 0xf6};
+    p.button_text = {0x1c, 0x1c, 0x1e};
+    p.bright_text = {0xff, 0x3b, 0x30};
+    p.highlight = {0x00, 0x7a, 0xff};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xf9, 0xf9, 0xf9};
+    p.tool_tip_text = {0x1c, 0x1c, 0x1e};
+    p.placeholder_text = {0x9b, 0x9b, 0xa0};
+    p.link = {0x00, 0x66, 0xcc};
+    p.link_visited = {0x85, 0x4f, 0xd8};
+    p.disabled_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_button_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_window_text = {0xb0, 0xb0, 0xb4};
+    p.disabled_highlight = {0xc9, 0xc9, 0xcd};
+    return p;
+}
+
+static ThemePalette makeMacDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x28, 0x28, 0x2a};
+    p.window_text = {0xf2, 0xf2, 0xf7};
+    p.base = {0x1e, 0x1e, 0x1e};
+    p.alternate_base = {0x2a, 0x2a, 0x2c};
+    p.text = {0xf2, 0xf2, 0xf7};
+    p.button = {0x3a, 0x3a, 0x3c};
+    p.button_text = {0xf2, 0xf2, 0xf7};
+    p.bright_text = {0xff, 0x45, 0x3a};
+    p.highlight = {0x0a, 0x84, 0xff};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0x3a, 0x3a, 0x3c};
+    p.tool_tip_text = {0xf2, 0xf2, 0xf7};
+    p.placeholder_text = {0x8e, 0x8e, 0x93};
+    p.link = {0x41, 0x9c, 0xff};
+    p.link_visited = {0xbf, 0x5a, 0xf2};
+    p.disabled_text = {0x6b, 0x6b, 0x70};
+    p.disabled_button_text = {0x6b, 0x6b, 0x70};
+    p.disabled_window_text = {0x6b, 0x6b, 0x70};
+    p.disabled_highlight = {0x3a, 0x3a, 0x3c};
+    return p;
+}
+
 // The syntax colors keep the light table's familiar hues (a blue keyword, a
 // teal builtin, a red string, a magenta number) and lift each to a brighter,
 // lower-saturation tint for the dark table so the tokens read clearly on the
@@ -146,12 +202,32 @@ ThemePalette const & darkThemePalette()
     return palette;
 }
 
+static ThemePalette const & macLightThemePalette()
+{
+    static ThemePalette const palette = makeMacLightPalette();
+    return palette;
+}
+
+static ThemePalette const & macDarkThemePalette()
+{
+    static ThemePalette const palette = makeMacDarkPalette();
+    return palette;
+}
+
 ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant)
 {
-    // Every platform seeds from the curated tables; the platform rooms furnished
-    // in later steps replace this with their own tuned copies.
-    (void)platform;
-    return variant == ThemeVariant::Dark ? darkThemePalette() : lightThemePalette();
+    // macOS has its own room; the other platforms still draw from the shared
+    // curated tables until their rooms are furnished in later steps.
+    bool const dark = variant == ThemeVariant::Dark;
+    switch (platform)
+    {
+    case PlatformId::Mac:
+        return dark ? macDarkThemePalette() : macLightThemePalette();
+    case PlatformId::Windows:
+    case PlatformId::Linux:
+    default:
+        return dark ? darkThemePalette() : lightThemePalette();
+    }
 }
 
 SyntaxColors const & lightSyntaxColors()

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -7,6 +7,10 @@
 
 #include <QtGlobal>
 
+#if defined(Q_OS_MACOS)
+#include <solvcon/pilot/RMacThemeBackend.hpp>
+#endif
+
 namespace solvcon
 {
 
@@ -60,7 +64,7 @@ private:
 std::unique_ptr<RThemeBackend> makeThemeBackend()
 {
 #if defined(Q_OS_MACOS)
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Mac);
+    return std::make_unique<RMacThemeBackend>();
 #elif defined(Q_OS_WIN)
     return std::make_unique<DefaultThemeBackend>(PlatformId::Windows);
 #else

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -86,18 +86,40 @@ TEST(PilotThemePalette, LightAndDarkDifferAndAreConsistent)
 
 TEST(PilotThemePalette, EveryPlatformSelectsTheVariantTable)
 {
-    // The platform axis is seeded from the curated tables, so every platform
-    // resolves a variant to the same base table until its room is furnished.
-    // The lookup must still select the requested variant on each platform.
+    // Whatever table backs a platform, its light window must be brighter than
+    // its dark one, so the lookup never swaps a variant.
     for (PlatformId platform : {PlatformId::Linux, PlatformId::Mac, PlatformId::Windows})
     {
         EXPECT_GT(themePaletteFor(platform, ThemeVariant::Light).window.g,
                   themePaletteFor(platform, ThemeVariant::Dark).window.g);
+    }
+}
+
+TEST(PilotThemePalette, UnfurnishedPlatformsDrawFromTheCuratedTable)
+{
+    // Linux and Windows have no room yet, so they resolve to the shared curated
+    // tables. macOS is furnished, so it must not.
+    for (PlatformId platform : {PlatformId::Linux, PlatformId::Windows})
+    {
         EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Light).window.r,
                   lightThemePalette().window.r);
         EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Dark).window.r,
                   darkThemePalette().window.r);
     }
+}
+
+TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
+{
+    // The macOS room is tuned separately, so its window differs from the shared
+    // curated table in both variants, yet stays a light-on-top, dark-on-bottom
+    // pair.
+    auto const & mac_light = themePaletteFor(PlatformId::Mac, ThemeVariant::Light);
+    auto const & mac_dark = themePaletteFor(PlatformId::Mac, ThemeVariant::Dark);
+
+    EXPECT_NE(mac_light.window.r, lightThemePalette().window.r);
+    EXPECT_NE(mac_dark.window.r, darkThemePalette().window.r);
+    EXPECT_GT(mac_light.window.g, mac_dark.window.g);
+    EXPECT_LT(mac_light.text.g, mac_dark.text.g);
 }
 
 TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)


### PR DESCRIPTION
Fifth step of the pilot theme system: the first platform room. macOS
moves off the shared fallback onto its own native look. Stacked on
wip/theme-step4.

## What this adds

- A **macOS color table** tuned to the Aqua conventions: a near-white
  light window and a deep neutral dark window, both a touch cooler than
  the shared curated greys, with the system blue as the fallback accent.
  `themePaletteFor(Mac, ...)` routes to it.
- **`RMacThemeBackend`**: installs the native `macos` style, reads the
  user's system accent from the style's standard palette (so the
  highlight follows the platform accent), and reports its capabilities.
  Pinning a variant rides the color-scheme hint the manager already
  sets, which on Qt 6.8+ flips the whole native appearance, title bar
  included; on older Qt the capability record drops title-bar control and
  the curated palette carries the forced variant.
- The factory `makeThemeBackend()` selects it on macOS. The backend body
  compiles only on macOS; elsewhere it is an empty translation unit.

## Verification

The macOS **table** is pure data in the Qt-free core, so its
`test_nopython` cases run on every runner: the macOS window differs from
the curated table in both variants and stays a light-on-top pair
(`make gtest` green, 203 tests). The **native backend** is exercised by
the macOS CI, where it compiles and the render tests run. The Linux
Python suite is unchanged (1416 passed), since the running platform there
is still Linux.