### PR TITLE
Give each master CI run its own concurrency group

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serialises master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serialises master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:

--- a/.github/workflows/nouse_install.yml
+++ b/.github/workflows/nouse_install.yml
@@ -8,10 +8,14 @@ on:
     - cron: '34 17 * * *'
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  # A push to master must never cancel an earlier master run, so every
-  # merge keeps its own CI result. Superseded pull request and branch
-  # runs still cancel.
+  # Key each master push on its commit SHA so every merge lands in its own
+  # concurrency group. Sharing one group serialises master runs, and with
+  # cancel-in-progress disabled GitHub still cancels a pending run when the
+  # next merge queues behind the one in progress, so a later merge would
+  # drop an earlier merge's result. A unique group per SHA keeps every
+  # master run independent. Pull requests key on the PR number and other
+  # branches on the ref, so their superseded runs still cancel.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || (github.ref == 'refs/heads/master' && github.sha) || github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
 
 jobs:


### PR DESCRIPTION
The lint, devbuild, and nouse_install workflows shared the concurrency group refs/heads/master across every push to master, relying on cancel-in-progress being false there to preserve each merge's CI result. That is not enough. With cancel-in-progress disabled GitHub serialises runs in a group, and when a new run queues behind the one in progress it cancels whatever run was previously pending. A merge that lands while an earlier master run is still going therefore drops that earlier run, and the earlier head never gets a completed result.

The two behaviors this aims for:

1. Commits pushed to a pull request branch: a later push cancels the earlier still-running CI, so only the newest commit on the branch is tested.
2. Commits merged from a pull request into master: every merge keeps its own CI run, so no landed commit is left without a result.

Key each master push on its commit SHA so every merge lands in its own concurrency group and never queues behind or cancels another master run. Pull requests still key on the pull request number and other branches on the ref, so their superseded runs cancel as before.

How the group and cancel-in-progress expressions resolve per event:

- Push to a pull request branch (pull_request synchronize): group is workflow-PRnumber and cancel-in-progress is true (the ref is refs/pull/N/merge, not refs/heads/master), so a later push cancels the previous run. This is behavior 1.
- Merge to master (push to refs/heads/master): the PR number is empty so the group falls through to workflow-sha, a unique group per commit, and cancel-in-progress is false, so every merged commit runs to completion. This is behavior 2.
- Push to a plain feature branch (push): group is workflow-ref and cancel-in-progress is true, so a later push supersedes the earlier one. Non-master pushes gate their heavy jobs off, so this mainly keeps branch runs from piling up.

The keep-every-run behavior is keyed on refs/heads/master specifically, matching the rest of the config that already singles master out. Merging a pull request into a different long-lived branch would fall into the feature-branch case and cancel, which is acceptable while master is the sole merge target.

Verified the mechanism on a scratch branch with a sleep-probe workflow that reuses the exact group expressions. With the old shared group, racing three pushes cancels the middle (pending) run; with the per-SHA group, all three runs proceed concurrently and none is cancelled.