### PR TITLE
Explain why RField does not reuse the TrianglePad container

### DIFF
--- a/cpp/solvcon/pilot/visual/RField.hpp
+++ b/cpp/solvcon/pilot/visual/RField.hpp
@@ -61,7 +61,17 @@ protected:
 
 private:
 
-    // Interleaved [x, y, z, r, g, b] per vertex, captured at construction.
+    /*
+     * The geometry is kept as one interleaved [x, y, z, r, g, b] vertex buffer
+     * plus a shared-vertex index buffer, the layout QRhi vertex input reads
+     * directly, so createGeometry() uploads it with no repack. This is
+     * deliberately not the universe TrianglePad: that container stores corners
+     * de-indexed in a structure-of-arrays layout and carries no color, so it
+     * cannot express the per-vertex color or the vertex sharing kept here, and
+     * it would force a gather into this buffer on every upload while pulling the
+     * geometry/boolean-ops module into the renderer. A TrianglePad is adapted
+     * into the (vertices, colors, indices) constructor arrays instead.
+     */
     SimpleCollector<float> m_interleaved;
     SimpleCollector<uint32_t> m_indices;
 


### PR DESCRIPTION
Records a design finding in the code: whether the pilot drawable RField should adopt the universe TrianglePad for its interface and internal storage. The conclusion is no, and this PR captures the reasoning as a Doxygen note on the RField class so it lives next to the code someone would edit if they reconsidered the layout.

Why a class note (not a doc page): doc/source/pilot/domain.md is operational (how to drive the viewer), and the repo has no design-notes section. The decision is about RFields internal representation, so the person who would revisit it is editing RField, and a class-level note is what they read. It travels with the code.

The rationale, in brief:

- RField stores geometry as one interleaved [x, y, z, r, g, b] vertex buffer plus a shared-vertex index buffer. That is exactly the layout Qt QRhi vertex input reads, so createGeometry uploads it with no repack (zero-copy).
- TrianglePad stores triangle corners de-indexed in a structure-of-arrays layout and carries no color. It cannot express the per-vertex color or the vertex sharing RField needs.
- Using it internally would force a gather into the interleaved buffer on every upload and pull the geometry/boolean-ops module into the renderer (a layer inversion).
- The right seam, when universe geometry needs drawing, is an adapter that flattens a TrianglePad into RFields (vertices, colors, indices) arrays, not making TrianglePad the storage.

Only a comment changes; no behavior is affected, so the full test suite was not run. make lint checks pass (checkascii, checktws, cformat) and the C++ style review of the diff is clean.

skip-ci: documentation-only, no need for the CI matrix.

Opened for your review.