### PR TITLE
Subwin step 3: Tabbed View toggle

### DIFF
--- a/solvcon/pilot/panel/_window_manager.py
+++ b/solvcon/pilot/panel/_window_manager.py
@@ -10,7 +10,7 @@ Arrange the open MDI sub-windows through layout actions under the
 foreground when its entry is chosen.
 """
 
-from PySide6 import QtGui
+from PySide6 import QtGui, QtWidgets
 
 from ..base import _gui_common
 
@@ -22,9 +22,10 @@ __all__ = [
 class WindowManager(_gui_common.PilotFeature):
     """Arrange and list open MDI sub-windows under the "Window" menu.
 
-    A static section on top holds the layout actions (Tile, Cascade)
-    driving the QMdiArea built-in layouts. Below a separator follows one
-    checkable action per open sub-window, labelled by its title.
+    A static section on top holds the layout actions arranging the
+    sub-windows over the area, and a toggle switching the area to a
+    tabbed view. Below a separator follows one checkable action per
+    open sub-window, labelled by its title.
     Triggering an action activates that sub-window; the active one is
     checked. The list is rebuilt, and the layout actions follow whether
     any sub-window is open, each time the menu is about to show.
@@ -40,6 +41,8 @@ class WindowManager(_gui_common.PilotFeature):
     HORIZONTAL_ID = "window.layout.horizontal"
     #: objectName of the single-column tiling action.
     VERTICAL_ID = "window.layout.vertical"
+    #: objectName of the tabbed view mode toggle.
+    TABBED_ID = "window.layout.tabbed"
 
     def __init__(self, *args, **kw):
         super(WindowManager, self).__init__(*args, **kw)
@@ -76,6 +79,13 @@ class WindowManager(_gui_common.PilotFeature):
                 "Arrange the open sub-windows in a single column",
                 self._tile_vertical, id=self.VERTICAL_ID, weight=13),
         ]
+
+        act = self.add_action(
+            "Window", "Tabbed View",
+            "Show the sub-windows as pages of a tab bar",
+            None, id=self.TABBED_ID, weight=20, checkable=True)
+        act.toggled.connect(self._set_tabbed)
+
         self._mgr.menu_model.place_separator("Window", weight=30)
 
         self._menu.aboutToShow.connect(self._rebuild)
@@ -87,11 +97,41 @@ class WindowManager(_gui_common.PilotFeature):
     def _cascade(self):
         self._mgr.mdiArea.cascadeSubWindows()
 
+    def _set_tabbed(self, on):
+        """Switch the MDI area between sub-window and tabbed view.
+
+        Entering the tabbed view makes the tabs closable and movable, so
+        the tab bar keeps the window controls the sub-window frames
+        provided. The layout actions are refreshed right away: tiling
+        and cascading mean nothing while the area shows tabs.
+        """
+        mdi = self._mgr.mdiArea
+        if on:
+            mdi.setViewMode(QtWidgets.QMdiArea.ViewMode.TabbedView)
+            mdi.setTabsClosable(True)
+            mdi.setTabsMovable(True)
+        else:
+            mdi.setViewMode(QtWidgets.QMdiArea.ViewMode.SubWindowView)
+        self._update_layout_actions()
+
     def _tile_horizontal(self):
         self._arrange(horizontal=True)
 
     def _tile_vertical(self):
         self._arrange(horizontal=False)
+
+    def _update_layout_actions(self):
+        """Enable the layout actions only when they can act.
+
+        They need a sub-window to arrange, and the sub-window view to
+        arrange it in: geometry is meaningless while the area shows
+        tabs.
+        """
+        mdi = self._mgr.mdiArea
+        subwins = [s for s in mdi.subWindowList() if s.isVisible()]
+        tabbed = mdi.viewMode() == QtWidgets.QMdiArea.ViewMode.TabbedView
+        for act in self._layout_actions:
+            act.setEnabled(bool(subwins) and not tabbed)
 
     def _arrange(self, horizontal):
         """Line the visible sub-windows up along one direction.
@@ -139,8 +179,7 @@ class WindowManager(_gui_common.PilotFeature):
         active = mdi.activeSubWindow()
         subwins = [s for s in mdi.subWindowList() if s.isVisible()]
 
-        for act in self._layout_actions:
-            act.setEnabled(bool(subwins))
+        self._update_layout_actions()
 
         if not subwins:
             self._append_placeholder()

--- a/tests/test_pilot_window_menu.py
+++ b/tests/test_pilot_window_menu.py
@@ -245,6 +245,63 @@ class WindowLayoutTC(unittest.TestCase):
         self.assertFalse(one.intersects(two))
 
 
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class TabbedViewTC(unittest.TestCase):
+    """Drive the "Tabbed View" toggle in the "Window" menu."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        self.model = self.mgr.menu_model
+        self.area = self.mgr.mdiArea
+        self.mgr.show()
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+        # The MDI area outlives each case; put the view mode back so a
+        # leftover tab bar cannot leak into the next case.
+        self.addCleanup(self.model.action(WindowManager.TABBED_ID)
+                        .setChecked, False)
+
+    def tearDown(self):
+        self.area.closeAllSubWindows()
+        QtWidgets.QApplication.processEvents()
+
+    def _show(self):
+        """Fire the real freshness hook that refreshes the menu."""
+        self.model.menu("Window").aboutToShow.emit()
+
+    def test_toggle_switches_the_view_mode(self):
+        act = self.model.action(WindowManager.TABBED_ID)
+        Mode = QtWidgets.QMdiArea.ViewMode
+        self.assertEqual(self.area.viewMode(), Mode.SubWindowView)
+        act.setChecked(True)
+        self.assertEqual(self.area.viewMode(), Mode.TabbedView)
+        act.setChecked(False)
+        self.assertEqual(self.area.viewMode(), Mode.SubWindowView)
+
+    def test_tabs_are_closable_and_movable(self):
+        # Tabs must keep the window controls the sub-window frames
+        # provided, or a window opened in tabbed view could never be
+        # closed from the tab bar.
+        self.model.action(WindowManager.TABBED_ID).setChecked(True)
+        self.assertTrue(self.area.tabsClosable())
+        self.assertTrue(self.area.tabsMovable())
+
+    def test_tabbed_view_disables_the_layout_actions(self):
+        self.mgr.add2DWidget()
+        act = self.model.action(WindowManager.TABBED_ID)
+        self._show()
+        self.assertTrue(self.model.action(WindowManager.TILE_ID)
+                        .isEnabled())
+        act.setChecked(True)
+        self.assertFalse(self.model.action(WindowManager.TILE_ID)
+                         .isEnabled())
+        self.assertTrue(act.isEnabled())
+        act.setChecked(False)
+        self.assertTrue(self.model.action(WindowManager.TILE_ID)
+                        .isEnabled())
+
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
Sub-windows suit side-by-side comparison, but hopping between full-size viewers is better served by tabs. This last step adds a checkable Tabbed View action switching the MDI area between the sub-window and tabbed view modes. Tabs are made closable and movable so the tab bar keeps the window controls the sub-window frames provided, and the layout actions are disabled while the area shows tabs because geometry means nothing there.

Widget tests cover the mode switch round trip, the tab bar controls, and the enable state of the layout actions across the toggle.

Related to #104.
