### PR TITLE
Use a rectangular domain for the oblique-shock reflection

### DIFF
--- a/solvcon/multidim/euler/__init__.py
+++ b/solvcon/multidim/euler/__init__.py
@@ -3,8 +3,7 @@
 
 
 """
-Multi-dimensional Euler-equation solver; currently the mesh builder and
-boundary tagging for the oblique-shock reflection.
+Multi-dimensional Euler-equation solver.
 """
 
 from . import oblique

--- a/solvcon/multidim/euler/oblique.py
+++ b/solvcon/multidim/euler/oblique.py
@@ -22,6 +22,7 @@ from ... import core
 __all__ = [
     'ObliqueShock',
     'ObliqueShockMesher',
+    'ObliqueShockRelation',
 ]
 
 
@@ -286,6 +287,116 @@ class ObliqueShockMesher(object):
             else:
                 walls.append(ifc)
         return sorted(inlet), sorted(walls), sorted(outflow)
+
+
+class ObliqueShockRelation(object):
+    """Calculate the flow-property jumps across an oblique shock.
+
+    (Not yet validated.)
+
+    ``beta`` is the shock angle and ``theta`` the flow-deflection angle,
+    both in radians and measured from the upstream flow direction; the
+    formulas follow chapter 4 of Anderson, Modern Compressible Flow (3rd
+    ed.).  Ported from the gas parcel of the legacy solvcon code base.
+
+    :ivar gamma: Ratio of specific heats.
+    """
+
+    def __init__(self, gamma):
+        self.gamma = gamma
+
+    def calc_density_ratio(self, mach1, beta):
+        """Return the density ratio rho2/rho1 across a shock of angle
+        ``beta`` at upstream Mach number ``mach1``."""
+        gamma = self.gamma
+        mn1sq = (mach1 * math.sin(beta)) ** 2
+        return (gamma + 1) * mn1sq / ((gamma - 1) * mn1sq + 2)
+
+    def calc_pressure_ratio(self, mach1, beta):
+        """Return the pressure ratio p2/p1 across a shock of angle ``beta``
+        at upstream Mach number ``mach1``."""
+        gamma = self.gamma
+        mn1sq = (mach1 * math.sin(beta)) ** 2
+        return 1 + 2 * gamma / (gamma + 1) * (mn1sq - 1)
+
+    def calc_temperature_ratio(self, mach1, beta):
+        """Return the temperature ratio T2/T1 across a shock of angle
+        ``beta`` at upstream Mach number ``mach1``."""
+        return (self.calc_pressure_ratio(mach1, beta)
+                / self.calc_density_ratio(mach1, beta))
+
+    def calc_normal_dmach(self, mach_n1):
+        """Return the downstream Mach number normal to the shock from the
+        normal upstream Mach number ``mach_n1``."""
+        gamma = self.gamma
+        mn1sq = mach_n1 * mach_n1
+        return math.sqrt(((gamma - 1) * mn1sq + 2)
+                         / (2 * gamma * mn1sq - (gamma - 1)))
+
+    def calc_dmach(self, mach1, beta=None, theta=None, delta=1):
+        """Return the downstream Mach number from the upstream Mach number
+        ``mach1`` and either the shock angle ``beta`` or the deflection
+        angle ``theta`` (with ``delta`` selecting the weak, 1, or strong,
+        0, shock branch)."""
+        if (beta is None) == (theta is None):
+            raise ValueError(
+                f"got (beta={beta}, theta={theta}), "
+                f"but I need to take either beta or theta")
+        if beta is None:
+            beta = self.calc_shock_angle(mach1, theta, delta=delta)
+        if theta is None:
+            theta = self.calc_flow_angle(mach1, beta)
+        mach_n1 = mach1 * math.sin(beta)
+        return self.calc_normal_dmach(mach_n1) / math.sin(beta - theta)
+
+    def calc_flow_angle(self, mach1, beta):
+        """Return the deflection angle theta from the upstream Mach number
+        ``mach1`` and the shock angle ``beta``."""
+        return math.atan(self.calc_flow_tangent(mach1, beta))
+
+    def calc_flow_tangent(self, mach1, beta):
+        """Return tan(theta) through the theta-beta-M relation."""
+        gamma = self.gamma
+        m1sq = mach1 * mach1
+        return (2 / math.tan(beta) * (m1sq * math.sin(beta) ** 2 - 1)
+                / (m1sq * (gamma + math.cos(2 * beta)) + 2))
+
+    def calc_shock_angle(self, mach1, theta, delta=1):
+        """Return the shock angle beta from the upstream Mach number
+        ``mach1`` and the deflection angle ``theta`` (with ``delta``
+        selecting the weak, 1, or strong, 0, shock branch)."""
+        return math.atan(self.calc_shock_tangent(mach1, theta, delta))
+
+    def calc_shock_tangent(self, mach1, theta, delta):
+        """Return tan(beta) through the closed-form inversion of the
+        theta-beta-M relation."""
+        gamma = self.gamma
+        m1sq = mach1 * mach1
+        lmbd, chi = self.calc_shock_tangent_aux(mach1, theta)
+        num = (m1sq - 1 + 2 * lmbd
+               * math.cos((4 * math.pi * delta + math.acos(chi)) / 3))
+        den = 3 * (1 + (gamma - 1) / 2 * m1sq) * math.tan(theta)
+        return num / den
+
+    def calc_shock_tangent_aux(self, mach1, theta):
+        """Return the (lambda, chi) auxiliary pair of the closed-form
+        theta-beta-M inversion used by :meth:`calc_shock_tangent`."""
+        gamma = self.gamma
+        m1sq = mach1 * mach1
+        tansq = math.tan(theta) ** 2
+        disc = ((m1sq - 1) ** 2
+                - 3 * (1 + (gamma - 1) / 2 * m1sq)
+                * (1 + (gamma + 1) / 2 * m1sq) * tansq)
+        if disc <= 0.0:
+            raise ValueError(
+                f"no attached shock for mach1={mach1:g} and "
+                f"theta={math.degrees(theta):g} deg")
+        lmbd = math.sqrt(disc)
+        chi = ((m1sq - 1) ** 3
+               - 9 * (1 + (gamma - 1) / 2 * m1sq)
+               * (1 + (gamma - 1) / 2 * m1sq + (gamma + 1) / 4 * m1sq * m1sq)
+               * tansq) / lmbd ** 3
+        return lmbd, chi
 
 
 class ObliqueShock(object):

--- a/solvcon/multidim/euler/oblique.py
+++ b/solvcon/multidim/euler/oblique.py
@@ -4,15 +4,6 @@
 
 """
 Mesh, boundary tagging, and solver driver for the oblique-shock reflection.
-
-A uniform supersonic stream enters from the left over a slip wall whose
-bottom turns into a wedge inclined by a fixed angle.  The wedge deflects the
-flow, an oblique shock forms at the wedge tip and reflects off the flat top
-slip wall, and the flow leaves through the non-reflective outflow on the
-right.  This module owns the programmatic mesh builder, the geometric
-boundary classifier, and the :class:`ObliqueShock` driver that marches the
-CESE Euler solver over the mesh; all three are shared by the unit tests and
-the pilot GUI.
 """
 
 import math
@@ -29,33 +20,19 @@ __all__ = [
 class ObliqueShockMesher(object):
     """Generate the mesh for the oblique-shock reflection.
 
-    The rectangular-like domain runs from the lower-left corner ``ll`` to
-    the upper-right corner ``ur``.  The bottom edge is flat up to ``x_ramp``
-    and then ramps up at ``wedge_angle`` degrees.  The wedge top must stay
-    below the domain height (``ur[1] - ll[1]``); otherwise the grid columns
-    would invert and the mesh silently self-overlap, so the constructor
-    raises :class:`ValueError` instead.
+    The rectangular domain runs from the lower-left corner ``ll`` to the
+    upper-right corner ``ur`` and is divided into ``nx`` by ``ny`` grid
+    boxes.
     """
 
-    def __init__(self, nx=48, ny=16, ll=(0.0, 0.0), ur=(3.0, 1.0),
-                 x_ramp=1.5, wedge_angle=15.0):
+    def __init__(self, nx=64, ny=16, ll=(0.0, 0.0), ur=(4.0, 1.0)):
         self.nx = nx
         self.ny = ny
         (self.x0, self.y0), (self.x1, self.y1) = ll, ur
-        self.x_ramp = x_ramp
-        self.tan_theta = math.tan(math.radians(wedge_angle))
-        wedge_top = (self.x1 - x_ramp) * self.tan_theta
-        if wedge_top >= self.y1 - self.y0:
-            raise ValueError(
-                f"wedge top (ur[0] - x_ramp) * tan(wedge_angle) = "
-                f"{wedge_top:g} must stay below the domain height "
-                f"{self.y1 - self.y0:g}")
 
     def _node(self, it, jt):
-        x = self.x0 + it * (self.x1 - self.x0) / self.nx
-        yb = (self.y0 if x <= self.x_ramp
-              else self.y0 + (x - self.x_ramp) * self.tan_theta)
-        return x, yb + (self.y1 - yb) * jt / self.ny
+        return (self.x0 + it * (self.x1 - self.x0) / self.nx,
+                self.y0 + jt * (self.y1 - self.y0) / self.ny)
 
     def _nid(self, it, jt):
         return jt * (self.nx + 1) + it
@@ -258,35 +235,39 @@ class ObliqueShockMesher(object):
 
     @staticmethod
     def classify_boundary(mh, tol=1e-9):
-        """Bucket the boundary faces of ``mh`` by physical role.
+        """Bucket the boundary faces of ``mh`` by domain edge.
 
         A boundary face has no neighbour cell, i.e. ``fccls(ifc, 1) < 0``.
-        Each is classified by its face-centre ``fccnd`` x position and
-        outward ``fcnml`` direction: the left edge (``x == xmin``, normal
-        pointing in -x) is the supersonic inlet, the right edge
-        (``x == xmax``, normal in +x) is the non-reflective outflow, and
-        every remaining face -- the deflecting bottom wedge and the
-        reflecting top -- is a slip wall.  ``xmin``/``xmax`` come from the
-        boundary face centres because ``ndcrd`` also carries extrapolated
-        ghost-node coordinates that overshoot the real edges.
+        Each is classified by its face-centre ``fccnd`` position and
+        outward ``fcnml`` direction into the left (``x == xmin``, normal
+        in -x), top (``y == ymax``, normal in +y), bottom, and right
+        (``x == xmax``, normal in +x) edges.  The driver imposes the free
+        stream at the left, the post-shock state at the top, the slip wall
+        at the bottom, and the non-reflective outflow at the right.  The
+        edge extrema come from the boundary face centres because ``ndcrd``
+        also carries extrapolated ghost-node coordinates that overshoot
+        the real edges.
 
-        Returns ``(inlet, walls, outflow)`` as sorted face-index lists
+        Returns ``(left, top, bottom, right)`` as sorted face-index lists
         ready to feed ``add_inlet`` / ``add_slipwall`` / ``add_nonrefl``.
         """
         bfaces = [ifc for ifc in range(mh.nface) if mh.fccls[ifc, 1] < 0]
         xcs = [mh.fccnd[ifc, 0] for ifc in bfaces]
-        xmin, xmax = min(xcs), max(xcs)
-        inlet, walls, outflow = [], [], []
+        ycs = [mh.fccnd[ifc, 1] for ifc in bfaces]
+        xmin, xmax, ymax = min(xcs), max(xcs), max(ycs)
+        left, top, bottom, right = [], [], [], []
         for ifc in bfaces:
-            xc = mh.fccnd[ifc, 0]
-            nx = mh.fcnml[ifc, 0]
+            xc, yc = mh.fccnd[ifc, 0], mh.fccnd[ifc, 1]
+            nx, ny = mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]
             if abs(xc - xmin) <= tol and nx < 0.0:
-                inlet.append(ifc)
+                left.append(ifc)
             elif abs(xc - xmax) <= tol and nx > 0.0:
-                outflow.append(ifc)
+                right.append(ifc)
+            elif abs(yc - ymax) <= tol and ny > 0.0:
+                top.append(ifc)
             else:
-                walls.append(ifc)
-        return sorted(inlet), sorted(walls), sorted(outflow)
+                bottom.append(ifc)
+        return sorted(left), sorted(top), sorted(bottom), sorted(right)
 
 
 class ObliqueShockRelation(object):
@@ -410,17 +391,28 @@ class ObliqueShock(object):
         self.mach = None
         self.speedofsound = None
         self.velocity = None
+        self.relation = None
+        self.theta = None
+        self.shock_angle = None
+        self.density2 = None
+        self.pressure2 = None
+        self.mach2 = None
+        self.velocity2 = None
         self.mesher = None
         self.mesh = None
         # Numerical solver core (EulerCore).
         self.svr = None
 
-    def build_constant(self, gamma=1.4, density=1.0, pressure=1.0, mach=2.0):
-        """Fix the supersonic free stream entering at the inlet.
+    def build_constant(self, gamma=1.4, density=1.0, pressure=1.0, mach=3.0,
+                       angle=10.0):
+        """Fix the flow states on the two sides of the incident shock.
 
-        The stream is horizontal; the bottom wedge of the phase-1 mesh
-        deflects it to form the oblique shock.  The flow speed follows from
-        the Mach number and the speed of sound of the given state.
+        The free stream (zone 1) enters horizontally at the given Mach
+        number; ``angle`` is the flow deflection across the incident shock
+        in degrees.  The oblique-shock relations give the post-shock state
+        (zone 2), whose velocity points ``angle`` below horizontal; the
+        driver imposes it at the top boundary to anchor the incident
+        shock.
         """
         self.gamma = gamma
         self.density = density
@@ -428,6 +420,16 @@ class ObliqueShock(object):
         self.mach = mach
         self.speedofsound = math.sqrt(gamma * pressure / density)
         self.velocity = mach * self.speedofsound
+        self.relation = ObliqueShockRelation(gamma=gamma)
+        self.theta = theta = math.radians(angle)
+        self.shock_angle = beta = self.relation.calc_shock_angle(mach, theta)
+        self.density2 = density * self.relation.calc_density_ratio(mach, beta)
+        self.pressure2 = (
+            pressure * self.relation.calc_pressure_ratio(mach, beta))
+        self.mach2 = self.relation.calc_dmach(mach, beta=beta)
+        speed2 = self.mach2 * math.sqrt(gamma * self.pressure2 / self.density2)
+        self.velocity2 = (speed2 * math.cos(theta),
+                          -speed2 * math.sin(theta))
 
     def build_numerical(self, cell_type='quad', time_increment=2.e-3,
                         sigma0=3.0, taumin=0.0, tauscale=1.0, **mesher_kw):
@@ -444,12 +446,15 @@ class ObliqueShock(object):
         svr.taumin = taumin
         svr.tauscale = tauscale
         svr.init_solution(gamma=self.gamma, rho=self.density,
-                          v=[0.0, 0.0], p=self.pressure)
-        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
-        svr.add_inlet(inlet, value=[self.density, self.velocity, 0.0,
-                                    self.pressure, self.gamma])
-        svr.add_slipwall(walls)
-        svr.add_nonrefl(outflow)
+                          v=[self.velocity, 0.0], p=self.pressure)
+        left, top, bottom, right = self.mesher.classify_boundary(self.mesh)
+        svr.add_inlet(left, value=[self.density, self.velocity, 0.0,
+                                   self.pressure, self.gamma])
+        svr.add_inlet(top, value=[self.density2, self.velocity2[0],
+                                  self.velocity2[1], self.pressure2,
+                                  self.gamma])
+        svr.add_slipwall(bottom)
+        svr.add_nonrefl(right)
         # Prime the ghost rows from the initial interior state so the first
         # substep does not read zero-filled ghosts.
         svr.bc_soln()

--- a/solvcon/pilot/_euler/_oblique.py
+++ b/solvcon/pilot/_euler/_oblique.py
@@ -7,9 +7,10 @@ Example pilot apps for the oblique-shock reflection.
 
 The mesh construction, boundary tagging, and solver driver live in
 :mod:`solvcon.multidim.euler.oblique`.  :class:`ObliqueShockMesh` draws the
-mesh in a 3D widget and reports the boundary classification (inlet / slip wall
-/ outflow) to the console.  Running the solver and animating its solution
-fields is handled by the interactive panel in :mod:`._solution_info`.
+mesh in a 3D widget and reports the boundary classification (left / top /
+bottom / right edges) to the console.  Running the solver and animating its
+solution fields is handled by the interactive panel in
+:mod:`._solution_info`.
 """
 
 from ...multidim.euler import oblique
@@ -29,13 +30,13 @@ class ObliqueShockMesh(_gui_common.PilotFeature):
         cat = "Oblique-shock reflection"
         return [
             (cat, "Quad mesh (2D)",
-             "Draw the quad wedge mesh for the oblique-shock reflection",
+             "Draw the quad mesh for the oblique-shock reflection",
              self.draw_quad_mesh),
             (cat, "Triangle mesh (2D)",
-             "Draw the triangle wedge mesh for the oblique-shock reflection",
+             "Draw the triangle mesh for the oblique-shock reflection",
              self.draw_triangle_mesh),
             (cat, "Unstructured mesh (2D)",
-             "Draw the unstructured (Delaunay) triangle wedge mesh for the "
+             "Draw the unstructured (Delaunay) triangle mesh for the "
              "oblique-shock reflection",
              self.draw_unstructured_mesh),
         ]
@@ -52,15 +53,15 @@ class ObliqueShockMesh(_gui_common.PilotFeature):
     def _draw_mesh(self, cell_type):
         mesher = oblique.ObliqueShockMesher()
         mh = mesher.make_mesh(cell_type=cell_type)
-        inlet, walls, outflow = mesher.classify_boundary(mh)
+        left, top, bottom, right = mesher.classify_boundary(mh)
         w = self._mgr.add3DWidget()
         w.updateMesh(mh)
         w.showAxis(True)
         self._pycon.writeToHistory(
             f"oblique-shock {cell_type} mesh: {mh.ncell} cells, "
             f"{mh.nedge} edges\n"
-            f"boundary faces: {len(inlet)} inlet, {len(walls)} slip wall, "
-            f"{len(outflow)} outflow\n")
+            f"boundary faces: {len(left)} left inlet, {len(top)} top inlet, "
+            f"{len(bottom)} bottom slip wall, {len(right)} right outflow\n")
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/_euler/_solution_info.py
+++ b/solvcon/pilot/_euler/_solution_info.py
@@ -72,7 +72,8 @@ class SolutionPanel(QWidget):
         self._gamma = self._spin(1.4, 1.01, 3.0, 0.01, 3)
         self._density = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
         self._pressure = self._spin(1.0, 1e-3, 1e6, 0.1, 3)
-        self._mach = self._spin(2.0, 0.1, 20.0, 0.1, 3)
+        self._mach = self._spin(3.0, 1.1, 20.0, 0.1, 3)
+        self._angle = self._spin(10.0, 0.5, 45.0, 0.5, 2)
         self._dt = self._spin(2e-3, 1e-6, 1.0, 1e-3, 6)
         self._steps = QSpinBox()
         self._steps.setRange(1, 1000)
@@ -88,6 +89,7 @@ class SolutionPanel(QWidget):
         form.addRow("density", self._density)
         form.addRow("pressure", self._pressure)
         form.addRow("mach", self._mach)
+        form.addRow("angle (deg)", self._angle)
         form.addRow("dt", self._dt)
         form.addRow("steps/frame", self._steps)
         form.addRow("cell type", self._cell_type)
@@ -140,6 +142,7 @@ class SolutionPanel(QWidget):
                     density=self._density.value(),
                     pressure=self._pressure.value(),
                     mach=self._mach.value(),
+                    angle=self._angle.value(),
                     time_increment=self._dt.value(),
                     cell_type=self._cell_type.currentText())
 
@@ -345,7 +348,8 @@ class SolutionInfo(_gui_common.PilotFeature):
         shock.build_constant(gamma=params['gamma'],
                              density=params['density'],
                              pressure=params['pressure'],
-                             mach=params['mach'])
+                             mach=params['mach'],
+                             angle=params['angle'])
         shock.build_numerical(cell_type=params['cell_type'],
                               time_increment=params['time_increment'])
         # Set the viewer mesh so the inspector can report it; reusing an open

--- a/tests/test_multidim_euler_oblique.py
+++ b/tests/test_multidim_euler_oblique.py
@@ -12,12 +12,14 @@ comes in three element flavors: one quadrilateral per grid box, each box cut
 into two triangles, or a Delaunay triangulation of jittered interior points.
 """
 
+import math
 import unittest
 
 from numpy.testing import assert_almost_equal
 
 import solvcon
-from solvcon.multidim.euler.oblique import ObliqueShock, ObliqueShockMesher
+from solvcon.multidim.euler.oblique import (ObliqueShock, ObliqueShockMesher,
+                                            ObliqueShockRelation)
 
 
 class _ObliqueMeshBase:
@@ -257,6 +259,63 @@ class ObliqueShockMesherTC(unittest.TestCase):
         with self.assertRaises(ValueError):
             ObliqueShockMesher(nx=2, ny=2, ll=(0.0, 0.0), ur=(3.0, 1.0),
                                x_ramp=0.5, wedge_angle=30.0)
+
+
+class ObliqueShockRelationTC(unittest.TestCase):
+    """The oblique-shock relation reproduces the reference values carried
+    over from the doctests of the legacy solvcon gas parcel (Anderson,
+    Modern Compressible Flow, chapter 4).
+    """
+
+    def setUp(self):
+        self.ob = ObliqueShockRelation(gamma=1.4)
+
+    def test_ratios(self):
+        beta = math.radians(37.8)
+        self.assertAlmostEqual(
+            2.4204302545, self.ob.calc_density_ratio(3, beta), places=10)
+        self.assertAlmostEqual(
+            3.7777114257, self.ob.calc_pressure_ratio(3, beta), places=10)
+        self.assertAlmostEqual(
+            1.5607602899, self.ob.calc_temperature_ratio(3, beta), places=10)
+
+    def test_gamma_changes_solution(self):
+        self.ob.gamma = 1.2
+        self.assertAlmostEqual(
+            2.7793244902,
+            self.ob.calc_density_ratio(3, math.radians(37.8)), places=10)
+
+    def test_downstream_mach(self):
+        self.assertAlmostEqual(
+            0.4751909633, self.ob.calc_normal_dmach(3), places=10)
+        self.assertAlmostEqual(
+            1.9924827009,
+            self.ob.calc_dmach(3, beta=math.radians(37.8)), places=10)
+        self.assertAlmostEqual(
+            1.9941316656,
+            self.ob.calc_dmach(3, theta=math.radians(20)), places=10)
+
+    def test_dmach_needs_one_angle(self):
+        with self.assertRaises(ValueError):
+            self.ob.calc_dmach(3)
+        with self.assertRaises(ValueError):
+            self.ob.calc_dmach(3, beta=0.2, theta=0.1)
+
+    def test_detached_shock_is_rejected(self):
+        # 40 degrees of deflection exceeds the maximum attached-shock
+        # deflection at Mach 2 (about 23 degrees).
+        with self.assertRaises(ValueError):
+            self.ob.calc_shock_angle(2, math.radians(40))
+
+    def test_angles_invert_each_other(self):
+        # Example 4.6 of Anderson: M1 = 4 and theta = 32 degrees give a
+        # weak-shock angle of about 48.2585 degrees, and the flow-angle
+        # calculation inverts it.
+        theta = math.radians(32)
+        beta = self.ob.calc_shock_angle(4, theta, delta=1)
+        self.assertAlmostEqual(48.2584798722, math.degrees(beta), places=10)
+        self.assertAlmostEqual(
+            32.0, math.degrees(self.ob.calc_flow_angle(4, beta)), places=6)
 
 
 class _ObliqueShockDriverBase:

--- a/tests/test_multidim_euler_oblique.py
+++ b/tests/test_multidim_euler_oblique.py
@@ -4,12 +4,13 @@
 
 """The oblique-shock reflection test.
 
-A uniform supersonic stream enters from the left over a slip wall whose bottom
-turns into a wedge inclined by a fixed angle.  The wedge deflects the flow, an
-oblique shock forms at the wedge tip and reflects off the flat top slip wall,
-and the flow leaves through the non-reflective outflow on the right.  The mesh
-comes in three element flavors: one quadrilateral per grid box, each box cut
-into two triangles, or a Delaunay triangulation of jittered interior points.
+The computing domain is a plain rectangle.  A uniform supersonic stream
+enters horizontally from the left, the top boundary holds the state behind
+an incident oblique shock, the bottom slip wall reflects the incident
+shock, and the flow leaves through the non-reflective outflow on the right.
+The mesh comes in three element flavors: one quadrilateral per grid box,
+each box cut into two triangles, or a Delaunay triangulation of jittered
+interior points.
 """
 
 import math
@@ -42,8 +43,7 @@ class _ObliqueMeshBase:
     @classmethod
     def setUpClass(cls):
         cls.mesher = ObliqueShockMesher(nx=cls.NX, ny=cls.NY, ll=cls.LL,
-                                        ur=cls.UR, x_ramp=0.5,
-                                        wedge_angle=15.0)
+                                        ur=cls.UR)
         cls.mesh = cls.mesher.make_mesh(cell_type=cls.CELL_TYPE)
 
     def _boundary_faces(self):
@@ -80,59 +80,46 @@ class _ObliqueMeshBase:
         self.assertEqual(2 * (self.NX + self.NY), len(self._boundary_faces()))
 
     def test_classification_partitions_boundary(self):
-        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
-        # Every role is present.
-        self.assertTrue(inlet)
-        self.assertTrue(walls)
-        self.assertTrue(outflow)
-        si, sw, so = set(inlet), set(walls), set(outflow)
-        # The three roles are pairwise disjoint.
-        self.assertEqual(set(), si & sw)
-        self.assertEqual(set(), si & so)
-        self.assertEqual(set(), sw & so)
+        edges = self.mesher.classify_boundary(self.mesh)
+        # Every edge is present.
+        for faces in edges:
+            self.assertTrue(faces)
+        sets = [set(faces) for faces in edges]
+        # The four edges are pairwise disjoint.
+        for it in range(len(sets)):
+            for jt in range(it + 1, len(sets)):
+                self.assertEqual(set(), sets[it] & sets[jt])
         # Together they cover every boundary face and nothing else.
-        self.assertEqual(self._boundary_faces(), si | sw | so)
+        self.assertEqual(self._boundary_faces(),
+                         sets[0] | sets[1] | sets[2] | sets[3])
 
     def test_classification_counts(self):
-        inlet, walls, outflow = self.mesher.classify_boundary(self.mesh)
+        left, top, bottom, right = self.mesher.classify_boundary(self.mesh)
         # The left and right edges carry one face per cell row; the top and
         # bottom edges carry one per cell column.
-        self.assertEqual(self.NY, len(inlet))
-        self.assertEqual(self.NY, len(outflow))
-        self.assertEqual(2 * self.NX, len(walls))
+        self.assertEqual(self.NY, len(left))
+        self.assertEqual(self.NY, len(right))
+        self.assertEqual(self.NX, len(top))
+        self.assertEqual(self.NX, len(bottom))
 
-    def test_inlet_outflow_geometry(self):
+    def test_boundary_geometry(self):
         mh = self.mesh
-        inlet, walls, outflow = self.mesher.classify_boundary(mh)
-        # The real domain spans [LL[0], UR[0]]; ndcrd would include ghost-node
+        left, top, bottom, right = self.mesher.classify_boundary(mh)
+        # The real domain spans LL to UR; ndcrd would include ghost-node
         # coordinates that overshoot the edges, so use the construction
         # bounds.
-        xmin, xmax = self.LL[0], self.UR[0]
-        # Inlet faces sit on x == xmin with the outward normal pointing in -x.
-        for ifc in inlet:
-            assert_almost_equal(mh.fccnd[ifc, 0], xmin, decimal=12)
-            assert_almost_equal(
-                [mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]], [-1.0, 0.0], decimal=12)
-        # Outflow faces sit on x == xmax with the normal pointing in +x.
-        for ifc in outflow:
-            assert_almost_equal(mh.fccnd[ifc, 0], xmax, decimal=12)
-            assert_almost_equal(
-                [mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]], [1.0, 0.0], decimal=12)
-        # Wall faces are the top and bottom edges: their centres are strictly
-        # interior in x and their outward normals are vertical-dominant.
-        for ifc in walls:
-            xc = mh.fccnd[ifc, 0]
-            self.assertGreater(xc, xmin)
-            self.assertLess(xc, xmax)
-            self.assertGreater(abs(mh.fcnml[ifc, 1]), abs(mh.fcnml[ifc, 0]))
-
-    def test_wedge_is_present(self):
-        # The defining feature versus a plain channel: some slip-wall faces
-        # are inclined, so their outward normal has a non-zero x component.
-        mh = self.mesh
-        _, walls, _ = self.mesher.classify_boundary(mh)
-        inclined = [ifc for ifc in walls if abs(mh.fcnml[ifc, 0]) > 1e-6]
-        self.assertTrue(inclined)
+        (xmin, ymin), (xmax, ymax) = self.LL, self.UR
+        # Each edge sits on its domain boundary with the outward normal
+        # exactly axis-aligned; the wedge-free domain has no inclined face.
+        groups = [(left, 0, xmin, [-1.0, 0.0]),
+                  (right, 0, xmax, [1.0, 0.0]),
+                  (top, 1, ymax, [0.0, 1.0]),
+                  (bottom, 1, ymin, [0.0, -1.0])]
+        for faces, axis, coord, normal in groups:
+            for ifc in faces:
+                assert_almost_equal(mh.fccnd[ifc, axis], coord, decimal=12)
+                assert_almost_equal(
+                    [mh.fcnml[ifc, 0], mh.fcnml[ifc, 1]], normal, decimal=12)
 
     def test_cell_winding_and_volume(self):
         # clvol alone cannot pin the winding: build_interior repairs
@@ -197,9 +184,9 @@ class ObliqueShockTriangleMeshTC(_ObliqueMeshBase, _SingleBoundaryFaceTB,
 
 class ObliqueShockUnstructuredMeshTC(_ObliqueMeshBase, _SingleBoundaryFaceTB,
                                      unittest.TestCase):
-    """Delaunay triangulation of the wedge: the structured boundary layout
-    with jittered interior points.  The boundary tests of the base apply
-    unchanged because all flavors share the boundary node layout.
+    """Delaunay triangulation of the rectangle: the structured boundary
+    layout with jittered interior points.  The boundary tests of the base
+    apply unchanged because all flavors share the boundary node layout.
     """
 
     CELL_TYPE = 'unstructured'
@@ -250,15 +237,6 @@ class ObliqueShockMesherTC(unittest.TestCase):
     def test_unknown_cell_type(self):
         with self.assertRaises(ValueError):
             ObliqueShockMesher(nx=2, ny=2).make_mesh(cell_type='hexagon')
-
-    def test_wedge_top_must_stay_below_ly(self):
-        # Past atan(height / (ur[0] - x_ramp)) the grid columns invert and
-        # the mesh would silently self-overlap; the constructor refuses
-        # instead.  Here the limit is atan(1.0 / 2.5) ~ 21.8 degrees, so 30
-        # degrees overflows.
-        with self.assertRaises(ValueError):
-            ObliqueShockMesher(nx=2, ny=2, ll=(0.0, 0.0), ur=(3.0, 1.0),
-                               x_ramp=0.5, wedge_angle=30.0)
 
 
 class ObliqueShockRelationTC(unittest.TestCase):
@@ -325,7 +303,7 @@ class _ObliqueShockDriverBase:
 
     CELL_TYPE = None
     # A coarse mesh keeps the driver tests fast.
-    MESHER_KW = dict(nx=24, ny=8, x_ramp=1.0)
+    MESHER_KW = dict(nx=24, ny=8)
 
     def test_build_and_march(self):
         shock = ObliqueShock()
@@ -364,6 +342,26 @@ class ObliqueShockDriverTC(unittest.TestCase):
     def test_numerical_requires_constants(self):
         with self.assertRaises(ValueError):
             ObliqueShock().build_numerical()
+
+    def test_constants_set_post_shock_state(self):
+        shock = ObliqueShock()
+        shock.build_constant(gamma=1.4, density=1.0, pressure=1.0, mach=3.0,
+                             angle=10.0)
+        relation = shock.relation
+        beta = relation.calc_shock_angle(3.0, math.radians(10.0))
+        self.assertAlmostEqual(beta, shock.shock_angle)
+        # The imposed zone-2 state carries the analytical jumps, and its
+        # velocity points 10 degrees below horizontal.
+        self.assertAlmostEqual(relation.calc_density_ratio(3.0, beta),
+                               shock.density2 / shock.density)
+        self.assertAlmostEqual(relation.calc_pressure_ratio(3.0, beta),
+                               shock.pressure2 / shock.pressure)
+        vx, vy = shock.velocity2
+        self.assertLess(vy, 0.0)
+        self.assertAlmostEqual(math.radians(10.0), math.atan2(-vy, vx))
+        speed2 = math.hypot(vx, vy)
+        sos2 = math.sqrt(1.4 * shock.pressure2 / shock.density2)
+        self.assertAlmostEqual(shock.mach2, speed2 / sos2)
 
 
 # vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
The oblique-shock reflection previously deflected the flow with a wedge ramping up from the bottom wall. This PR replaces the wedge with a plain rectangular domain and generates the incident shock through the boundary conditions instead: the left inlet carries the horizontal free stream, the top inlet holds the state behind the incident shock, the bottom slip wall reflects the shock, and the right edge remains the non-reflective outflow.

The post-shock state comes from the ObliqueShockRelation calculator ported from the legacy gas parcel, which solves the theta-beta-M relation and rejects detached-shock inputs with a clear error. classify_boundary now buckets the boundary faces by domain edge (left, top, bottom, right) so the driver can impose the two inlet states, and the pilot solution panel gains a flow-angle control with the Mach 3, 10-degree benchmark free stream as its default.

[skip-ci]
