### PR TITLE
Allow the agent to run build.ps1 without a prompt

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,8 @@
       "Bash(make buildext:*)",
       "Bash(make install:*)",
       "Bash(cmake:*)",
+      "Bash(powershell.exe -NoProfile -File ./build.ps1:*)",
+      "Bash(powershell.exe -NoProfile -File build.ps1:*)",
       "Bash(ctest:*)",
       "Bash(pytest:*)",
       "Bash(python -m pytest:*)",


### PR DESCRIPTION
On Windows the only supported build driver is `build.ps1`, a PowerShell
script. The agent's shell surface is the Bash tool (Git Bash), so it can
only reach the script by shelling out to `powershell.exe`. Without an
explicit allow rule the auto-mode permission classifier blocks that as
tool substitution, and the documented Windows build stays out of the
agent's reach.

This whitelists just the non-bypass `build.ps1` invocation in the agent
permission allowlist. The rule is scoped to the build script, not to
PowerShell in general, and deliberately omits `-ExecutionPolicy Bypass`
so only the safe invocation is pre-approved.