### PR TITLE
Fix the window manager's sub-window listing

### DIFF
--- a/solvcon/pilot/_window_manager.py
+++ b/solvcon/pilot/_window_manager.py
@@ -66,8 +66,8 @@ class WindowManager(_gui_common.PilotFeature):
             self._append_placeholder()
             return
 
-        for subwin in enumerate(subwins):
-            self._append_item(subwin, subwin is active)
+        for index, subwin in enumerate(subwins):
+            self._append_item(index, subwin, subwin is active)
 
     def _append_item(self, index, subwin, is_active):
         """Append one checkable action that activates ``subwin``."""


### PR DESCRIPTION
The Window menu's dynamic sub-window list raised `TypeError` as soon as a visible sub-window existed. The rebuild looped with `for subwin in enumerate(subwins)`, so each `subwin` was actually an `(index, window)` tuple, and it then called `_append_item(subwin, subwin is active)`, passing two positional arguments where the method expects three: `(index, subwin, is_active)`. Populating the Window menu with any open MDI sub-window therefore broke the menu.

This unpacks the `enumerate` pair and passes the index, the sub-window, and its active flag through in order.

The gap slips past CI because the pilot GUI tests are skipped on GitHub Actions. Run locally, `tests/test_pilot_window_menu.py` reproduces the crash before this change and passes after it.

```
self = <solvcon.pilot._window_manager.WindowManager(0x794dd6620) at 0x121d0d700>

    def _rebuild(self):
        """Refresh the sub-window list to match the MDI area.
    
        Drop the actions from the previous show, then append one checkable
        action per visible sub-window in area order, checking the active
        one. A disabled placeholder is shown when none are open.
        """
        for act in self._items:
            self._menu.removeAction(act)
            act.deleteLater()
        self._items = []
    
        mdi = self._mgr.mdiArea
        active = mdi.activeSubWindow()
        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
    
        if not subwins:
            self._append_placeholder()
            return
    
        for subwin in enumerate(subwins):
>           self._append_item(subwin, subwin is active)
E           TypeError: WindowManager._append_item() missing 1 required positional argument: 'is_active'

../../../../../../../../../solvcon/pilot/_window_manager.py:70: TypeError
=========================== short test summary info ============================
FAILED ../../../../../../../../../tests/test_pilot_2d.py::Save2DCanvasDialogTC::test_menu_action_is_registered - TypeError: WindowManager._append_item() missing 1 required positional argum...
!!!!!!!!!!!!!!!!!!!!!!!!!! stopping after 1 failures !!!!!!!!!!!!!!!!!!!!!!!!!!!
```
