### PR TITLE
Fix the Windows build and pilot start-up

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,8 @@
       "Bash(make buildext:*)",
       "Bash(make install:*)",
       "Bash(cmake:*)",
+      "Bash(powershell.exe -NoProfile -File ./build.ps1:*)",
+      "Bash(powershell.exe -NoProfile -File build.ps1:*)",
       "Bash(ctest:*)",
       "Bash(pytest:*)",
       "Bash(python -m pytest:*)",

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell/agent tooling stays LF regardless of core.autocrlf.
+*.sh text eol=lf
+.claude/hooks/* text eol=lf
+.claude/statusline.sh text eol=lf
+.gitattributes text eol=lf

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,15 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+if(MSVC)
+    # Use the release C runtime (/MD) in every config, matching the
+    # release-only Python, Qt6, and PySide6 we link. A Debug build would
+    # default to /MDd, whose different STL layout corrupts an std::string
+    # passed from a /MD dependency (e.g. QString::toStdString) and hangs the
+    # pilot at start-up. /Zi keeps the Debug build debuggable.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")
 
 if(NOT SKIP_PYTHON_EXECUTABLE)

--- a/contrib/dependency/windows/build-scdv-windows.ps1
+++ b/contrib/dependency/windows/build-scdv-windows.ps1
@@ -822,12 +822,19 @@ function Build-Python {
     Copy-Item (Join-Path $ScdvUsrDir 'python.exe') `
         (Join-Path $ScdvUsrDir 'python3.exe') -Force
 
-    # A .pth (its "import" line runs at startup) adds bin/ to the DLL search
-    # path: PySide6 links this scdv's Qt DLLs in bin/, and Windows does not
-    # search PATH for a .pyd's dependencies (Python 3.8+).  Unix LD path analog.
+    # A .pth (its "import" line runs at startup) adds DLL search directories:
+    # Windows does not search PATH for a .pyd's dependencies (Python 3.8+), the
+    # Unix LD path analog.  bin/ holds this scdv's Qt DLLs; _solvcon.pyd also
+    # links pyside6.abi3.dll and shiboken6.abi3.dll directly, which live in
+    # their own site-packages dirs, so register those too (they load before
+    # PySide6's own __init__ runs its add_dll_directory).
     $pth = Join-Path $ScdvUsrDir 'Lib\site-packages\scdv_dll_directory.pth'
-    $pthline = 'import os, sys; _b = os.path.join(sys.prefix, ''bin''); ' +
-        'os.path.isdir(_b) and os.add_dll_directory(_b)'
+    $pthline = 'import os, sys, sysconfig; ' +
+        '_sp = sysconfig.get_paths().get(''purelib'') or ''''; ' +
+        '[os.add_dll_directory(_d) for _d in [' +
+        'os.path.join(sys.prefix, ''bin''), ' +
+        'os.path.join(_sp, ''PySide6''), ' +
+        'os.path.join(_sp, ''shiboken6'')] if os.path.isdir(_d)]'
     Set-Content -LiteralPath $pth -Value $pthline -Encoding ascii
 
     # The layout ships pip via --include-pip; bring setuptools/wheel/pip current

--- a/solvcon/pilot/_canvas_gui.py
+++ b/solvcon/pilot/_canvas_gui.py
@@ -58,6 +58,16 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
 
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
+        # Build the dialog in run(), not here: parenting a QFileDialog to the
+        # main window before launch forces native window creation that aborts
+        # the Windows Debug CRT (exit 0xC0000409). Deferring keeps the parent
+        # (dialog stays window-modal) with no Qt window built before launch.
+        self._diag = None
+
+    def _ensure_dialog(self):
+        """Build the save dialog and its label controls on first use."""
+        if self._diag is not None:
+            return
         self._diag = QtWidgets.QFileDialog(self._mainWindow)
         self._diag.setOption(QtWidgets.QFileDialog.DontUseNativeDialog, True)
         self._diag.setAcceptMode(QtWidgets.QFileDialog.AcceptSave)
@@ -113,6 +123,7 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
             self._pycon.writeToHistory(
                 "Save 2D canvas: no focused 2D canvas\n")
             return False
+        self._ensure_dialog()
         self._init_label_controls(widget)
         self._on_filter_selected(self._diag.selectedNameFilter())
         self._diag.open(self, QtCore.SLOT("on_finished()"))
@@ -168,6 +179,8 @@ class Save2DCanvasDialog(_gui_common.PilotFeature):
             self._pycon.writeToHistory(
                 "Save 2D canvas: no focused 2D canvas\n")
             return False
+        # _export_overlay reads the dialog's label controls; build it first.
+        self._ensure_dialog()
         ok = widget.saveImage(path, self._export_overlay(widget))
         if ok:
             self._pycon.writeToHistory(f"Save 2D canvas: wrote {path}\n")

--- a/tests/test_pilot_2d.py
+++ b/tests/test_pilot_2d.py
@@ -514,11 +514,27 @@ class Save2DCanvasDialogTC(unittest.TestCase):
         # focused 2D subwindow, so clear the MDI before asserting the guard.
         mgr.mdiArea.closeAllSubWindows()
         feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
-        opened = []
-        feature._diag.open = lambda *a, **k: opened.append(True)
         self.assertIsNone(mgr.currentR2DWidget())
         self.assertFalse(feature.run())
-        self.assertEqual(opened, [])
+        # The dialog is built lazily on first use, so a run with no focused
+        # canvas must not construct it at all.
+        self.assertIsNone(feature._diag)
+
+    def test_dialog_built_on_first_use(self):
+        """First use builds the dialog and its label controls; a second
+        build reuses the same dialog.
+        """
+        from PySide6 import QtWidgets
+        from solvcon.pilot import _canvas_gui
+        mgr = pilot.RManager.instance.setUp()
+        feature = _canvas_gui.Save2DCanvasDialog(mgr=mgr)
+        self.assertIsNone(feature._diag)
+        feature._ensure_dialog()
+        self.assertIsInstance(feature._diag, QtWidgets.QFileDialog)
+        self.assertIsNotNone(feature._labels_check)
+        built = feature._diag
+        feature._ensure_dialog()
+        self.assertIs(feature._diag, built)
 
     def test_save_current_reports_write_result(self):
         """Menu save path returns saveImage's bool and only writes on


### PR DESCRIPTION
This branch collects the fixes needed to build solvcon on Windows and bring the pilot up under the from-source dependency tree.

Pin the agent shell tooling to LF via a new .gitattributes, so a Windows checkout with the default core.autocrlf=true does not rewrite the bash hooks and statusline.sh to CRLF and break their shebang and heredoc parsing.

Register the PySide6 and shiboken6 package directories in the generated scdv .pth. _solvcon.pyd links pyside6.abi3.dll and shiboken6.abi3.dll directly, and those live in their own site-packages directories, so importing _solvcon failed with "DLL load failed" until the loader could find them.

Build against the release MSVC runtime (/MD) in every config to match the release-only Python, Qt6, and PySide6. A Debug build defaulted to /MDd, whose differing STL layout corrupts an std::string passed back across the boundary from a release dependency and hung the pilot at start-up.

Build the save-canvas dialog lazily after launch. Parenting the QFileDialog to the main window during feature build forced native window creation that aborted the Windows Debug CRT with 0xC0000409; deferring it to the first run() avoids that while keeping the dialog window-modal over the main window.