### PR TITLE
Pin agent shell tooling to LF via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,4 @@
-# Keep shell scripts LF-only on every platform.  The agent tooling under
-# .claude/ and .cursor/ (hooks, statusline) is bash, and a Windows checkout
-# with the default core.autocrlf=true otherwise rewrites it to CRLF, which
-# breaks the `#!/bin/bash` shebang and heredoc/case parsing on stricter
-# shells.  This also matches the project's Unix-LF source rule (see STYLE.md).
+# Shell/agent tooling stays LF regardless of core.autocrlf.
 *.sh text eol=lf
 .claude/hooks/* text eol=lf
 .claude/statusline.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+# Keep shell scripts LF-only on every platform.  The agent tooling under
+# .claude/ and .cursor/ (hooks, statusline) is bash, and a Windows checkout
+# with the default core.autocrlf=true otherwise rewrites it to CRLF, which
+# breaks the `#!/bin/bash` shebang and heredoc/case parsing on stricter
+# shells.  This also matches the project's Unix-LF source rule (see STYLE.md).
+*.sh text eol=lf
+.claude/hooks/* text eol=lf
+.claude/statusline.sh text eol=lf
+.gitattributes text eol=lf


### PR DESCRIPTION
The repository carried no `.gitattributes`, so on Windows the default
`core.autocrlf=true` rewrites the LF-only agent scripts to CRLF on
checkout. That gives the `.claude` hooks a `#!/bin/bash\r` shebang and
CRLF `case`/heredoc bodies, which break under stricter shells, and it
contradicts the project's Unix-LF source rule that `check-source.sh`
itself enforces.

This adds a `.gitattributes` fixing `eol=lf` for shell scripts, the
`.claude` hooks, `statusline.sh`, and `.gitattributes` itself, so the
agent tooling stays LF regardless of the local `autocrlf` setting.

Verified on Windows: the shell scripts re-materialize as clean LF, both
hooks still run, and a full `_solvcon` build (Ninja + MSVC, scdv
py3.14.5) compiles, links, and imports.

[skip-ci]