### PR TITLE
Step1: Add buffer doc skeleton with overview and memory buffers

### DIFF
--- a/doc/source/compute/buffer.md
+++ b/doc/source/compute/buffer.md
@@ -1,8 +1,0 @@
-# Buffers and Arrays
-
-```{note}
-This page is a placeholder. Documentation for the buffers and arrays is
-forthcoming.
-```
-
-<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -50,6 +50,10 @@ Growable typed buffers collect elements one by one, in the spirit of
   `SimpleCollectorUint64`
 - `SimpleCollectorFloat32`, `SimpleCollectorFloat64`
 
+The extension module also registers `SimpleCollectorComplex64` and
+`SimpleCollectorComplex128`, but the top-level `solvcon` package does not
+export them; this document covers the exported set.
+
 ## Relation to Numpy
 
 The Python API of the SimpleArray family is designed against numpy, but not
@@ -70,8 +74,8 @@ numpy the desired behavior falls into three categories:
    convergence completes, the pages note where the current behavior still
    differs from the target.
 
-Throughout the subpages, each operation family is tagged with one of three
-parity labels:
+Throughout the subpages, each operation family with a numpy counterpart is
+tagged with one of three parity labels:
 
 - "matches numpy": the desired behavior is the numpy behavior; any observed
   difference is a defect.

--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -1,0 +1,92 @@
+# Buffers and Arrays
+
+The SimpleArray family provides typed multi-dimensional arrays whose memory
+is owned by C++ and shared with Python without copying.  The classes are
+implemented under `cpp/solvcon/buffer/` and exposed through the `_solvcon`
+extension module, so the same contiguous memory backs both the C++ solvers
+and numpy-based scripting.  The arrays are the data backbone of the solvers:
+mesh connectivity, solution variables, and working storage all live in them.
+
+This document defines the desired behavior of the Python API of the family.
+Each subpage covers one group of operations and states the semantics the
+implementation targets.  Behavior that is intended but not yet implemented
+is explicitly marked as target behavior.
+
+## Class Roster
+
+The family consists of four groups of classes, all importable from the
+top-level `solvcon` package.
+
+Raw memory buffers manage untyped bytes:
+
+- `ConcreteBuffer`: an untyped, fixed-size byte buffer.
+- `BufferExpander`: an untyped, growable staging buffer that can hand its
+  content over as a `ConcreteBuffer`.
+
+Typed array classes provide multi-dimensional access on top of a
+`ConcreteBuffer`.  There are 13 of them, one per element type:
+
+- `SimpleArrayBool`
+- `SimpleArrayInt8`, `SimpleArrayInt16`, `SimpleArrayInt32`,
+  `SimpleArrayInt64`
+- `SimpleArrayUint8`, `SimpleArrayUint16`, `SimpleArrayUint32`,
+  `SimpleArrayUint64`
+- `SimpleArrayFloat32`, `SimpleArrayFloat64`
+- `SimpleArrayComplex64`, `SimpleArrayComplex128`
+
+The dtype-erased class `SimpleArray` wraps any of the typed classes behind a
+single Python type.  It is constructed with a shape and a dtype string (or
+from a numpy `ndarray`) and dispatches operations to the concrete typed
+class it holds.  The `typed` property returns the wrapped typed array, and
+the `plex` property on a typed array returns the erased wrapper.
+
+Growable typed buffers collect elements one by one, in the spirit of
+`std::vector`:
+
+- `SimpleCollectorBool`
+- `SimpleCollectorInt8`, `SimpleCollectorInt16`, `SimpleCollectorInt32`,
+  `SimpleCollectorInt64`
+- `SimpleCollectorUint8`, `SimpleCollectorUint16`, `SimpleCollectorUint32`,
+  `SimpleCollectorUint64`
+- `SimpleCollectorFloat32`, `SimpleCollectorFloat64`
+
+## Relation to Numpy
+
+The Python API of the SimpleArray family is designed against numpy, but not
+as a clone of it.  This document is normative: it defines the desired
+behavior, and the implementation converges to it over time.  With respect to
+numpy the desired behavior falls into three categories:
+
+1. Some behavior deliberately matches numpy.  Element indexing, the buffer
+   protocol, and dtype naming follow numpy so that arrays move between the
+   two worlds without surprises.
+2. Some behavior deliberately diverges from numpy.  The arrays serve the
+   solvers first: ghost regions extend an array below index zero for
+   solver halo data, alignment is an explicit constructor argument for SIMD
+   kernels, and buffer ownership stays explicit instead of numpy's implicit
+   base-object chain.
+3. Some behavior is converging toward numpy.  Comparison and selection
+   operations are being brought to numpy semantics incrementally; until the
+   convergence completes, the pages note where the current behavior still
+   differs from the target.
+
+Throughout the subpages, each operation family is tagged with one of three
+parity labels:
+
+- "matches numpy": the desired behavior is the numpy behavior; any observed
+  difference is a defect.
+- "diverges from numpy": the desired behavior intentionally differs; the
+  tag is followed by a short statement of the target semantics.
+- "converging to numpy": the numpy behavior is the target, but the current
+  implementation is not there yet; the tag is followed by what still
+  differs.
+
+## Contents
+
+```{toctree}
+:maxdepth: 2
+
+memory
+```
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/memory.md
+++ b/doc/source/compute/buffer/memory.md
@@ -1,0 +1,173 @@
+# Memory Buffers
+
+The raw memory layer of the SimpleArray family consists of two untyped byte
+buffers.  `ConcreteBuffer` owns a fixed-size block of contiguous memory and
+is the storage that every typed array sits on.  `BufferExpander` is a
+growable staging buffer for code that must accumulate bytes before the final
+size is known, and can hand its content over as a `ConcreteBuffer`.
+
+## ConcreteBuffer
+
+`ConcreteBuffer` is an untyped byte buffer.  It has no dtype, no shape, and
+no stride: it is a length in bytes and the memory behind it.  Once
+constructed, its size never changes.
+
+### Construction
+
+A buffer is constructed with a byte count and an optional alignment:
+
+```python
+buf = solvcon.ConcreteBuffer(1024)
+buf = solvcon.ConcreteBuffer(1024, alignment=64)
+```
+
+The memory is allocated immediately and is not initialized.  The `nbytes`
+property returns the byte count and `alignment` returns the requested
+alignment.  Valid alignment values are 0 (the default, no specific
+alignment), 16, 32, and 64 bytes; any other value raises `ValueError`.  When
+a non-zero alignment is requested, the byte count must be a multiple of the
+alignment, or the allocation raises `ValueError`.  A zero-byte buffer is
+permitted and records the requested alignment without allocating.
+
+### Sizing and Byte Access
+
+The buffer sizes and indexes like a Python sequence of bytes.  `len(buf)`
+equals `buf.nbytes`.  Indexing with `buf[i]` reads one byte and assignment
+`buf[i] = value` writes one byte; the element type is a signed 8-bit
+integer.  Indexing at or beyond the size raises `IndexError`:
+
+```python
+buf = solvcon.ConcreteBuffer(10)
+for it in range(len(buf)):
+    buf[it] = it
+buf[10]  # IndexError: ConcreteBuffer: index 10 is out of bounds ...
+```
+
+Iteration follows from indexing, so `list(buf)` returns the byte values.
+
+### Sharing with Numpy
+
+`ConcreteBuffer` implements the Python buffer protocol, exposing its memory
+as a one-dimensional `int8` sequence.  A numpy array built on the buffer
+shares the memory rather than copying it:
+
+```python
+import numpy as np
+buf = solvcon.ConcreteBuffer(10)
+ndarr = np.array(buf, copy=False)  # dtype int8, shape (10,)
+buf[3] = 7
+assert ndarr[3] == 7
+```
+
+The `ndarray` property is a shortcut that returns such an `int8` view
+directly.  The returned array holds a reference to the buffer, so the memory
+stays alive as long as the array does.
+
+### Cloning
+
+`clone()` returns a deep copy: a new buffer with the same byte count, the
+same alignment, and a copy of the content.  Writes to either buffer are not
+visible in the other.
+
+### Wrapping a Numpy Array
+
+The second constructor form wraps the memory of an existing numpy array
+instead of allocating:
+
+```python
+ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+buf = solvcon.ConcreteBuffer(array=ndarr)
+assert buf.nbytes == ndarr.nbytes
+```
+
+The dtype and shape of the source array do not matter; the buffer covers its
+`nbytes` bytes and shares them zero-copy, so writing through one side is
+visible on the other.  The buffer holds a reference to the source array,
+tying the lifetime of the memory to the Python object.  The
+`is_from_python` property reports the provenance: it is `True` for a buffer
+wrapping a numpy array and `False` for a buffer that allocated its own
+memory.
+
+## BufferExpander
+
+`BufferExpander` is an untyped byte buffer that grows.  It distinguishes
+its size (the bytes currently in use) from its capacity (the bytes
+allocated), like `std::vector`.  Its role is a staging area: accumulate
+bytes while the final length is unknown, then hand the result over as a
+`ConcreteBuffer` for the typed layer.  The internal expandable memory is
+never exposed to other components; only the concrete result is.
+
+### Construction
+
+Three forms are supported:
+
+```python
+ep = solvcon.BufferExpander()          # empty: size 0, capacity 0
+ep = solvcon.BufferExpander(10)        # size 10, capacity 10
+ep = solvcon.BufferExpander(buf)       # copy of a ConcreteBuffer
+```
+
+The third form initializes size and capacity to the byte count of the given
+`ConcreteBuffer` and copies its content; the expander does not alias the
+source buffer, so later writes to the expander leave the source unchanged.
+All forms accept an optional `alignment` keyword with the same valid values
+as `ConcreteBuffer` (0, 16, 32, or 64).
+
+### Growing
+
+`reserve(cap)` grows the capacity to at least `cap` bytes while keeping the
+size and the existing content; when `cap` does not exceed the current
+capacity it does nothing.  Capacity never shrinks.  `expand(length)`
+reserves `length` bytes and then sets the size to `length`:
+
+```python
+ep = solvcon.BufferExpander()
+ep.reserve(10)   # capacity 10, size still 0
+ep.expand(10)    # capacity 10, size 10
+```
+
+The `capacity` property returns the allocated byte count and `len(ep)`
+returns the size.
+
+### Byte Access
+
+Indexing works as on `ConcreteBuffer`: `ep[i]` reads and `ep[i] = value`
+writes single signed 8-bit bytes.  Bounds are checked against the size, not
+the capacity, so a reserved-but-unexpanded region is not addressable and
+raises `IndexError`.
+
+### Producing a ConcreteBuffer
+
+Two methods convert the staged bytes into a `ConcreteBuffer`, differing in
+whether the result shares memory with the expander:
+
+- `copy_concrete(cap=0)` returns an independent copy.  The new buffer holds
+  `max(cap, len(ep))` bytes with the staged content copied in; later writes
+  on either side do not affect the other.
+- `as_concrete(cap=0)` converts the expander in place.  The expander
+  adopts a `ConcreteBuffer` as its storage and returns it; from then on the
+  two objects share memory, so a write through one is visible through the
+  other.
+
+`clone()` returns a new independent `BufferExpander` with a copy of the
+content.
+
+The `is_concrete` property reports whether the expander is currently backed
+by a `ConcreteBuffer`.  It is `False` for a freshly expanded buffer, `True`
+after `as_concrete()`, and `True` for an expander constructed from a
+`ConcreteBuffer`:
+
+```python
+ep = solvcon.BufferExpander(10)
+assert not ep.is_concrete
+cbuf = ep.as_concrete()
+assert ep.is_concrete
+cbuf[0] = 42
+assert ep[0] == 42  # memory is shared
+```
+
+Growing the capacity after `as_concrete()` reallocates the storage and
+detaches the expander from the concrete buffer: `is_concrete` drops back to
+`False` and the previously returned buffer keeps the old memory.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/memory.md
+++ b/doc/source/compute/buffer/memory.md
@@ -80,10 +80,13 @@ buf = solvcon.ConcreteBuffer(array=ndarr)
 assert buf.nbytes == ndarr.nbytes
 ```
 
-The dtype and shape of the source array do not matter; the buffer covers its
-`nbytes` bytes and shares them zero-copy, so writing through one side is
-visible on the other.  The buffer holds a reference to the source array,
-tying the lifetime of the memory to the Python object.  The
+The dtype and shape of the source array do not matter, but the array must
+be contiguous; the buffer covers its `nbytes` bytes and shares them
+zero-copy, so writing through one side is visible on the other.  The
+constructor also accepts the optional `alignment` keyword, validated
+against the same set (0, 16, 32, or 64); no size-multiple check applies
+because nothing is allocated.  The buffer holds a reference to the source
+array, tying the lifetime of the memory to the Python object.  The
 `is_from_python` property reports the provenance: it is `True` for a buffer
 wrapping a numpy array and `False` for a buffer that allocated its own
 memory.
@@ -110,8 +113,10 @@ ep = solvcon.BufferExpander(buf)       # copy of a ConcreteBuffer
 The third form initializes size and capacity to the byte count of the given
 `ConcreteBuffer` and copies its content; the expander does not alias the
 source buffer, so later writes to the expander leave the source unchanged.
-All forms accept an optional `alignment` keyword with the same valid values
-as `ConcreteBuffer` (0, 16, 32, or 64).
+The sized and buffer-copying forms accept an optional `alignment` keyword
+with the same valid values as `ConcreteBuffer` (0, 16, 32, or 64); the
+empty form fixes the alignment at 0.  The read-only `alignment` property
+returns the value given at construction.
 
 ### Growing
 
@@ -147,7 +152,9 @@ whether the result shares memory with the expander:
 - `as_concrete(cap=0)` converts the expander in place.  The expander
   adopts a `ConcreteBuffer` as its storage and returns it; from then on the
   two objects share memory, so a write through one is visible through the
-  other.
+  other.  When the expander is not yet concrete, the adopted buffer holds
+  `max(cap, len(ep))` bytes; when it already is, `cap` is ignored and the
+  existing buffer is returned.
 
 `clone()` returns a new independent `BufferExpander` with a copy of the
 content.

--- a/doc/source/compute/index.md
+++ b/doc/source/compute/index.md
@@ -6,7 +6,7 @@ losing high performance.
 ```{toctree}
 :maxdepth: 2
 
-buffer
+buffer/index
 numerics
 geometry
 inout


### PR DESCRIPTION
This PR starts the SimpleArray Python API behavior document. The placeholder page doc/source/compute/buffer.md grows into the directory doc/source/compute/buffer/ so the document can be authored in reviewable pieces, one topic page per PR.

The new index.md keeps the Buffers and Arrays title, states the purpose of the array family, lists the class roster (ConcreteBuffer and BufferExpander, the 13 typed SimpleArray classes, the dtype-erased plex SimpleArray, and the 11 exported SimpleCollector types), and defines the numpy-parity policy and the three parity tags (matches numpy, diverges from numpy, converging to numpy) used by the coming subpages.

The new memory.md documents the desired behavior of the raw memory layer: ConcreteBuffer construction and alignment rules, byte access, the buffer protocol and the int8 ndarray view, cloning, wrapping an ndarray with lifetime tied to the Python object, and BufferExpander reserve/expand semantics including the sharing behavior of copy_concrete and as_concrete.

The Sphinx build passes with no new warnings. Diff is 266 insertions and 9 deletions across 4 files.

Plan tracked in #103.