### PR TITLE
Polish the theme: accent role, chrome, overlays, persistence

### DIFF
--- a/cpp/solvcon/pilot/RScalarBar.cpp
+++ b/cpp/solvcon/pilot/RScalarBar.cpp
@@ -7,7 +7,9 @@
 
 #include <QColor>
 #include <QFont>
+#include <QGuiApplication>
 #include <QPainter>
+#include <QPalette>
 
 #include <algorithm>
 #include <utility>
@@ -66,11 +68,15 @@ QImage RScalarBar::renderImage() const
     QPainter painter(&image);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
+    // Follow the application palette so the labels and the strip border stay
+    // legible when the theme turns dark, instead of forcing black.
+    QColor const ink = QGuiApplication::palette().color(QPalette::WindowText);
+
     QFont font;
     font.setPixelSize(15);
     font.setBold(true);
     painter.setFont(font);
-    painter.setPen(Qt::black);
+    painter.setPen(ink);
     painter.drawText(QRect(0, 4, BAR_WIDTH, 20), Qt::AlignHCenter | Qt::AlignVCenter, m_title);
 
     font.setPixelSize(13);
@@ -90,7 +96,7 @@ QImage RScalarBar::renderImage() const
     painter.rotate(-90.0);
     painter.drawImage(QRect(0, 0, strip.height(), strip.width()), lut);
     painter.restore();
-    painter.setPen(Qt::black);
+    painter.setPen(ink);
     painter.drawRect(strip.adjusted(0, 0, -1, -1));
 
     int const label_left = strip.right() + 7;

--- a/cpp/solvcon/pilot/RTextOverlay.cpp
+++ b/cpp/solvcon/pilot/RTextOverlay.cpp
@@ -7,7 +7,9 @@
 
 #include <QColor>
 #include <QFont>
+#include <QGuiApplication>
 #include <QPainter>
+#include <QPalette>
 
 #include <algorithm>
 
@@ -46,7 +48,9 @@ QImage RTextOverlay::renderImage() const
     font.setPixelSize(28);
     font.setBold(true);
     painter.setFont(font);
-    painter.setPen(Qt::black);
+    // Follow the application palette so the label stays legible when the theme
+    // turns dark, instead of forcing black.
+    painter.setPen(QGuiApplication::palette().color(QPalette::WindowText));
     painter.drawText(image.rect(), Qt::AlignHCenter | Qt::AlignVCenter, m_text);
     painter.end();
     return image;

--- a/cpp/solvcon/pilot/RThemeManager.cpp
+++ b/cpp/solvcon/pilot/RThemeManager.cpp
@@ -8,6 +8,7 @@
 #include <QApplication>
 #include <QColor>
 #include <QGuiApplication>
+#include <QSettings>
 #include <QStyle>
 #include <QStyleFactory>
 #include <QStyleHints>
@@ -24,6 +25,10 @@ RThemeManager::RThemeManager(QObject * parent)
     : QObject(parent)
     , m_backend(makeThemeBackend())
 {
+    // Start on the mode and look the last session left behind, so a chosen
+    // theme carries across restarts.
+    restorePersisted();
+
     // Track live operating-system color-scheme changes while in System mode.
     // The style-hints object is owned by the application and outlives the
     // manager, so the connection stays valid for the manager's lifetime.
@@ -73,6 +78,8 @@ void RThemeManager::apply()
         QPalette const native = QApplication::style()->standardPalette();
         m_window_color = native.color(QPalette::Window);
         QApplication::setPalette(native);
+        // Leave the native look untouched, including any style the platform set.
+        qApp->setStyleSheet(QString());
     }
     else
     {
@@ -80,6 +87,7 @@ void RThemeManager::apply()
             buildPalette(themePaletteFor(m_backend->platform(), variant), variant);
         m_window_color = curated.color(QPalette::Window);
         QApplication::setPalette(curated);
+        qApp->setStyleSheet(supplementalStyleSheet(curated));
     }
     if (m_window != nullptr)
     {
@@ -100,6 +108,7 @@ void RThemeManager::setWindow(QWidget * window)
 void RThemeManager::setMode(ThemeMode mode)
 {
     m_mode = mode;
+    persist();
     syncOsColorScheme();
     apply();
 }
@@ -112,6 +121,7 @@ void RThemeManager::setModeById(std::string const & id)
 void RThemeManager::setLook(ThemeLook look)
 {
     m_look = look;
+    persist();
     apply();
 }
 
@@ -203,6 +213,11 @@ QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant var
     pal.setColor(QPalette::ButtonText, color(spec.button_text));
     pal.setColor(QPalette::BrightText, color(spec.bright_text));
     pal.setColor(QPalette::Highlight, highlight);
+#if QT_VERSION >= QT_VERSION_CHECK(6, 6, 0)
+    // The dedicated Accent role (Qt 6.6+) lets widgets that want the platform
+    // accent, distinct from a selection highlight, pick it up from the palette.
+    pal.setColor(QPalette::Accent, highlight);
+#endif
     pal.setColor(QPalette::HighlightedText, color(spec.highlighted_text));
     pal.setColor(QPalette::ToolTipBase, color(spec.tool_tip_base));
     pal.setColor(QPalette::ToolTipText, color(spec.tool_tip_text));
@@ -218,6 +233,36 @@ QPalette RThemeManager::buildPalette(ThemePalette const & spec, ThemeVariant var
     pal.setColor(QPalette::Disabled, QPalette::HighlightedText, color(spec.disabled_text));
     pal.setColor(QPalette::Disabled, QPalette::Highlight, color(spec.disabled_highlight));
     return pal;
+}
+
+QString RThemeManager::supplementalStyleSheet(QPalette const & pal) const
+{
+    // A QPalette cannot draw a tooltip border or a focus ring, so add just
+    // those two, colored from the theme, and nothing more, so the native style
+    // keeps drawing everything else.
+    QColor const border = pal.color(QPalette::WindowText);
+    QColor const focus = pal.color(QPalette::Highlight);
+    return QStringLiteral(
+               "QToolTip { border: 1px solid %1; }\n"
+               "QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus"
+               " { border: 1px solid %2; }")
+        .arg(border.name(), focus.name());
+}
+
+void RThemeManager::restorePersisted()
+{
+    QSettings settings(QStringLiteral("solvcon"), QStringLiteral("pilot"));
+    m_mode = themeModeFromId(
+        settings.value(QStringLiteral("theme/mode")).toString().toUtf8().constData());
+    m_look = themeLookFromId(
+        settings.value(QStringLiteral("theme/look")).toString().toUtf8().constData());
+}
+
+void RThemeManager::persist() const
+{
+    QSettings settings(QStringLiteral("solvcon"), QStringLiteral("pilot"));
+    settings.setValue(QStringLiteral("theme/mode"), QString::fromStdString(modeId()));
+    settings.setValue(QStringLiteral("theme/look"), QString::fromStdString(lookId()));
 }
 
 } /* end namespace solvcon */

--- a/cpp/solvcon/pilot/RThemeManager.hpp
+++ b/cpp/solvcon/pilot/RThemeManager.hpp
@@ -128,6 +128,17 @@ private:
     /// accent when the backend supplies one, and filling the disabled group.
     QPalette buildPalette(ThemePalette const & spec, ThemeVariant variant) const;
 
+    /// A thin stylesheet that adds what a QPalette cannot: a tooltip border and
+    /// a focus ring on text inputs, colored from @p pal. Applied under the
+    /// curated look and cleared under the system look, which stays native.
+    QString supplementalStyleSheet(QPalette const & pal) const;
+
+    /// Read the persisted mode and look, if any, into the current state.
+    void restorePersisted();
+
+    /// Write the current mode and look so the next session starts on them.
+    void persist() const;
+
     ThemeMode m_mode = ThemeMode::System;
 
     /// Where the colors come from. Curated is the controlled default; System is

--- a/tests/test_pilot_theme.py
+++ b/tests/test_pilot_theme.py
@@ -10,7 +10,11 @@ import solvcon
 try:
     from solvcon import pilot
     from PySide6 import QtWidgets
+    from PySide6.QtCore import QSettings, QStandardPaths
     from PySide6.QtGui import QPalette
+    # Redirect QSettings to a throwaway location so the theme's persistence
+    # does not touch the developer's real configuration during the tests.
+    QStandardPaths.setTestModeEnabled(True)
 except ImportError:
     pilot = None
 
@@ -167,6 +171,42 @@ class ThemeLookTC(unittest.TestCase):
         group = self.model.group("theme.look")
         self.assertEqual(group.checkedAction().objectName(),
                          "theme.look_system")
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class ThemePolishTC(unittest.TestCase):
+    def setUp(self):
+        self.mgr = pilot.RManager.instance.setUp()
+        self.app = QtWidgets.QApplication.instance()
+
+    def tearDown(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("system")
+
+    def test_accent_role_matches_the_highlight(self):
+        self.mgr.set_look("curated")
+        self.mgr.set_theme("light")
+        pal = self.app.palette()
+        self.assertEqual(pal.color(QPalette.Accent),
+                         pal.color(QPalette.Highlight))
+
+    def test_curated_look_adds_a_supplemental_stylesheet(self):
+        self.mgr.set_look("curated")
+        self.assertIn("QToolTip", self.app.styleSheet())
+
+    def test_system_look_clears_the_stylesheet(self):
+        self.mgr.set_look("system")
+        self.assertEqual(self.app.styleSheet(), "")
+
+    def test_mode_and_look_persist_across_sessions(self):
+        self.mgr.set_theme("dark")
+        self.mgr.set_look("system")
+        # A new session reads these back through the same store to start on the
+        # last chosen theme.
+        settings = QSettings("solvcon", "pilot")
+        self.assertEqual(settings.value("theme/mode"), "dark")
+        self.assertEqual(settings.value("theme/look"), "system")
 
 
 @unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,


### PR DESCRIPTION
Ninth and final step of the pilot theme system: the touches a palette
alone does not reach. Stacked on wip/theme-step8.

## What this adds

- **Accent role**: set the dedicated `QPalette::Accent` (Qt 6.6+) from
  the highlight, so widgets wanting the platform accent, distinct from a
  selection highlight, pick it up.
- **Supplemental stylesheet**: a thin sheet for the one thing a palette
  cannot draw, a tooltip border and a focus ring on text inputs, colored
  from the theme under the curated look and cleared under the system look
  so the native style stays untouched.
- **Overlays follow the theme**: the two remaining hardcoded overlays,
  the axis text and the scalar bar, now take their ink from the
  application palette so their labels stay legible under a dark theme
  instead of forcing black.
- **Persistence**: the chosen mode and look are stored through
  `QSettings` and read back when the manager is built, so a theme carries
  across restarts.

## Tests

The Python suite covers the accent role, the stylesheet under each look,
and the persistence round-trip, with `QSettings` redirected to a
throwaway location so the tests leave no trace. Full theme suite green
(1426 passed with the bar tests), `make gtest` green (206).