### PR TITLE
Furnish the Linux room

### DIFF
--- a/cpp/solvcon/pilot/CMakeLists.txt
+++ b/cpp/solvcon/pilot/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOLVCON_PILOT_PYMODHEADERS
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.hpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.hpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.hpp
@@ -66,6 +67,7 @@ set(SOLVCON_PILOT_PYMODSOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RMacThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RWindowsThemeBackend.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/RLinuxThemeBackend.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RThemeManager.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleDockWidget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/RPythonConsoleHistory.cpp

--- a/cpp/solvcon/pilot/RLinuxThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RLinuxThemeBackend.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+#include <solvcon/pilot/RLinuxThemeBackend.hpp>
+
+#include <cstdint>
+
+#include <QApplication>
+#include <QByteArray>
+#include <QColor>
+#include <QPalette>
+#include <QStyle>
+#include <QtGlobal>
+
+namespace solvcon
+{
+
+namespace
+{
+
+// Whether the running desktop names a Qt platform theme the room honors, read
+// from the environment through the Qt-free recognizer.
+bool desktopHasNativeTheme()
+{
+    QByteArray const desktop = qgetenv("XDG_CURRENT_DESKTOP");
+    return linuxDesktopHasNativeTheme(desktop.isEmpty() ? nullptr : desktop.constData());
+}
+
+} /* end namespace */
+
+PlatformId RLinuxThemeBackend::platform() const
+{
+    return PlatformId::Linux;
+}
+
+std::string RLinuxThemeBackend::styleName() const
+{
+    // Keep the desktop's own Qt style so the pilot looks native; an empty name
+    // tells the manager to leave the installed style alone.
+    return {};
+}
+
+std::optional<ThemeColor> RLinuxThemeBackend::accentColor(ThemeVariant /*variant*/) const
+{
+    // Only a recognized desktop is trusted to expose an accent worth honoring;
+    // elsewhere the curated highlight stays.
+    if (!desktopHasNativeTheme())
+    {
+        return std::nullopt;
+    }
+
+    QStyle * style = QApplication::style();
+    if (style == nullptr)
+    {
+        return std::nullopt;
+    }
+
+    QPalette const platform = style->standardPalette();
+    QColor accent;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    accent = platform.color(QPalette::Accent);
+#endif
+    if (!accent.isValid())
+    {
+        accent = platform.color(QPalette::Highlight);
+    }
+    if (!accent.isValid())
+    {
+        return std::nullopt;
+    }
+    return ThemeColor{static_cast<std::uint8_t>(accent.red()),
+                      static_cast<std::uint8_t>(accent.green()),
+                      static_cast<std::uint8_t>(accent.blue())};
+}
+
+void RLinuxThemeBackend::applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/)
+{
+    // Linux window managers own the title bar, so there is no chrome to apply.
+}
+
+ThemeCapabilities RLinuxThemeBackend::capabilities() const
+{
+    ThemeCapabilities caps = themeCapabilitiesFor(PlatformId::Linux);
+    // The accent is only genuinely native on a recognized desktop; elsewhere
+    // the highlight is the curated one, so report that plainly.
+    caps.has_native_accent = desktopHasNativeTheme();
+    return caps;
+}
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RLinuxThemeBackend.hpp
+++ b/cpp/solvcon/pilot/RLinuxThemeBackend.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+/*
+ * Copyright (c) 2026, solvcon team <contact@solvcon.net>
+ * BSD 3-Clause License, see COPYING
+ */
+
+/**
+ * @file
+ * The Linux room: the native theme backend for Linux and other desktops.
+ *
+ * Keeps the desktop's own Qt style, honors the desktop accent when a
+ * recognized platform theme exposes one, and otherwise leans on the curated
+ * palettes. It is the room with the most variety across desktops, so it leans
+ * hardest on the shared fallback. This is also the factory's default, selected
+ * for any platform without a room of its own.
+ *
+ * @ingroup group_domain
+ */
+
+#include <solvcon/pilot/RThemeBackend.hpp>
+
+#include <optional>
+#include <string>
+
+namespace solvcon
+{
+
+/**
+ * @brief The Linux native theme backend.
+ *
+ * @ingroup group_domain
+ */
+class RLinuxThemeBackend
+    : public RThemeBackend
+{
+
+public:
+
+    PlatformId platform() const override;
+    std::string styleName() const override;
+    std::optional<ThemeColor> accentColor(ThemeVariant variant) const override;
+    void applyNativeChrome(QWidget * window, ThemeVariant variant) override;
+    ThemeCapabilities capabilities() const override;
+
+}; /* end class RLinuxThemeBackend */
+
+} /* end namespace solvcon */
+
+// vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -5,7 +5,9 @@
 
 #include <solvcon/pilot/RTheme.hpp>
 
+#include <cctype>
 #include <cstring>
+#include <string>
 
 namespace solvcon
 {
@@ -404,6 +406,24 @@ char const * platformIdName(PlatformId platform)
     default:
         return "linux";
     }
+}
+
+bool linuxDesktopHasNativeTheme(char const * xdg_current_desktop)
+{
+    if (xdg_current_desktop == nullptr)
+    {
+        return false;
+    }
+
+    // XDG_CURRENT_DESKTOP is a colon-separated, case-varying list such as
+    // "ubuntu:GNOME" or "KDE", so fold to lower case and look for a name whose
+    // Qt platform theme is worth honoring.
+    std::string desktop(xdg_current_desktop);
+    for (char & c : desktop)
+    {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return desktop.find("gnome") != std::string::npos || desktop.find("kde") != std::string::npos;
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RTheme.hpp
+++ b/cpp/solvcon/pilot/RTheme.hpp
@@ -201,6 +201,17 @@ ThemeMode themeModeFromId(char const * id);
 /// the Python boundary and in tests.
 char const * platformIdName(PlatformId platform);
 
+/**
+ * @brief Whether a Linux desktop names a theme the pilot recognizes.
+ *
+ * Reads the value of XDG_CURRENT_DESKTOP and reports true for GNOME or KDE,
+ * whose Qt platform themes expose a palette and an accent worth honoring. An
+ * empty or unrecognized value returns false, so the Linux room falls back to
+ * the curated palettes. The matching is Qt-free so it is tested on every
+ * runner.
+ */
+bool linuxDesktopHasNativeTheme(char const * xdg_current_desktop);
+
 } /* end namespace solvcon */
 
 // vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/cpp/solvcon/pilot/RThemeBackend.cpp
+++ b/cpp/solvcon/pilot/RThemeBackend.cpp
@@ -5,6 +5,8 @@
 
 #include <solvcon/pilot/RThemeBackend.hpp>
 
+#include <solvcon/pilot/RLinuxThemeBackend.hpp>
+
 #include <QtGlobal>
 
 #if defined(Q_OS_MACOS)
@@ -16,53 +18,6 @@
 namespace solvcon
 {
 
-namespace
-{
-
-/**
- * @brief The fallback backend: it keeps the platform's own default style and
- * pulls no native levers.
- *
- * Every platform starts here and is replaced by its furnished room in a later
- * step. Keeping the default style already gives each platform its native
- * widgets; the room adds the accent, the title bar, and an explicit style
- * choice on top.
- */
-class DefaultThemeBackend
-    : public RThemeBackend
-{
-
-public:
-
-    explicit DefaultThemeBackend(PlatformId platform)
-        : m_platform(platform)
-    {
-    }
-
-    PlatformId platform() const override { return m_platform; }
-
-    std::string styleName() const override { return {}; }
-
-    std::optional<ThemeColor> accentColor(ThemeVariant /*variant*/) const override
-    {
-        return std::nullopt;
-    }
-
-    void applyNativeChrome(QWidget * /*window*/, ThemeVariant /*variant*/) override {}
-
-    ThemeCapabilities capabilities() const override
-    {
-        return themeCapabilitiesFor(m_platform);
-    }
-
-private:
-
-    PlatformId m_platform;
-
-}; /* end class DefaultThemeBackend */
-
-} /* end namespace */
-
 std::unique_ptr<RThemeBackend> makeThemeBackend()
 {
 #if defined(Q_OS_MACOS)
@@ -70,7 +25,8 @@ std::unique_ptr<RThemeBackend> makeThemeBackend()
 #elif defined(Q_OS_WIN)
     return std::make_unique<RWindowsThemeBackend>();
 #else
-    return std::make_unique<DefaultThemeBackend>(PlatformId::Linux);
+    // Linux, and every other desktop without a room of its own, land here.
+    return std::make_unique<RLinuxThemeBackend>();
 #endif
 }
 

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -13,6 +13,7 @@ using solvcon::darkSyntaxColors;
 using solvcon::darkThemePalette;
 using solvcon::lightSyntaxColors;
 using solvcon::lightThemePalette;
+using solvcon::linuxDesktopHasNativeTheme;
 using solvcon::PlatformId;
 using solvcon::platformIdName;
 using solvcon::resolveThemeVariant;
@@ -156,6 +157,22 @@ TEST(PilotThemeSyntax, DarkTokensAreBrighterAndSelectByVariant)
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Light).keyword.b, light.keyword.b);
         EXPECT_EQ(syntaxColorsFor(platform, ThemeVariant::Dark).keyword.b, dark.keyword.b);
     }
+}
+
+TEST(PilotThemeLinuxRoom, RecognizesGnomeAndKdeDesktops)
+{
+    // GNOME and KDE expose a Qt platform theme the room honors; the value may
+    // be a colon-separated, mixed-case list.
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("GNOME"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("ubuntu:GNOME"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("KDE"));
+    EXPECT_TRUE(linuxDesktopHasNativeTheme("kde"));
+
+    // An unrecognized, empty, or missing desktop falls back to the curated
+    // palettes.
+    EXPECT_FALSE(linuxDesktopHasNativeTheme("XFCE"));
+    EXPECT_FALSE(linuxDesktopHasNativeTheme(""));
+    EXPECT_FALSE(linuxDesktopHasNativeTheme(nullptr));
 }
 
 TEST(PilotThemeCapabilities, DifferByPlatform)


### PR DESCRIPTION
Seventh step of the pilot theme system: the Linux room, the last of the
three. Stacked on wip/theme-step6.

## What this adds

- **`RLinuxThemeBackend`**: keeps the desktop's own Qt style so the pilot
  looks native, honors the desktop accent when a recognized platform
  theme exposes one, and otherwise falls back to the curated palettes and
  reports no native accent. Linux window managers own the title bar, so
  there is no chrome to apply.
- **`linuxDesktopHasNativeTheme()`**: a Qt-free reader of
  `XDG_CURRENT_DESKTOP` that reports true for GNOME or KDE, whose Qt
  platform themes expose a palette and accent worth honoring. Being
  Qt-free, it is unit tested on every runner.
- With all three rooms furnished, the factory no longer needs the
  placeholder `DefaultThemeBackend`, so it is dropped and the Linux
  backend becomes the default for any platform without a room of its own.

## Verification

This is the one room that builds and runs on the Linux CI, so it is
exercised directly: `make gtest` covers the desktop recognizer (205
tests), and the Linux Python theme suite drives the running backend end
to end (1416 passed). `clang-tidy` runs over the full backend here, since
its body is portable rather than platform-guarded.