### PR TITLE
Expose the system-versus-curated look choice

### DIFF
--- a/cpp/solvcon/pilot/RManager.cpp
+++ b/cpp/solvcon/pilot/RManager.cpp
@@ -353,15 +353,14 @@ void RManager::setUpCentral()
                      { applyDrawTool(); });
 
     // The MDI area paints its own backdrop instead of reading the palette, so
-    // drive it from the theme's window color and follow theme changes;
-    // otherwise a stale slab shows through under the dark theme. Take the color
-    // from the theme model, not m_mainWindow->palette(): when themeChanged fires
-    // the freshly set application palette has not yet propagated to the window,
-    // so palette() would lag one switch behind.
-    auto paintBackdrop = [this](ThemeVariant variant)
+    // drive it from the theme's effective window color and follow theme
+    // changes; otherwise a stale slab shows through under the dark theme. Read
+    // the color the manager just applied, whether curated or native, rather
+    // than m_mainWindow->palette(), which lags a switch behind when themeChanged
+    // fires.
+    auto paintBackdrop = [this](ThemeVariant)
     {
-        ThemeColor const c = themePaletteFor(m_themeManager->platform(), variant).window;
-        m_mdiArea->setBackground(QColor(c.r, c.g, c.b));
+        m_mdiArea->setBackground(m_themeManager->windowColor());
     };
     paintBackdrop(m_themeManager->currentVariant());
     QObject::connect(m_themeManager, &RThemeManager::themeChanged, m_mdiArea, paintBackdrop);
@@ -506,6 +505,66 @@ void RManager::setUpThemeMenuItems() const
         });
 
     if (QAction * current = m_menuModel->action("theme.mode_" + m_themeManager->modeId()))
+    {
+        current->setChecked(true);
+    }
+
+    setUpThemeLookItems();
+}
+
+void RManager::setUpThemeLookItems() const
+{
+    struct LookItem
+    {
+        ThemeLook look;
+        QString tip;
+    };
+    std::vector<LookItem> const items = {
+        {ThemeLook::System, QString("Show the platform's own colors through the native style")},
+        {ThemeLook::Curated, QString("Apply the curated palette for a look that travels between machines")},
+    };
+
+    // Showing the platform's own colors needs a native style to show them
+    // through; where there is none the choice is greyed and the curated look
+    // stands alone.
+    ThemeCapabilities const caps = m_themeManager->capabilities();
+    auto honored = [&caps](ThemeLook look)
+    { return look == ThemeLook::Curated || caps.has_native_style; };
+
+    auto * lookGroup = m_menuModel->group("theme.look");
+    int weight = 110;
+    for (auto const & item : items)
+    {
+        ThemeLook const look = item.look;
+        bool const enabled = honored(look);
+        QString const tip = enabled
+                                ? item.tip
+                                : item.tip + QString(" (not available on this platform)");
+        auto * action = new RAction(
+            QString(themeLookLabel(look)), tip, [this, look]()
+            { m_themeManager->setLook(look); },
+            m_menuModel);
+        action->setObjectName(QString("theme.look_") + themeLookId(look));
+        action->setCheckable(true);
+        action->setEnabled(enabled);
+        lookGroup->addAction(action);
+        m_menuModel->place("View/Theme", action, weight);
+        weight += 10;
+    }
+
+    QObject::connect(
+        m_themeManager,
+        &RThemeManager::themeChanged,
+        m_menuModel,
+        [this](ThemeVariant)
+        {
+            if (QAction * current = m_menuModel->action("theme.look_" + m_themeManager->lookId()))
+            {
+                current->setChecked(true);
+            }
+        });
+
+    if (QAction * current = m_menuModel->action("theme.look_" + m_themeManager->lookId()))
     {
         current->setChecked(true);
     }

--- a/cpp/solvcon/pilot/RManager.hpp
+++ b/cpp/solvcon/pilot/RManager.hpp
@@ -113,6 +113,7 @@ private:
 
     void setUpEditMenuItems() const;
     void setUpThemeMenuItems() const;
+    void setUpThemeLookItems() const;
     void setUpCameraControllersMenuItems() const;
     void setUpCameraMovementMenuItems() const;
 

--- a/cpp/solvcon/pilot/RTheme.cpp
+++ b/cpp/solvcon/pilot/RTheme.cpp
@@ -394,6 +394,25 @@ ThemeMode themeModeFromId(char const * id)
     return ThemeMode::System;
 }
 
+char const * themeLookId(ThemeLook look)
+{
+    return look == ThemeLook::System ? "system" : "curated";
+}
+
+char const * themeLookLabel(ThemeLook look)
+{
+    return look == ThemeLook::System ? "System colors" : "Curated colors";
+}
+
+ThemeLook themeLookFromId(char const * id)
+{
+    if (id != nullptr && 0 == std::strcmp(id, "system"))
+    {
+        return ThemeLook::System;
+    }
+    return ThemeLook::Curated;
+}
+
 char const * platformIdName(PlatformId platform)
 {
     switch (platform)

--- a/cpp/solvcon/pilot/RTheme.hpp
+++ b/cpp/solvcon/pilot/RTheme.hpp
@@ -47,6 +47,20 @@ enum class ThemeVariant
 };
 
 /**
+ * @brief Where the pilot's colors come from, independent of the light or dark
+ * mode.
+ *
+ * System lets the running platform's own colors show through the native style
+ * untouched; Curated paints the plan's palettes over that style for a
+ * controlled look that travels between machines.
+ */
+enum class ThemeLook
+{
+    System,
+    Curated,
+};
+
+/**
  * @brief The platform a color table and a capability record are written for.
  *
  * The palette lookup carries this axis so each platform's look is tuned in its
@@ -196,6 +210,16 @@ char const * themeModeLabel(ThemeMode mode);
 
 /// The mode named by @p id, or ThemeMode::System when @p id matches none.
 ThemeMode themeModeFromId(char const * id);
+
+/// The stable identifier for a look ("system", "curated"), used as the menu
+/// action object name, at the Python boundary, and in tests.
+char const * themeLookId(ThemeLook look);
+
+/// The human-readable menu label for a look.
+char const * themeLookLabel(ThemeLook look);
+
+/// The look named by @p id, or ThemeLook::Curated when @p id matches none.
+ThemeLook themeLookFromId(char const * id);
 
 /// The stable identifier for a platform ("linux", "mac", "windows"), used at
 /// the Python boundary and in tests.

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -8,6 +8,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QGuiApplication>
+#include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
 #include <QString>
@@ -64,8 +65,22 @@ void RThemeManager::apply()
     }
 
     ThemeVariant const variant = currentVariant();
-    QApplication::setPalette(
-        buildPalette(themePaletteFor(m_backend->platform(), variant), variant));
+    if (m_look == ThemeLook::System)
+    {
+        // Let the platform's own colors show through the native style. The
+        // color-scheme hint has already steered the style toward the requested
+        // variant, so its standard palette carries the right light or dark set.
+        QPalette const native = QApplication::style()->standardPalette();
+        m_window_color = native.color(QPalette::Window);
+        QApplication::setPalette(native);
+    }
+    else
+    {
+        QPalette const curated =
+            buildPalette(themePaletteFor(m_backend->platform(), variant), variant);
+        m_window_color = curated.color(QPalette::Window);
+        QApplication::setPalette(curated);
+    }
     if (m_window != nullptr)
     {
         m_backend->applyNativeChrome(m_window, variant);
@@ -94,6 +109,17 @@ void RThemeManager::setModeById(std::string const & id)
     setMode(themeModeFromId(id.c_str()));
 }
 
+void RThemeManager::setLook(ThemeLook look)
+{
+    m_look = look;
+    apply();
+}
+
+void RThemeManager::setLookById(std::string const & id)
+{
+    setLook(themeLookFromId(id.c_str()));
+}
+
 ThemeVariant RThemeManager::currentVariant() const
 {
     return resolveThemeVariant(m_mode, osPrefersDark());
@@ -112,6 +138,11 @@ ThemeCapabilities RThemeManager::capabilities() const
 std::string RThemeManager::modeId() const
 {
     return themeModeId(m_mode);
+}
+
+std::string RThemeManager::lookId() const
+{
+    return themeLookId(m_look);
 }
 
 std::string RThemeManager::variantId() const

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -21,6 +21,7 @@
 #include <solvcon/pilot/RTheme.hpp>
 #include <solvcon/pilot/RThemeBackend.hpp>
 
+#include <QColor>
 #include <QObject>
 #include <QPalette>
 
@@ -71,7 +72,17 @@ public:
     /// falls back to System. Convenience for the Python console and menu.
     void setModeById(std::string const & id);
 
+    /// Switch where the colors come from and re-apply. System shows the
+    /// platform's own colors; Curated paints the plan's palettes over them.
+    void setLook(ThemeLook look);
+
+    /// Switch look by its string id ("system", "curated"); an unknown id falls
+    /// back to Curated.
+    void setLookById(std::string const & id);
+
     ThemeMode mode() const { return m_mode; }
+
+    ThemeLook look() const { return m_look; }
 
     /// The concrete variant the current mode resolves to right now.
     ThemeVariant currentVariant() const;
@@ -86,8 +97,16 @@ public:
     /// String id of the current mode, for the Python boundary.
     std::string modeId() const;
 
+    /// String id of the current look, for the Python boundary.
+    std::string lookId() const;
+
     /// "light" or "dark" for the current variant, for the Python boundary.
     std::string variantId() const;
+
+    /// The Window color of the palette in effect, whether curated or native, so
+    /// widgets that paint their own backdrop can match it without lagging a
+    /// switch behind the application palette.
+    QColor windowColor() const { return m_window_color; }
 
 signals:
 
@@ -110,6 +129,14 @@ private:
     QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
 
     ThemeMode m_mode = ThemeMode::System;
+
+    /// Where the colors come from. Curated is the controlled default; System is
+    /// opted into for the platform's own colors.
+    ThemeLook m_look = ThemeLook::Curated;
+
+    /// The Window color of the palette last applied, cached so the backdrop can
+    /// read it without waiting for the application palette to propagate.
+    QColor m_window_color;
 
     /// The running platform's backend, the only object that touches native
     /// levers. Never null after construction.

--- a/cpp/solvcon/pilot/wrap_pilot.cpp
+++ b/cpp/solvcon/pilot/wrap_pilot.cpp
@@ -905,6 +905,19 @@ class SOLVCON_PYTHON_WRAPPER_VISIBILITY WrapRManager
                 {
                     return self.themeManager()->variantId();
                 })
+            .def(
+                "set_look",
+                [](wrapped_type & self, std::string const & look)
+                {
+                    self.themeManager()->setLookById(look);
+                },
+                py::arg("look"))
+            .def_property_readonly(
+                "theme_look",
+                [](wrapped_type & self)
+                {
+                    return self.themeManager()->lookId();
+                })
             .def_property_readonly(
                 "theme_platform",
                 [](wrapped_type & self)

--- a/gtests/test_nopython_pilot_theme.cpp
+++ b/gtests/test_nopython_pilot_theme.cpp
@@ -19,6 +19,10 @@ using solvcon::platformIdName;
 using solvcon::resolveThemeVariant;
 using solvcon::syntaxColorsFor;
 using solvcon::themeCapabilitiesFor;
+using solvcon::ThemeLook;
+using solvcon::themeLookFromId;
+using solvcon::themeLookId;
+using solvcon::themeLookLabel;
 using solvcon::ThemeMode;
 using solvcon::themeModeFromId;
 using solvcon::themeModeId;
@@ -62,6 +66,22 @@ TEST(PilotThemeId, EveryModeHasALabel)
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::System)).size(), 0U);
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::Light)).size(), 0U);
     EXPECT_GT(std::string(themeModeLabel(ThemeMode::Dark)).size(), 0U);
+}
+
+TEST(PilotThemeLook, RoundTripsThroughItsId)
+{
+    EXPECT_EQ(std::string("system"), themeLookId(ThemeLook::System));
+    EXPECT_EQ(std::string("curated"), themeLookId(ThemeLook::Curated));
+
+    EXPECT_EQ(themeLookFromId("system"), ThemeLook::System);
+    EXPECT_EQ(themeLookFromId("curated"), ThemeLook::Curated);
+
+    // An unknown look falls back to Curated, the controlled default.
+    EXPECT_EQ(themeLookFromId("native"), ThemeLook::Curated);
+    EXPECT_EQ(themeLookFromId(nullptr), ThemeLook::Curated);
+
+    EXPECT_GT(std::string(themeLookLabel(ThemeLook::System)).size(), 0U);
+    EXPECT_GT(std::string(themeLookLabel(ThemeLook::Curated)).size(), 0U);
 }
 
 TEST(PilotThemePlatform, EveryPlatformHasAName)

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -76,7 +76,10 @@ class ThemeMenuTC(unittest.TestCase):
         return app.palette().color(QPalette.Window).lightness()
 
     def test_theme_menu_lists_the_three_modes(self):
-        items = [a.text() for a in self.model.menu("View/Theme").actions()]
+        # The Theme menu also carries the look choices, so filter to the mode
+        # actions by their object-name prefix.
+        items = [a.text() for a in self.model.menu("View/Theme").actions()
+                 if a.objectName().startswith("theme.mode_")]
         self.assertEqual(items, ["Follow system", "Light", "Dark"])
 
     def test_theme_group_is_exclusive_and_defaults_to_system(self):
@@ -113,6 +116,57 @@ class ThemeMenuTC(unittest.TestCase):
         # never disagrees with the applied palette.
         checked = group.checkedAction()
         self.assertEqual(checked.objectName(), "theme.mode_dark")
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemeLookTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.model = self.mgr.menu_model
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        # The manager is a shared singleton, so restore the controlled default
+        # to keep the tests independent of the order they run in.
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("system")
+
+    def test_look_menu_lists_the_two_looks(self):
+        items = [a.text() for a in self.model.menu("View/Theme").actions()
+                 if a.objectName().startswith("theme.look_")]
+        self.assertEqual(items, ["System colors", "Curated colors"])
+
+    def test_look_group_is_exclusive_and_defaults_to_curated(self):
+        group = self.model.group("theme.look")
+        self.assertEqual(len(group.actions()), 2)
+        self.assertTrue(group.isExclusive())
+        self.assertEqual(group.checkedAction().objectName(),
+                         "theme.look_curated")
+
+    def test_both_looks_are_enabled_on_this_platform(self):
+        for look in ("system", "curated"):
+            self.assertTrue(
+                self.model.action("theme.look_" + look).isEnabled())
+
+    def test_curated_look_paints_the_curated_dark_window(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("dark")
+        self.assertEqual(self.mgr.theme_look, "curated")
+        self.assertLess(
+            self.app.palette().color(QPalette.Window).lightness(), 100)
+
+    def test_system_look_uses_the_native_style_palette(self):
+        self.mgr.set_look("system")
+        self.assertEqual(self.mgr.theme_look, "system")
+        native = self.app.style().standardPalette().color(QPalette.Window)
+        self.assertEqual(self.app.palette().color(QPalette.Window), native)
+
+    def test_look_menu_check_follows_scripting(self):
+        self.mgr.set_look("system")
+        group = self.model.group("theme.look")
+        self.assertEqual(group.checkedAction().objectName(),
+                         "theme.look_system")
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
Eighth step of the pilot theme system. With three furnished rooms, the
tension between a native feel and a look that travels between machines
becomes a policy the user should own. Stacked on wip/theme-step7.

## What this adds

- A **look preference** alongside the light/dark mode:
  - **System** lets the platform's own colors show through the native
    style untouched.
  - **Curated** paints the plan's palettes over that style for a
    controlled look that carries between machines. Curated is the
    default.
- The **`ThemeLook`** vocabulary in the Qt-free core, routed through the
  manager: `apply()` paints the curated palette or the style's native
  standard palette by the current look, caching the effective window
  color so the MDI backdrop matches whichever is in force.
- A second exclusive group in **View > Theme**, gated by the capability
  record so System greys out where no native style can carry it, with the
  radio check kept in step with the manager.
- `set_look` and `theme_look` exposed to Python.

## Tests

`test_nopython` covers the look identifiers; the Python suite covers the
menu, the exclusive default, the capability gating, and both looks'
applied palettes (System matches the style's standard palette, Curated
paints the curated dark window). `make gtest` green (206) and the Python
suite green (1422 passed).