### PR TITLE
Subwin step 2: directional tiling actions

### DIFF
--- a/solvcon/pilot/panel/_window_manager.py
+++ b/solvcon/pilot/panel/_window_manager.py
@@ -36,6 +36,10 @@ class WindowManager(_gui_common.PilotFeature):
     TILE_ID = "window.layout.tile"
     #: objectName of the cascade layout action.
     CASCADE_ID = "window.layout.cascade"
+    #: objectName of the single-row tiling action.
+    HORIZONTAL_ID = "window.layout.horizontal"
+    #: objectName of the single-column tiling action.
+    VERTICAL_ID = "window.layout.vertical"
 
     def __init__(self, *args, **kw):
         super(WindowManager, self).__init__(*args, **kw)
@@ -63,6 +67,14 @@ class WindowManager(_gui_common.PilotFeature):
                 "Window", "Cascade",
                 "Stack the open sub-windows with an offset",
                 self._cascade, id=self.CASCADE_ID, weight=11),
+            self.add_action(
+                "Window", "Tile Horizontally",
+                "Arrange the open sub-windows in a single row",
+                self._tile_horizontal, id=self.HORIZONTAL_ID, weight=12),
+            self.add_action(
+                "Window", "Tile Vertically",
+                "Arrange the open sub-windows in a single column",
+                self._tile_vertical, id=self.VERTICAL_ID, weight=13),
         ]
         self._mgr.menu_model.place_separator("Window", weight=30)
 
@@ -74,6 +86,41 @@ class WindowManager(_gui_common.PilotFeature):
 
     def _cascade(self):
         self._mgr.mdiArea.cascadeSubWindows()
+
+    def _tile_horizontal(self):
+        self._arrange(horizontal=True)
+
+    def _tile_vertical(self):
+        self._arrange(horizontal=False)
+
+    def _arrange(self, horizontal):
+        """Line the visible sub-windows up along one direction.
+
+        Each gets an equal share of the MDI viewport: side by side over
+        the full height when ``horizontal``, stacked over the full width
+        otherwise. QMdiArea has no directional counterpart to
+        tileSubWindows, so the geometry is dealt out by hand. A
+        minimized or maximized sub-window is restored first, else the
+        new geometry would not take effect.
+        """
+        mdi = self._mgr.mdiArea
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+        if not subwins:
+            return
+
+        area = mdi.contentsRect()
+        width, height = area.width(), area.height()
+        if horizontal:
+            width //= len(subwins)
+        else:
+            height //= len(subwins)
+
+        for index, subwin in enumerate(subwins):
+            if subwin.isMinimized() or subwin.isMaximized():
+                subwin.showNormal()
+            x = area.x() + index * width if horizontal else area.x()
+            y = area.y() if horizontal else area.y() + index * height
+            subwin.setGeometry(x, y, width, height)
 
     def _rebuild(self):
         """Refresh the sub-window list to match the MDI area.

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -151,6 +151,16 @@ class WindowLayoutTC(unittest.TestCase):
         """Fire the real freshness hook that refreshes the menu."""
         self.model.menu("Window").aboutToShow.emit()
 
+    def _layout_ids(self):
+        """Every static layout action the menu is expected to carry.
+
+        Not a class attribute: WindowManager is unbound when the GUI
+        imports fail, and a class-body reference would then break
+        collection of this skipped module.
+        """
+        return (WindowManager.TILE_ID, WindowManager.CASCADE_ID,
+                WindowManager.HORIZONTAL_ID, WindowManager.VERTICAL_ID)
+
     def test_layout_actions_precede_the_list(self):
         # The static layout section sits above the separator; the
         # dynamic list follows it.
@@ -158,21 +168,17 @@ class WindowLayoutTC(unittest.TestCase):
         names = [a.objectName() for a in acts]
         sep = [i for i, a in enumerate(acts) if a.isSeparator()]
         self.assertEqual(len(sep), 1)
-        self.assertLess(names.index(WindowManager.TILE_ID), sep[0])
-        self.assertLess(names.index(WindowManager.CASCADE_ID), sep[0])
+        for aid in self._layout_ids():
+            self.assertLess(names.index(aid), sep[0])
 
     def test_layout_actions_follow_open_windows(self):
         self._show()
-        self.assertFalse(self.model.action(WindowManager.TILE_ID)
-                         .isEnabled())
-        self.assertFalse(self.model.action(WindowManager.CASCADE_ID)
-                         .isEnabled())
+        for aid in self._layout_ids():
+            self.assertFalse(self.model.action(aid).isEnabled())
         self.mgr.add2DWidget()
         self._show()
-        self.assertTrue(self.model.action(WindowManager.TILE_ID)
-                        .isEnabled())
-        self.assertTrue(self.model.action(WindowManager.CASCADE_ID)
-                        .isEnabled())
+        for aid in self._layout_ids():
+            self.assertTrue(self.model.action(aid).isEnabled())
 
     def _stack(self):
         """Pile every sub-window onto one rectangle.
@@ -202,6 +208,41 @@ class WindowLayoutTC(unittest.TestCase):
         QtWidgets.QApplication.processEvents()
         one, two = [s.geometry() for s in self.area.subWindowList()]
         self.assertNotEqual(one.topLeft(), two.topLeft())
+
+    def test_horizontal_tiling_forms_a_single_row(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        self._stack()
+        self.model.action(WindowManager.HORIZONTAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+        self.assertEqual(one.y(), two.y())
+        self.assertEqual(one.height(), two.height())
+        self.assertNotEqual(one.x(), two.x())
+
+    def test_vertical_tiling_forms_a_single_column(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        self._stack()
+        self.model.action(WindowManager.VERTICAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
+        self.assertEqual(one.x(), two.x())
+        self.assertEqual(one.width(), two.width())
+        self.assertNotEqual(one.y(), two.y())
+
+    def test_directional_tiling_restores_a_minimized_window(self):
+        self.mgr.add2DWidget()
+        self.mgr.add3DWidget()
+        minimized = self.area.subWindowList()[0]
+        minimized.showMinimized()
+        self.model.action(WindowManager.HORIZONTAL_ID).trigger()
+        QtWidgets.QApplication.processEvents()
+        self.assertFalse(minimized.isMinimized())
+        one, two = [s.geometry() for s in self.area.subWindowList()]
+        self.assertFalse(one.intersects(two))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tile and Cascade spread the sub-windows over a grid, but comparing two viewers calls for a single row or a single column. QMdiArea has no directional counterpart to tileSubWindows, so the new Tile Horizontally and Tile Vertically actions deal equal shares of the MDI viewport out by hand, restoring a minimized or maximized sub-window first so the assigned geometry takes effect.

Widget tests assert the single-row and single-column geometry from a deliberately piled-up start, and that a minimized sub-window is restored and placed.

Related to #104.
