### PR TITLE
Keep master CI runs from cancelling each other

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -9,7 +9,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # A push to master must never cancel an earlier master run, so every
+  # merge keeps its own CI result. Superseded pull request and branch
+  # runs still cancel.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:
 


### PR DESCRIPTION
## Problem

The `lint`, `devbuild`, and `nouse_install` workflows share this concurrency setting:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

For a pull request the group is keyed on the PR number, so a new push to the PR correctly cancels the PR's earlier, now-superseded run. That behavior is fine and stays.

For a push to `master` there is no pull request number, so the group falls back to the ref and becomes `<workflow>-refs/heads/master`. Every merge into master lands in that same group. With `cancel-in-progress: true`, a second merge arriving while the first run is still in progress cancels the first run, and the head that was just merged never gets a completed CI result.

## Fix

Make the cancellation conditional on the ref:

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
```

- Pull requests and feature branches: superseded runs are still cancelled (`github.ref` is `refs/pull/<n>/merge` or `refs/heads/<branch>`, not master), so the fast-iteration behavior is unchanged.
- Pushes to master: never cancelled, so back-to-back merges each complete their own run.

Applied to `lint.yml`, `devbuild.yml`, and `nouse_install.yml`. `profiling.yml` has no concurrency group and needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShtPJHpqEh2yiLGSyTUrVw