### PR TITLE
Furnish the Windows room

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -27,6 +27,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -64,6 +65,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RTheme.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -122,6 +122,61 @@ static ThemePalette makeMacDarkPalette()
     return p;
 }
 
+// The Windows tables follow the Fluent conventions of Windows 11: a light
+// neutral window and a near-black dark window, with the default system blue as
+// the fallback accent. A running Windows backend replaces the highlight with
+// the operating system accent when it reads one.
+
+static ThemePalette makeWindowsLightPalette()
+{
+    ThemePalette p;
+    p.window = {0xf3, 0xf3, 0xf3};
+    p.window_text = {0x1a, 0x1a, 0x1a};
+    p.base = {0xff, 0xff, 0xff};
+    p.alternate_base = {0xf5, 0xf5, 0xf5};
+    p.text = {0x1a, 0x1a, 0x1a};
+    p.button = {0xfb, 0xfb, 0xfb};
+    p.button_text = {0x1a, 0x1a, 0x1a};
+    p.bright_text = {0xc4, 0x2b, 0x1c};
+    p.highlight = {0x00, 0x67, 0xc0};
+    p.highlighted_text = {0xff, 0xff, 0xff};
+    p.tool_tip_base = {0xf9, 0xf9, 0xf9};
+    p.tool_tip_text = {0x1a, 0x1a, 0x1a};
+    p.placeholder_text = {0x8a, 0x8a, 0x8a};
+    p.link = {0x00, 0x5a, 0x9e};
+    p.link_visited = {0x74, 0x4d, 0xa9};
+    p.disabled_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_button_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_window_text = {0xa8, 0xa8, 0xa8};
+    p.disabled_highlight = {0xcc, 0xcc, 0xcc};
+    return p;
+}
+
+static ThemePalette makeWindowsDarkPalette()
+{
+    ThemePalette p;
+    p.window = {0x20, 0x20, 0x20};
+    p.window_text = {0xf0, 0xf0, 0xf0};
+    p.base = {0x2b, 0x2b, 0x2b};
+    p.alternate_base = {0x30, 0x30, 0x30};
+    p.text = {0xf0, 0xf0, 0xf0};
+    p.button = {0x33, 0x33, 0x33};
+    p.button_text = {0xf0, 0xf0, 0xf0};
+    p.bright_text = {0xff, 0x99, 0x8a};
+    p.highlight = {0x4c, 0xc2, 0xff};
+    p.highlighted_text = {0x00, 0x00, 0x00};
+    p.tool_tip_base = {0x2b, 0x2b, 0x2b};
+    p.tool_tip_text = {0xf0, 0xf0, 0xf0};
+    p.placeholder_text = {0x9a, 0x9a, 0x9a};
+    p.link = {0x60, 0xcd, 0xff};
+    p.link_visited = {0xc5, 0x9a, 0xf0};
+    p.disabled_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_button_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_window_text = {0x6e, 0x6e, 0x6e};
+    p.disabled_highlight = {0x3a, 0x3a, 0x3a};
+    return p;
+}
+
 // The syntax colors keep the light table's familiar hues (a blue keyword, a
 // teal builtin, a red string, a magenta number) and lift each to a brighter,
 // lower-saturation tint for the dark table so the tokens read clearly on the
@@ -214,16 +269,29 @@ static ThemePalette const & macDarkThemePalette()
     return palette;
 }
 
+static ThemePalette const & windowsLightThemePalette()
+{
+    static ThemePalette const palette = makeWindowsLightPalette();
+    return palette;
+}
+
+static ThemePalette const & windowsDarkThemePalette()
+{
+    static ThemePalette const palette = makeWindowsDarkPalette();
+    return palette;
+}
+
 ThemePalette const & themePaletteFor(PlatformId platform, ThemeVariant variant)
 {
-    // macOS has its own room; the other platforms still draw from the shared
-    // curated tables until their rooms are furnished in later steps.
+    // macOS and Windows have their own rooms; Linux still draws from the shared
+    // curated tables until its room is furnished.
     bool const dark = variant == ThemeVariant::Dark;
     switch (platform)
     {
     case PlatformId::Mac:
         return dark ? macDarkThemePalette() : macLightThemePalette();
     case PlatformId::Windows:
+        return dark ? windowsDarkThemePalette() : windowsLightThemePalette();
     case PlatformId::Linux:
     default:
         return dark ? darkThemePalette() : lightThemePalette();

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -9,6 +9,8 @@
 
 #if defined(Q_OS_MACOS)
 #include <solvcon/pilot/RMacThemeBackend.hpp>
+#elif defined(Q_OS_WIN)
+#include <solvcon/pilot/RWindowsThemeBackend.hpp>
 #endif
 
 namespace solvcon
@@ -66,7 +68,7 @@ std::unique_ptr<RThemeBackend> makeThemeBackend()
 #if defined(Q_OS_MACOS)
     return std::make_unique<RMacThemeBackend>();
 #elif defined(Q_OS_WIN)
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Windows);
+    return std::make_unique<RWindowsThemeBackend>();
 #else
     return std::make_unique<DefaultThemeBackend>(PlatformId::Linux);
 #endif

--- a/cpp/solvcon/pilot/RWindowsThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RWindowsThemeBackend.cpp
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RWindowsThemeBackend.hpp>
+
+#include <QtGlobal>
+
+// The whole room is native to Windows, so the body compiles only there. On
+// other platforms this is an empty translation unit and the factory never names
+// the class.
+#if defined(Q_OS_WIN)
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QColor>
+#include <QGuiApplication>
+#include <QPalette>
+#include <QString>
+#include <QStyle>
+#include <QStyleFactory>
+#include <QWidget>
+
+#include <windows.h>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// The desktop window manager attribute that switches the title bar to its dark
+// variant. Defined here so the room needs no extra SDK header.
+constexpr DWORD kUseImmersiveDarkMode = 20;
+
+} /* end namespace */
+
+PlatformId RWindowsThemeBackend::platform() const
+{
+    return PlatformId::Windows;
+}
+
+std::string RWindowsThemeBackend::styleName() const
+{
+    // Prefer the Fluent windows11 style; fall back to windowsvista on the Qt
+    // builds that do not ship it.
+    if (QStyleFactory::keys().contains(QStringLiteral("windows11")))
+    {
+        return "windows11";
+    }
+    return "windowsvista";
+}
+
+std::optional<ThemeColor> RWindowsThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // The Windows style's standard palette carries the operating system accent
+    // in the Accent role (Qt 6.6+), falling back to Highlight. Reading it from
+    // the style keeps it independent of the curated palette applied over the
+    // top.
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RWindowsThemeBackend::applyNativeChrome(QWidget * window, ThemeVariant variant)
+{
+    if (window == nullptr)
+    {
+        return;
+    }
+
+    // Under the offscreen or minimal platform there is no native window to
+    // theme, so skip the call rather than reach for a handle that is not there.
+    QString const qpa = QGuiApplication::platformName();
+    if (qpa == QStringLiteral("offscreen") || qpa == QStringLiteral("minimal"))
+    {
+        return;
+    }
+
+    auto * const hwnd = reinterpret_cast<HWND>(window->winId());
+    if (hwnd == nullptr)
+    {
+        return;
+    }
+
+    // dwmapi is loaded at runtime so the room needs no extra link dependency.
+    HMODULE const dwm = LoadLibraryW(L"dwmapi.dll");
+    if (dwm == nullptr)
+    {
+        return;
+    }
+
+    using DwmSetWindowAttributeFn = HRESULT(WINAPI *)(HWND, DWORD, LPCVOID, DWORD);
+    auto * const set_attribute = reinterpret_cast<DwmSetWindowAttributeFn>(
+        GetProcAddress(dwm, "DwmSetWindowAttribute"));
+    if (set_attribute != nullptr)
+    {
+        BOOL const dark = (variant == ThemeVariant::Dark) ? TRUE : FALSE;
+        set_attribute(hwnd, kUseImmersiveDarkMode, &dark, sizeof(dark));
+    }
+    FreeLibrary(dwm);
+}
+
+ThemeCapabilities RWindowsThemeBackend::capabilities() const
+{
+    // The title bar switches through the desktop window manager on every Qt
+    // version, and the curated palette carries a forced variant where the
+    // color-scheme hint is a no-op, so the seeded record already holds.
+    return themeCapabilitiesFor(PlatformId::Windows);
+}
+
+} /* end namespace solvcon */
+
+#endif /* defined(Q_OS_WIN) */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RWindowsThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RWindowsThemeBackend.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The Windows room: the native theme backend for Windows.
+ *
+ * Installs the windows11 style (falling back to windowsvista), reads the
+ * operating system accent, and switches the title bar to its dark variant
+ * through the desktop window manager. Only linked into the Windows build; the
+ * factory in RThemeBackend.cpp is the sole site that selects it.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The Windows native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RWindowsThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RWindowsThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -97,15 +97,11 @@ TEST(PilotThemePalette, EveryPlatformSelectsTheVariantTable)
 
 TEST(PilotThemePalette, UnfurnishedPlatformsDrawFromTheCuratedTable)
 {
-    // Linux and Windows have no room yet, so they resolve to the shared curated
-    // tables. macOS is furnished, so it must not.
-    for (PlatformId platform : {PlatformId::Linux, PlatformId::Windows})
-    {
-        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Light).window.r,
-                  lightThemePalette().window.r);
-        EXPECT_EQ(themePaletteFor(platform, ThemeVariant::Dark).window.r,
-                  darkThemePalette().window.r);
-    }
+    // Linux has no room yet, so it resolves to the shared curated tables.
+    EXPECT_EQ(themePaletteFor(PlatformId::Linux, ThemeVariant::Light).window.r,
+              lightThemePalette().window.r);
+    EXPECT_EQ(themePaletteFor(PlatformId::Linux, ThemeVariant::Dark).window.r,
+              darkThemePalette().window.r);
 }
 
 TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
@@ -120,6 +116,20 @@ TEST(PilotThemeMacRoom, HasItsOwnTableDistinctFromTheCurated)
     EXPECT_NE(mac_dark.window.r, darkThemePalette().window.r);
     EXPECT_GT(mac_light.window.g, mac_dark.window.g);
     EXPECT_LT(mac_light.text.g, mac_dark.text.g);
+}
+
+TEST(PilotThemeWindowsRoom, HasItsOwnTableDistinctFromTheCuratedAndMac)
+{
+    // The Windows room is tuned separately, so its dark window differs from both
+    // the curated and the macOS tables, and it stays a light-on-top pair.
+    auto const & win_light = themePaletteFor(PlatformId::Windows, ThemeVariant::Light);
+    auto const & win_dark = themePaletteFor(PlatformId::Windows, ThemeVariant::Dark);
+    auto const & mac_dark = themePaletteFor(PlatformId::Mac, ThemeVariant::Dark);
+
+    EXPECT_NE(win_dark.window.r, darkThemePalette().window.r);
+    EXPECT_NE(win_dark.window.r, mac_dark.window.r);
+    EXPECT_GT(win_light.window.g, win_dark.window.g);
+    EXPECT_LT(win_light.text.g, win_dark.text.g);
 }
 
 TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)


### PR DESCRIPTION
Sixth step of the pilot theme system: the Windows room. Stacked on
wip/theme-step5.

## What this adds

- A **Windows color table** in the Fluent conventions of Windows 11: a
  light neutral window and a near-black dark window, with the default
  system blue as the fallback accent. `themePaletteFor(Windows, ...)`
  routes to it.
- **`RWindowsThemeBackend`**: installs the `windows11` style (falling
  back to `windowsvista` where absent), reads the OS accent from the
  style's standard palette, and switches the title bar to its dark
  variant through the desktop window manager
  (`DWMWA_USE_IMMERSIVE_DARK_MODE`). The chrome call loads `dwmapi` at
  runtime, so the room needs no extra link dependency, and it is skipped
  under the offscreen and minimal platforms where there is no native
  window.
- The factory `makeThemeBackend()` selects it on Windows. The backend
  body compiles only on Windows; elsewhere it is an empty translation
  unit.

## Verification

The Windows **table** is pure data in the Qt-free core, so its
`test_nopython` cases run on every runner: the Windows dark window
differs from both the curated and the macOS tables and stays a
light-on-top pair (`make gtest` green, 204 tests). The **native backend**
(style selection, DWM title bar) is exercised by the Windows CI, which
renders through WARP. The Linux Python suite is unchanged (1416 passed).