### PR TITLE
Import the release Qt into the Windows Debug build (issue #1058)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,28 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+# The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
+# Debug build must match their runtime and configuration or it corrupts the heap
+# (issue #1058). Both default on; turn one off to link debug dependencies when
+# they are available.
+option(SOLVCON_MSVC_FORCE_RELEASE_RUNTIME
+    "MSVC: use the release C runtime (/MD) in every config" ON)
+option(SOLVCON_MSVC_FORCE_RELEASE_IMPORTS
+    "MSVC: import dependencies from their release config in a Debug build" ON)
+
 if(MSVC)
-    # Use the release C runtime (/MD) in every config, matching the
-    # release-only Python, Qt6, and PySide6 we link. A Debug build would
-    # default to /MDd, whose different STL layout corrupts an std::string
-    # passed from a /MD dependency (e.g. QString::toStdString) and hangs the
-    # pilot at start-up. /Zi keeps the Debug build debuggable.
-    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    # /MDd has a different STL layout and corrupts an std::string passed from a
+    # /MD dependency (e.g. QString::toStdString).
+    if(SOLVCON_MSVC_FORCE_RELEASE_RUNTIME)
+        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+    endif()
+
+    # Without this a Debug pilot links the debug Qt (Qt6Cored.dll) while PySide6
+    # loads the release Qt6Core.dll; two Qt runtimes then run at once and a
+    # QString freed across the /MDd and /MD split corrupts the heap.
+    if(SOLVCON_MSVC_FORCE_RELEASE_IMPORTS)
+        set(CMAKE_MAP_IMPORTED_CONFIG_DEBUG "Release;")
+    endif()
 endif()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${PROJECT_SOURCE_DIR}/cmake/")


### PR DESCRIPTION
Fixes the remaining Windows Debug pilot crash behind issue solvcon/solvcon#1058.

Root cause. The Debug pilot.exe linked the debug Qt (Qt6Cored.dll, Qt6Guid.dll, Qt6Widgetsd.dll) because CMAKE_BUILD_TYPE=Debug makes CMake import Qt's debug configuration, while PySide6 loads the release Qt6Core.dll. Two Qt runtimes then ran in one process, one built /MDd and one /MD. Qt rejected every release plugin ("Cannot mix debug and release libraries") and loaded the debug style plugin instead, and the QStyleFactory::keys() QString list read while the theme is applied (RThemeManager::apply -> RWindowsThemeBackend::styleName) was allocated on the debug heap and freed by pilot's release CRT, corrupting the heap. That is the drifting 0xc0000374 abort. AddressSanitizer never saw it because the ASan job builds Release, where only the one release Qt loads.

Fix. The build already forces the release C runtime (/MD) in every config for the same "release-only Python, Qt6, PySide6" reason, but that governs only our own objects. Set CMAKE_MAP_IMPORTED_CONFIG_DEBUG to Release so imported targets resolve to their release libraries, and the Debug pilot links the one release Qt the rest of the process already uses.

How it was found. Local Debug repro is not possible on the dev box (Smart App Control blocks the unsigned binaries) and ASan cannot see it, so it was diagnosed on CI: pilot.exe was run under cdb with full page heap (gflags /full /backwards) so the corruption broke into the debugger, and the loaded-module list plus the Qt plugin-loader "Cannot mix debug and release" messages identified the debug/release Qt split. With the fix the Windows Debug pilot pytest is green: the previously-crashing test_pilot_2d.py::R2DWidgetWorldTC passes and the suite reports 1405 passed, 174 skipped, 3 xfailed.

The diagnostic scaffold used to reach this (running Debug on branch pushes under cdb and page heap) was added and then removed within this branch; the net change is the CMakeLists.txt map alone.

Related to solvcon/solvcon#1058