### PR TITLE
Remember the pilot window size and location

### DIFF
--- a/STYLE.md
+++ b/STYLE.md
@@ -199,6 +199,8 @@ some_object.do_something(with_some_information)
 ### Acronym
 
 Treat acronyms like a word. Do not make them all-upper-cases in names.
+The rule holds in both C++ and Python, and applies no matter how short
+the acronym is or how habitually it is written in capitals elsewhere.
 
 ```cpp
 // "Http" is treated like a word in CamelCase.
@@ -207,6 +209,14 @@ class HttpRequest
     // "http" is treated like a word in snake_case.
     void update_http_header();
 } /* end class HttpRequest */
+```
+
+```python
+# "Ui" is treated like a word in CamelCase, so it is not "UIState".
+class UiState(object):
+    # "ui" is treated like a word in snake_case.
+    def apply_ui_section(self, section):
+        pass
 ```
 
 ### Qt

--- a/doc/source/pilot/index.md
+++ b/doc/source/pilot/index.md
@@ -9,6 +9,7 @@ from the interactive console. It provides two major functions:
 
 Graphical Editor in 2D Plane <canvas>
 Analysis and Visualization in 2/3D Spatial Domain <domain>
+Settings <settings>
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/pilot/settings.md
+++ b/doc/source/pilot/settings.md
@@ -1,0 +1,36 @@
+# Settings
+
+Pilot keeps its settings in `pilot.json` in solvcon's configuration directory,
+resolved in this order:
+
+1. `$SOLVCON_CONFIG_HOME`, taken as the directory itself when it is set. This
+   keeps a test or a self-contained checkout from touching the settings of the
+   user who runs it.
+2. `$XDG_CONFIG_HOME/solvcon`, when `XDG_CONFIG_HOME` is set.
+3. `~/.config/solvcon` otherwise.
+
+Pilot starts from its defaults when the file is missing or cannot be parsed,
+so removing the file or breaking a hand edit does not stop the application.
+
+Settings are grouped by section. The `ui` section holds the state of the user
+interface, one entry per part of it that is remembered:
+
+```json
+{
+  "ui": {
+    "window": {
+      "height": 600,
+      "width": 1000,
+      "x": 100,
+      "y": 80
+    }
+  }
+}
+```
+
+The `window` entry is the main window's size and location, applied at startup
+and written back when the application quits. A saved location on a screen that
+is no longer connected is ignored, so the window cannot come back out of sight
+after a monitor is detached.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/solvcon/__init__.py
+++ b/solvcon/__init__.py
@@ -19,6 +19,7 @@ from . import multidim  # noqa: F401
 from . import system  # noqa: F401
 from . import testing  # noqa: F401
 from . import toggle  # noqa: F401
+from . import config  # noqa: F401
 from . import track  # noqa: F401
 
 clinfo = core.ProcessInfo.instance.command_line

--- a/solvcon/config.py
+++ b/solvcon/config.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+The application configuration and its persistent storage.
+"""
+
+
+import os
+import json
+
+
+__all__ = [
+    'Config',
+]
+
+
+class Config(object):
+    """The application configuration, collected from every source.
+
+    This is the one object the rest of the code asks for a setting. It reads
+    and writes the JSON file in the user's configuration directory.
+
+    Reading tolerates a missing or unreadable file by starting from an empty
+    configuration, so a first run or a hand-corrupted file never blocks the
+    application. Writing goes through a sibling temporary file and an atomic
+    replace, so an interrupted write never truncates a good configuration.
+
+    :ivar path: Filesystem path of the backing JSON file.
+    :vartype path: str
+    """
+
+    #: Basename of the settings file, which holds the GUI's configuration.
+    FILENAME = "pilot.json"
+
+    def __init__(self, path=None):
+        self.path = self.default_path() if path is None else path
+        self._data = {}
+
+    @staticmethod
+    def config_home():
+        """The directory holding solvcon's configuration files.
+
+        ``SOLVCON_CONFIG_HOME`` names the directory outright and wins when
+        it is set, which lets a test or a self-contained checkout keep its
+        settings away from the invoking user's. Otherwise the directory is
+        ``solvcon`` under ``XDG_CONFIG_HOME``, or under ``~/.config`` when
+        that is unset, the convention on the platforms solvcon targets.
+        """
+        home = os.environ.get("SOLVCON_CONFIG_HOME", "")
+        if home:
+            return home
+        base = os.environ.get("XDG_CONFIG_HOME", "")
+        if not base:
+            base = os.path.join(os.path.expanduser("~"), ".config")
+        return os.path.join(base, "solvcon")
+
+    @classmethod
+    def default_path(cls):
+        """The default configuration path, ``<config_home>/<FILENAME>``."""
+        return os.path.join(cls.config_home(), cls.FILENAME)
+
+    def load(self):
+        """Read the file into memory, or start empty when it is unusable."""
+        try:
+            with open(self.path, "r", encoding="utf-8") as fobj:
+                data = json.load(fobj)
+        except (OSError, ValueError):
+            data = {}
+        self._data = data if isinstance(data, dict) else {}
+        return self
+
+    def save(self):
+        """Write the in-memory configuration back to the file atomically."""
+        os.makedirs(os.path.dirname(self.path), exist_ok=True)
+        tmp = self.path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fobj:
+            json.dump(self._data, fobj, indent=2, sort_keys=True)
+            fobj.write("\n")
+        os.replace(tmp, self.path)
+        return self
+
+    def get(self, key, default=None):
+        """Return the setting at ``key``, or ``default`` when it is absent."""
+        return self._data.get(key, default)
+
+    def set(self, key, value):
+        """Store ``value`` under ``key``; :meth:`save` writes it out."""
+        self._data[key] = value
+        return self
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/solvcon/pilot/base/_gui.py
+++ b/solvcon/pilot/base/_gui.py
@@ -28,6 +28,7 @@ if _pcore.enable:
     from ..panel import _profiling
     from ..agent import _agent_gui
     from . import _theme
+    from . import _ui_state
     from ..panel import _window_manager
 
 __all__ = [  # noqa: F822
@@ -75,6 +76,7 @@ class _Controller(metaclass=_Singleton):
         self.agent = None
         self.theme_menu = None
         self.window_manager = None
+        self.ui_state = None
 
     def __getattr__(self, name):
         return None if self._rmgr is None else getattr(self._rmgr, name)
@@ -125,6 +127,7 @@ class _Controller(metaclass=_Singleton):
         self.agent = _agent_gui.AgentPanel(mgr=self._rmgr)
         self.theme_menu = _theme.ThemeMenu(mgr=self._rmgr)
         self.window_manager = _window_manager.WindowManager(mgr=self._rmgr)
+        self.ui_state = _ui_state.UiState(mgr=self._rmgr)
         self.populate_menu()
         self._seed_console_namespace()
         self._built = True

--- a/solvcon/pilot/base/_ui_state.py
+++ b/solvcon/pilot/base/_ui_state.py
@@ -1,0 +1,130 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Remember the pilot user-interface state across sessions.
+"""
+
+
+from PySide6 import QtCore, QtGui
+
+from ...config import Config
+from . import _gui_common
+
+__all__ = [
+    'UiState',
+    'WindowGeometry',
+    'apply_geometry',
+    'capture_geometry',
+]
+
+
+def _is_int(value):
+    """Whether ``value`` is a plain integer, excluding ``bool``."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _on_screen(x, y):
+    """Whether the point ``(x, y)`` lies on some connected screen."""
+    point = QtCore.QPoint(x, y)
+    for screen in QtGui.QGuiApplication.screens():
+        if screen.availableGeometry().contains(point):
+            return True
+    return False
+
+
+def apply_geometry(window, section):
+    """Apply a stored geometry ``section`` to ``window``."""
+    if not isinstance(section, dict):
+        return
+    width, height = section.get("width"), section.get("height")
+    if _is_int(width) and _is_int(height) and width > 0 and height > 0:
+        window.resize(width, height)
+    x, y = section.get("x"), section.get("y")
+    if _is_int(x) and _is_int(y) and _on_screen(x, y):
+        window.move(x, y)
+
+
+def capture_geometry(window):
+    """Return the current size and location of ``window`` as a section."""
+    size, pos = window.size(), window.pos()
+    return {
+        "width": size.width(),
+        "height": size.height(),
+        "x": pos.x(),
+        "y": pos.y(),
+    }
+
+
+class WindowGeometry(object):
+    """The size and location of a window, as one piece of UI state."""
+
+    #: Name of this part within the UI state.
+    KEY = "window"
+
+    def __init__(self, window):
+        self._window = window
+
+    def apply(self, section):
+        """Resize and move the window to match ``section``."""
+        apply_geometry(self._window, section)
+
+    def capture(self):
+        """Return the window's present size and location."""
+        return capture_geometry(self._window)
+
+
+class UiState(_gui_common.PilotFeature):
+    """Persist the pilot user-interface state in the user configuration.
+
+    The state is a set of parts stored under the ``ui`` section. A part
+    carries a ``KEY`` naming its section, an ``apply`` taking that section,
+    and a ``capture`` returning it. :meth:`add` registers one, and a part
+    whose section is absent receives ``None``.
+    """
+
+    #: Configuration key holding every UI-state part.
+    SECTION = "ui"
+
+    def __init__(self, *args, config=None, parts=None, **kw):
+        """
+        :param config: Store the state is read from and written to.
+            Defaults to the configuration in the user's directory.
+        :type config: solvcon.config.Config
+        :param parts: The parts to keep, in the order they are applied.
+            Defaults to the main window's geometry alone.
+        :type parts: iterable
+        """
+        super(UiState, self).__init__(*args, **kw)
+        self._config = Config() if config is None else config
+        if parts is None:
+            parts = [WindowGeometry(self._mainWindow)]
+        self._parts = list(parts)
+        self._config.load()
+        self.restore()
+        app = QtCore.QCoreApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self.save)
+
+    def add(self, part):
+        """Register one more part, returning it for the caller to keep."""
+        self._parts.append(part)
+        return part
+
+    def restore(self):
+        """Apply every stored part to the interface."""
+        state = self._config.get(self.SECTION)
+        if not isinstance(state, dict):
+            state = {}
+        for part in self._parts:
+            part.apply(state.get(part.KEY))
+
+    def save(self):
+        """Capture every part and persist them together."""
+        state = {part.KEY: part.capture() for part in self._parts}
+        self._config.set(self.SECTION, state)
+        self._config.save()
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Tests for the user-level configuration file.
+"""
+
+
+import os
+import json
+import tempfile
+import unittest
+
+from solvcon.config import Config
+
+
+class ConfigPathTC(unittest.TestCase):
+    """Where the default configuration file resolves."""
+
+    #: Every variable the resolution consults, saved and restored per test.
+    VARIABLES = ("SOLVCON_CONFIG_HOME", "XDG_CONFIG_HOME")
+
+    def setUp(self):
+        self._saved = {k: os.environ.get(k) for k in self.VARIABLES}
+        for name in self.VARIABLES:
+            os.environ.pop(name, None)
+
+    def tearDown(self):
+        for name, value in self._saved.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+
+    def test_honors_solvcon_config_home(self):
+        os.environ["SOLVCON_CONFIG_HOME"] = "/sc/here"
+        self.assertEqual(Config.config_home(), "/sc/here")
+        self.assertEqual(Config.default_path(), "/sc/here/pilot.json")
+
+    def test_solvcon_config_home_precedes_xdg(self):
+        os.environ["SOLVCON_CONFIG_HOME"] = "/sc/here"
+        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
+        self.assertEqual(Config.config_home(), "/sc/here")
+
+    def test_empty_solvcon_config_home_falls_through(self):
+        os.environ["SOLVCON_CONFIG_HOME"] = ""
+        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
+        self.assertEqual(Config.config_home(), "/xdg/here/solvcon")
+
+    def test_honors_xdg_config_home(self):
+        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
+        self.assertEqual(Config.config_home(), "/xdg/here/solvcon")
+        self.assertEqual(
+            Config.default_path(), "/xdg/here/solvcon/pilot.json")
+
+    def test_falls_back_to_dot_config(self):
+        home = os.path.expanduser("~")
+        self.assertEqual(
+            Config.config_home(),
+            os.path.join(home, ".config", "solvcon"))
+
+    def test_default_path_is_used_without_an_argument(self):
+        self.assertEqual(Config().path, Config.default_path())
+
+
+class ConfigIoTC(unittest.TestCase):
+    """Reading, writing, and the resilience of both."""
+
+    def setUp(self):
+        self._dir = tempfile.mkdtemp()
+        self.path = os.path.join(self._dir, "sub", "pilot.json")
+
+    def tearDown(self):
+        for root, _, files in os.walk(self._dir, topdown=False):
+            for name in files:
+                os.remove(os.path.join(root, name))
+            os.rmdir(root)
+
+    def test_missing_file_loads_empty(self):
+        cfg = Config(self.path).load()
+        self.assertIsNone(cfg.get("window"))
+        self.assertEqual(cfg.get("window", "fallback"), "fallback")
+
+    def test_save_creates_parent_directory(self):
+        Config(self.path).set("window", {"width": 800}).save()
+        self.assertTrue(os.path.isfile(self.path))
+
+    def test_round_trip(self):
+        Config(self.path).set(
+            "window", {"width": 800, "height": 600, "x": 10, "y": 20}).save()
+        reloaded = Config(self.path).load()
+        self.assertEqual(
+            reloaded.get("window"),
+            {"width": 800, "height": 600, "x": 10, "y": 20})
+
+    def test_save_leaves_no_temporary_file(self):
+        Config(self.path).set("window", {"width": 800}).save()
+        self.assertFalse(os.path.exists(self.path + ".tmp"))
+
+    def test_corrupt_file_loads_empty(self):
+        os.makedirs(os.path.dirname(self.path))
+        with open(self.path, "w", encoding="utf-8") as fobj:
+            fobj.write("{not valid json")
+        cfg = Config(self.path).load()
+        self.assertIsNone(cfg.get("window"))
+
+    def test_non_object_file_loads_empty(self):
+        os.makedirs(os.path.dirname(self.path))
+        with open(self.path, "w", encoding="utf-8") as fobj:
+            json.dump([1, 2, 3], fobj)
+        cfg = Config(self.path).load()
+        self.assertIsNone(cfg.get("window"))
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:

--- a/tests/test_pilot_ui_state.py
+++ b/tests/test_pilot_ui_state.py
@@ -1,0 +1,169 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+
+"""
+Tests for remembering the pilot user-interface state.
+"""
+
+
+import os
+import tempfile
+import unittest
+
+import solvcon
+
+try:
+    from solvcon import pilot
+    from solvcon.config import Config
+    from solvcon.pilot.base import _gui
+    from solvcon.pilot.base import _ui_state
+    from PySide6 import QtGui, QtWidgets
+except ImportError:
+    pilot = None
+
+GITHUB_ACTIONS = os.getenv('GITHUB_ACTIONS', False)
+
+
+class FakePart(object):
+    """A UI-state part with no Qt behind it, to drive UiState alone."""
+
+    def __init__(self, key, value=None):
+        self.KEY = key
+        self.value = value
+        self.applied = []
+
+    def apply(self, section):
+        self.applied.append(section)
+        if section is not None:
+            self.value = section
+
+    def capture(self):
+        return self.value
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class GeometrySeamTC(unittest.TestCase):
+    """Drive the geometry policy against a hidden, fully controlled window.
+
+    A hidden top-level window honors resize() and move() synchronously,
+    without a window manager imposing its own size, so these assertions are
+    stable where a live shown window would be flaky.
+    """
+
+    def setUp(self):
+        _gui.controller.build()
+        self.win = QtWidgets.QMainWindow()
+        self.win.resize(1000, 600)
+
+    def tearDown(self):
+        self.win.deleteLater()
+        QtWidgets.QApplication.processEvents()
+
+    def _on_screen_origin(self):
+        """A point safely inside the primary screen's available area."""
+        avail = QtGui.QGuiApplication.primaryScreen().availableGeometry()
+        return avail.x() + 40, avail.y() + 40
+
+    def test_apply_sets_size_and_location(self):
+        x, y = self._on_screen_origin()
+        _ui_state.apply_geometry(
+            self.win, {"width": 820, "height": 540, "x": x, "y": y})
+        self.assertEqual(self.win.size().width(), 820)
+        self.assertEqual(self.win.size().height(), 540)
+        self.assertEqual((self.win.pos().x(), self.win.pos().y()), (x, y))
+
+    def test_apply_ignores_a_missing_section(self):
+        _ui_state.apply_geometry(self.win, None)
+        self.assertEqual((self.win.size().width(), self.win.size().height()),
+                         (1000, 600))
+
+    def test_apply_rejects_non_positive_size(self):
+        _ui_state.apply_geometry(self.win, {"width": 0, "height": -5})
+        self.assertEqual((self.win.size().width(), self.win.size().height()),
+                         (1000, 600))
+
+    def test_apply_rejects_off_screen_location(self):
+        _ui_state.apply_geometry(self.win, {"x": -30000, "y": -30000})
+        self.assertNotEqual((self.win.pos().x(), self.win.pos().y()),
+                            (-30000, -30000))
+
+    def test_capture_reads_the_current_geometry(self):
+        x, y = self._on_screen_origin()
+        self.win.resize(760, 480)
+        self.win.move(x, y)
+        section = _ui_state.capture_geometry(self.win)
+        self.assertEqual(section["width"], 760)
+        self.assertEqual(section["height"], 480)
+        self.assertEqual((section["x"], section["y"]), (x, y))
+
+    def test_window_geometry_part_round_trips_its_window(self):
+        part = _ui_state.WindowGeometry(self.win)
+        self.assertEqual(part.KEY, "window")
+        part.apply({"width": 700, "height": 420})
+        self.assertEqual(part.capture()["width"], 700)
+        self.assertEqual(part.capture()["height"], 420)
+
+
+@unittest.skipIf(GITHUB_ACTIONS or not solvcon.HAS_PILOT,
+                 "GUI is not available in GitHub Actions")
+class UiStateTC(unittest.TestCase):
+    """UiState coordinates any number of named parts, not windows alone."""
+
+    def setUp(self):
+        self.mgr = _gui.controller.build()
+        fd, self.path = tempfile.mkstemp(suffix=".json")
+        os.close(fd)
+        os.remove(self.path)
+
+    def tearDown(self):
+        if os.path.exists(self.path):
+            os.remove(self.path)
+
+    def _state(self, parts):
+        return _ui_state.UiState(
+            mgr=self.mgr, config=Config(self.path), parts=parts)
+
+    def test_save_groups_every_part_under_the_ui_section(self):
+        self._state([FakePart("alpha", 1), FakePart("beta", 2)]).save()
+        data = Config(self.path).load()
+        self.assertEqual(data.get("ui"), {"alpha": 1, "beta": 2})
+
+    def test_restore_hands_each_part_its_own_section(self):
+        Config(self.path).set(
+            "ui", {"alpha": "A", "beta": "B"}).save()
+        alpha, beta = FakePart("alpha"), FakePart("beta")
+        self._state([alpha, beta])
+        self.assertEqual(alpha.applied, ["A"])
+        self.assertEqual(beta.applied, ["B"])
+
+    def test_restore_passes_none_for_an_absent_part(self):
+        Config(self.path).set("ui", {"alpha": "A"}).save()
+        beta = FakePart("beta", "default")
+        self._state([beta])
+        self.assertEqual(beta.applied, [None])
+        self.assertEqual(beta.value, "default")
+
+    def test_restore_tolerates_a_missing_ui_section(self):
+        part = FakePart("alpha", "default")
+        self._state([part])
+        self.assertEqual(part.applied, [None])
+
+    def test_added_part_joins_the_saved_state(self):
+        state = self._state([FakePart("alpha", 1)])
+        state.add(FakePart("gamma", 3))
+        state.save()
+        self.assertEqual(
+            Config(self.path).load().get("ui"), {"alpha": 1, "gamma": 3})
+
+    def test_window_geometry_is_the_default_part(self):
+        state = _ui_state.UiState(
+            mgr=self.mgr, config=Config(self.path))
+        state.save()
+        section = Config(self.path).load().get("ui")["window"]
+        self.assertEqual(
+            section, _ui_state.capture_geometry(self.mgr.mainWindow))
+
+
+# vim: set ff=unix fenc=utf8 et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Add a user configuration file for the pilot and use it to remember the user-interface state across sessions. The window size and location is the first piece of state it carries.

The new UserConfig is a user-tier settings store backed by a JSON file. It resolves its path under the user's configuration home, honoring XDG_CONFIG_HOME and falling back to ~/.config, and offers load, save, get, and set over a plain settings dictionary. Reads tolerate a missing or corrupt file by starting empty, and writes go through a temporary file and an atomic replace so an interrupted write cannot truncate a good configuration. This is only the user tier; a global tier and a tier-overriding mechanism are left for later.

The UIState pilot feature restores the saved interface state on startup and writes it back when the application is about to quit, under the "ui" section of the configuration file. The state is a set of named parts rather than one fixed record: each part owns a configuration key, applies its stored section on startup, and captures it again on exit, so a later piece of interface state joins by registering with add() instead of by extending the feature. WindowGeometry is the first part.

The geometry policy lives in the free functions apply_geometry and capture_geometry so it can be tested against a controlled window rather than the live main window, whose on-screen size a window manager can override. A restore is skipped when the saved size is non-positive or the saved location falls on no connected screen, so the window cannot come back off-screen after a monitor is detached. The controller builds the feature last, after the launch-default resize, so a saved geometry takes precedence over the default.

Tests: the configuration file behavior is covered by Qt-free unit tests that run everywhere. The UI-state coordination is driven through a fake part with no Qt behind it, covering per-part sections, an absent section, and registration through add(). The geometry policy and the default part are covered by GUI tests that skip where no display is available. The full suite passes locally and make lint is clean.