### PR TITLE
Step2: Document array construction, dtypes, and collectors

### DIFF
--- a/doc/source/compute/buffer/collector.md
+++ b/doc/source/compute/buffer/collector.md
@@ -90,14 +90,15 @@ arr = ct.as_array()
 assert list(arr) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
 ```
 
-The conversion does not copy: it converts the underlying expander in
-place, and the returned array shares memory with the collector, so a
-write through one side is visible through the other.  The alignment of
-the collector carries over to the array.  Growing the collector past its
-capacity after the conversion reallocates the storage and detaches the
-two objects; the previously returned array keeps the old memory, as does
-`clear()`, which only resets the size and leaves the shared content in
-place.
+The conversion converts the underlying expander in place: the expander
+adopts a `ConcreteBuffer` as its storage, and the returned array wraps
+that buffer, so from then on the array and the collector share memory
+and a write through one side is visible through the other.  The
+alignment of the collector carries over to the array.  The conversion
+also sets the capacity equal to the size, so a subsequent `push_back`
+reallocates the storage and detaches the two objects; the previously
+returned array keeps the old memory, as does `clear()`, which only
+resets the size and leaves the shared content in place.
 
 ## Alignment
 
@@ -113,13 +114,19 @@ Valid values are 0 (the default), 16, 32, and 64 bytes; any other value
 raises `ValueError`.  With a non-zero alignment, the byte count of every
 allocation (the element count times the item size) must be a multiple of
 the alignment, or the operation raises `ValueError`; the check applies to
-the sized constructor and to `reserve`:
+the sized constructor, to `reserve`, to the allocation behind
+`as_array`, and to the growth done by `push_back`:
 
 ```python
 ct = solvcon.SimpleCollectorFloat64(16, 16)  # 128 bytes, multiple of 16
 ct.reserve(33)
 # ValueError: BufferExpander::allocate: size ... must be a multiple ...
 ```
+
+An aligned collector must therefore start from a size that satisfies the
+multiple constraint: an empty 16-byte-aligned `SimpleCollectorFloat64`
+cannot `push_back`, because the initial capacity-one growth would
+allocate 8 bytes against the 16-byte alignment.
 
 The read-only `alignment` property returns the requested value, and the
 array produced by `as_array()` reports the same alignment.

--- a/doc/source/compute/buffer/collector.md
+++ b/doc/source/compute/buffer/collector.md
@@ -1,0 +1,127 @@
+# Element Collectors
+
+The SimpleCollector classes are growable typed buffers in the spirit of
+`std::vector`.  A collector accumulates elements one by one while the
+final count is unknown, then hands the result over as a `SimpleArray` for
+the typed layer.  It is the element-typed counterpart of the byte-level
+`BufferExpander` and is built on top of it.  Numpy has no counterpart:
+numpy arrays are fixed-size, so the accumulate-then-convert workflow is
+where solvcon code reaches for a collector instead of an array.
+
+The exported roster has 11 classes, one per non-complex element type:
+`SimpleCollectorBool`, `SimpleCollectorInt8` through
+`SimpleCollectorInt64`, `SimpleCollectorUint8` through
+`SimpleCollectorUint64`, `SimpleCollectorFloat32`, and
+`SimpleCollectorFloat64`.  The extension module also registers the two
+complex collectors, but the top-level `solvcon` package does not export
+them.
+
+## Construction
+
+Two forms are supported:
+
+```python
+ct = solvcon.SimpleCollectorFloat64()    # size 0, capacity 0
+ct = solvcon.SimpleCollectorFloat64(10)  # size 10, capacity 10
+```
+
+The sized form allocates storage for the given element count and sets
+both the size and the capacity to it; the elements are not initialized.
+The sized form also accepts an optional alignment as the second argument
+(see below).
+
+## Sizing and Growing
+
+A collector distinguishes its size (the elements currently stored) from
+its capacity (the elements allocated), both counted in elements.
+`len(ct)` returns the size and the `capacity` property returns the
+capacity.  `reserve(cap)` grows the capacity while keeping the size, and
+`expand(length)` reserves and then sets the size, mirroring the methods
+of `BufferExpander` at element granularity.
+
+`push_back(value)` appends one element, growing the capacity when full:
+an empty collector allocates capacity 1, and a full collector doubles its
+capacity.  The amortized-doubling growth keeps a long accumulation loop
+cheap:
+
+```python
+ct = solvcon.SimpleCollectorFloat64()
+for it in range(6):
+    ct.push_back(it * 1.1)
+assert len(ct) == 6
+assert ct.capacity == 8   # grew 0, 1, 2, 4, 8
+```
+
+`clear()` resets the size to zero and keeps the capacity and alignment,
+so the collector can be refilled without reallocating.
+
+## Element Access
+
+Indexing reads and writes single elements of the collector's value type,
+so a collector sized up front can also be filled by index instead of by
+appending:
+
+```python
+ct = solvcon.SimpleCollectorFloat64()
+ct.expand(6)
+for it in range(6):
+    ct[it] = float(it)
+```
+
+Bounds are checked against the size, not the capacity, so a
+reserved-but-unfilled slot is not addressable:
+
+```python
+ct = solvcon.SimpleCollectorFloat64()
+ct.reserve(6)
+ct[0]  # IndexError: SimpleCollector: index 0 is out of bounds ...
+```
+
+## Converting to a SimpleArray
+
+`as_array()` returns a one-dimensional `SimpleArray` of the matching
+dtype whose length is the collector's size:
+
+```python
+ct = solvcon.SimpleCollectorFloat64()
+for it in range(6):
+    ct.push_back(float(it))
+arr = ct.as_array()
+assert list(arr) == [0.0, 1.0, 2.0, 3.0, 4.0, 5.0]
+```
+
+The conversion does not copy: it converts the underlying expander in
+place, and the returned array shares memory with the collector, so a
+write through one side is visible through the other.  The alignment of
+the collector carries over to the array.  Growing the collector past its
+capacity after the conversion reallocates the storage and detaches the
+two objects; the previously returned array keeps the old memory, as does
+`clear()`, which only resets the size and leaves the shared content in
+place.
+
+## Alignment
+
+Like the arrays, a collector accepts a solvcon-specific alignment with no
+numpy analogue, passed as the second constructor argument:
+
+```python
+ct = solvcon.SimpleCollectorFloat64(16, 16)
+assert ct.alignment == 16
+```
+
+Valid values are 0 (the default), 16, 32, and 64 bytes; any other value
+raises `ValueError`.  With a non-zero alignment, the byte count of every
+allocation (the element count times the item size) must be a multiple of
+the alignment, or the operation raises `ValueError`; the check applies to
+the sized constructor and to `reserve`:
+
+```python
+ct = solvcon.SimpleCollectorFloat64(16, 16)  # 128 bytes, multiple of 16
+ct.reserve(33)
+# ValueError: BufferExpander::allocate: size ... must be a multiple ...
+```
+
+The read-only `alignment` property returns the requested value, and the
+array produced by `as_array()` reports the same alignment.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/construct.md
+++ b/doc/source/compute/buffer/construct.md
@@ -1,0 +1,266 @@
+# Construction and Data Types
+
+The SimpleArray family is constructed in two styles.  The 13 typed classes
+fix the element type in the class name and take a shape; the dtype-erased
+`SimpleArray` takes a shape plus a dtype string and wraps the matching
+typed class behind a single Python type.  Both styles either allocate a
+`ConcreteBuffer` or wrap the memory of an existing numpy array.  This page
+defines the constructor forms, the element types, the `fill` and `clone`
+operations, and the alignment extension.
+
+## Element Types
+
+Each typed class binds one C++ element type.  The dtype string in the
+table names the numpy dtype of the array and selects the typed class in
+the `SimpleArray` constructor.  The dtype naming matches numpy: the
+strings are the numpy dtype names, so an array round-trips to numpy
+without translation.
+
+| Class                   | C++ value type    | dtype string |
+| ----------------------- | ----------------- | ------------ |
+| `SimpleArrayBool`       | `bool`            | `bool`       |
+| `SimpleArrayInt8`       | `int8_t`          | `int8`       |
+| `SimpleArrayInt16`      | `int16_t`         | `int16`      |
+| `SimpleArrayInt32`      | `int32_t`         | `int32`      |
+| `SimpleArrayInt64`      | `int64_t`         | `int64`      |
+| `SimpleArrayUint8`      | `uint8_t`         | `uint8`      |
+| `SimpleArrayUint16`     | `uint16_t`        | `uint16`     |
+| `SimpleArrayUint32`     | `uint32_t`        | `uint32`     |
+| `SimpleArrayUint64`     | `uint64_t`        | `uint64`     |
+| `SimpleArrayFloat32`    | `float`           | `float32`    |
+| `SimpleArrayFloat64`    | `double`          | `float64`    |
+| `SimpleArrayComplex64`  | `Complex<float>`  | `complex64`  |
+| `SimpleArrayComplex128` | `Complex<double>` | `complex128` |
+
+The complex classes use solvcon's own `Complex` value type in C++ but
+expose the standard numpy complex dtypes through the buffer protocol.
+The item size follows the element type, and the numpy view of an array
+carries the matching dtype:
+
+```python
+import numpy as np
+assert solvcon.SimpleArrayInt8((2, 3)).nbytes == 6
+assert solvcon.SimpleArrayInt32(7).nbytes == 28
+assert solvcon.SimpleArrayFloat64((2, 3, 4)).nbytes == 192
+assert solvcon.SimpleArrayFloat64((2, 3)).ndarray.dtype == np.float64
+```
+
+## Typed Constructors
+
+Every typed class offers the same five constructor forms, shown here on
+`SimpleArrayFloat64`:
+
+```python
+solvcon.SimpleArrayFloat64(shape)
+solvcon.SimpleArrayFloat64(shape, alignment=64)
+solvcon.SimpleArrayFloat64(shape, value=1.0)
+solvcon.SimpleArrayFloat64(shape, value=1.0, alignment=64)
+solvcon.SimpleArrayFloat64(array=ndarr)
+```
+
+The first four allocate; the last wraps existing numpy memory.  The
+sections below define each form.
+
+### Construction from a Shape
+
+A typed array is constructed from a shape given as a single integer (a
+one-dimensional array) or a tuple of integers:
+
+```python
+sarr = solvcon.SimpleArrayInt32(7)          # shape (7,)
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+```
+
+The element storage is allocated immediately and is not initialized; the
+allocation semantics match numpy `numpy.empty`.  The `shape`, `stride`,
+`size`, `itemsize`, and `nbytes` properties describe the layout of the
+row-major result, and `len()` returns the element count:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+assert sarr.shape == (2, 3, 4)
+assert sarr.stride == (12, 4, 1)  # counted in elements, not bytes
+assert sarr.size == 24
+assert sarr.itemsize == 8
+assert sarr.nbytes == 24 * 8
+assert len(sarr) == 24
+```
+
+A negative shape dimension raises `IndexError`:
+
+```python
+solvcon.SimpleArrayFloat64((-1, 2))
+# IndexError: SimpleArray: shape dimension must be non-negative ...
+```
+
+### Fill Value
+
+The second constructor form takes an initial value and fills every
+element with it, in the spirit of numpy `numpy.full`:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((4, 4), value=3.14159)
+assert sarr[0, 0] == 3.14159
+```
+
+Pass the value with the `value=` keyword.  An integer given positionally
+in the second slot resolves to the alignment overload instead of the fill
+value, because the alignment constructor is matched first; the keyword
+removes the ambiguity.
+
+### Wrapping a Numpy Array
+
+The `array=` keyword form wraps the memory of an existing numpy array
+instead of allocating:
+
+```python
+ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+sarr = solvcon.SimpleArrayFloat64(array=ndarr)
+```
+
+The array and the wrapping `SimpleArray` share memory zero-copy, and the
+wrapper keeps the source alive by holding a reference.  The dtype of the
+source must equal the element type of the class; a mismatch raises
+`RuntimeError`.  As on `ConcreteBuffer`, the `is_from_python` property
+reports the provenance: `True` for an array wrapping numpy memory and
+`False` for an array that allocated its own buffer.
+
+Unlike the buffer-level wrap, the source does not need to be contiguous.
+Strided views are supported, including negative strides from reversed
+slices; the stride of the view is recorded in elements, and writes made
+through the wrapper land in the viewed region of the original array:
+
+```python
+ndarr = np.arange(6, dtype='float64').reshape((2, 3))
+view = ndarr[::-1, ::-1]
+sarr = solvcon.SimpleArrayFloat64(array=view)
+assert sarr.stride == (-3, -1)
+sarr[0, 0] = 200.0
+assert ndarr[1, 2] == 200.0
+```
+
+A source whose byte stride is not divisible by the item size, or whose
+data pointer is not aligned for the element type, raises `RuntimeError`.
+A Fortran-ordered source is likewise wrapped with its own stride; the
+`is_c_contiguous` and `is_f_contiguous` properties report the layout,
+and a degenerate shape (a single row, column, or element) reports both
+as `True`.
+
+## The Dtype-Erased SimpleArray
+
+`SimpleArray` erases the element type from the class name and moves it
+into a `dtype` string argument, closer to the numpy calling convention:
+
+```python
+sarr = solvcon.SimpleArray((2, 3, 4), dtype='float64')
+sarr = solvcon.SimpleArray((2, 3, 4), value=3.0, dtype='float64')
+sarr = solvcon.SimpleArray(np.arange(6, dtype='int32'))
+```
+
+The dtype string selects the typed class per the table above; a string
+outside the table raises `ValueError`.  The third form infers the dtype
+from the numpy array and shares its memory, like the typed `array=` form.
+
+The `value=` form diverges from numpy: where `numpy.full` casts the fill
+value to the array dtype, `SimpleArray` validates the Python type of the
+value strictly and raises `TypeError` on mismatch.  A `bool` dtype
+requires a Python `bool`, the integer dtypes require a Python `int`, and
+the floating-point dtypes require a Python `float`:
+
+```python
+solvcon.SimpleArray((2, 3), dtype='bool', value=3.3)
+# TypeError: Data type mismatch, expected Python bool
+solvcon.SimpleArray((2, 3), dtype='int32', value=3.3)
+# TypeError: Data type mismatch, expected Python int
+solvcon.SimpleArray((2, 3), dtype='float64', value=3)
+# TypeError: Data type mismatch, expected Python float
+```
+
+The complex dtypes do not accept a Python complex fill value; construct a
+complex array from a numpy array instead.
+
+The erased wrapper exposes the core of the typed interface: the layout
+properties, element indexing, `reshape`, `fill`, `clone`, ghost control,
+and the `min`, `max`, `sum`, and `abs` reductions all behave as on the
+typed classes.  For operations it does not yet mirror, the `typed`
+property bridges to the concrete class: it returns the wrapped array as
+its typed class, and the `plex` property on a typed array returns the
+erased wrapper.  The content survives the round trip in both directions:
+
+```python
+plex = solvcon.SimpleArray((2, 3, 4), dtype='float64', value=1.5)
+typed = plex.typed
+assert type(typed) is solvcon.SimpleArrayFloat64
+assert typed[0, 0, 0] == 1.5
+assert type(typed.plex) is solvcon.SimpleArray
+```
+
+## Filling
+
+`fill(value)` assigns the value to every element in place, matching numpy
+`ndarray.fill`:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.fill(2.0)
+```
+
+On the dtype-erased `SimpleArray`, `fill` applies the same strict value
+typing as the `value=` constructor and raises `TypeError` when the Python
+type of the value does not match the dtype.
+
+## Cloning
+
+`clone()` returns a deep copy: a new array with the same shape, stride,
+alignment, and a copy of the content, on a freshly allocated buffer.  The
+copy never shares memory with the source, regardless of how the source
+was constructed; cloning an array that wraps numpy memory yields an
+independent array whose `is_from_python` is `False`:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4), value=2.0)
+clone = sarr.clone()
+sarr[0, 0, 3] = 3.0
+assert clone[0, 0, 3] == 2.0
+```
+
+The dtype-erased `SimpleArray` clones the same way and returns another
+erased wrapper.
+
+The spelling diverges from numpy: numpy calls this operation `copy()`.
+The target behavior is that `clone()` remains the canonical spelling for
+a deep copy across the family, and no `copy()` alias is provided.
+
+## Alignment
+
+Alignment is a solvcon-specific extension with no numpy counterpart.
+Every allocating constructor form accepts an optional `alignment`
+argument that aligns the start of the buffer for SIMD kernels, which
+require 16-, 32-, or 64-byte alignment depending on the vector width:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((4, 4), alignment=16)
+sarr = solvcon.SimpleArrayFloat64((4, 4), value=2.7, alignment=16)
+sarr = solvcon.SimpleArray((4, 4), dtype='float64', alignment=16)
+```
+
+Valid alignment values are 0 (the default, no specific alignment), 16,
+32, and 64 bytes; any other value raises `ValueError`.  When a non-zero
+alignment is requested, the total byte count of the array must be a
+multiple of the alignment, or the allocation raises `ValueError`:
+
+```python
+solvcon.SimpleArrayFloat64((4, 4), alignment=17)
+# ValueError: ... alignment must be 0, 16, 32, or 64, but got 17
+solvcon.SimpleArrayFloat64((5, 1), alignment=16)
+# ValueError: ConcreteBuffer::allocate: size ... must be a multiple ...
+```
+
+The read-only `alignment` property returns the requested alignment, and
+`clone()` preserves it.  Arrays that wrap numpy memory do not take the
+argument, because nothing is allocated.  An aligned array behaves like
+any other array elsewhere: it fills, computes, converts to numpy, and
+clones the same way, and additionally satisfies the memory precondition
+of the `_simd` operation variants.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/construct.md
+++ b/doc/source/compute/buffer/construct.md
@@ -72,7 +72,7 @@ sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
 ```
 
 The element storage is allocated immediately and is not initialized; the
-allocation semantics match numpy `numpy.empty`.  The `shape`, `stride`,
+allocation semantics match `numpy.empty`.  The `shape`, `stride`,
 `size`, `itemsize`, and `nbytes` properties describe the layout of the
 row-major result, and `len()` returns the element count:
 
@@ -86,6 +86,10 @@ assert sarr.nbytes == 24 * 8
 assert len(sarr) == 24
 ```
 
+`len()` diverges from numpy: it returns the total element count, where
+numpy returns the length of the first dimension (24 versus 2 for the
+shape above).
+
 A negative shape dimension raises `IndexError`:
 
 ```python
@@ -96,7 +100,7 @@ solvcon.SimpleArrayFloat64((-1, 2))
 ### Fill Value
 
 The second constructor form takes an initial value and fills every
-element with it, in the spirit of numpy `numpy.full`:
+element with it, in the spirit of `numpy.full`:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((4, 4), value=3.14159)
@@ -159,7 +163,12 @@ sarr = solvcon.SimpleArray(np.arange(6, dtype='int32'))
 
 The dtype string selects the typed class per the table above; a string
 outside the table raises `ValueError`.  The third form infers the dtype
-from the numpy array and shares its memory, like the typed `array=` form.
+from the numpy array and shares its memory.  Unlike the typed `array=`
+form, the erased form currently requires a C-contiguous source: it takes
+the data pointer and byte count as-is and assumes row-major strides,
+with no stride or contiguity validation, so a Fortran-ordered or sliced
+source is silently mis-wrapped.  Accepting strided and Fortran-ordered
+sources with the same fidelity as the typed form is target behavior.
 
 The `value=` form diverges from numpy: where `numpy.full` casts the fill
 value to the array dtype, `SimpleArray` validates the Python type of the
@@ -176,16 +185,25 @@ solvcon.SimpleArray((2, 3), dtype='float64', value=3)
 # TypeError: Data type mismatch, expected Python float
 ```
 
-The complex dtypes do not accept a Python complex fill value; construct a
-complex array from a numpy array instead.
+The complex dtypes reject the Python built-in `complex` as a fill value;
+the accepted spelling is solvcon's own complex value types, matched
+exactly to the dtype:
+
+```python
+value = solvcon.complex64(real=1.5, imag=2.5)
+sarr = solvcon.SimpleArray((2, 3), dtype='complex64', value=value)
+```
 
 The erased wrapper exposes the core of the typed interface: the layout
 properties, element indexing, `reshape`, `fill`, `clone`, ghost control,
 and the `min`, `max`, `sum`, and `abs` reductions all behave as on the
 typed classes.  For operations it does not yet mirror, the `typed`
-property bridges to the concrete class: it returns the wrapped array as
-its typed class, and the `plex` property on a typed array returns the
-erased wrapper.  The content survives the round trip in both directions:
+property bridges to the concrete class: it returns an independent copy
+of the wrapped array as its typed class, and the `plex` property on a
+typed array returns an erased copy the same way.  Neither direction
+shares memory with the original, so the bridge serves read-style
+workflows; a write made through the bridged object stays in the copy.
+The content survives the round trip in both directions:
 
 ```python
 plex = solvcon.SimpleArray((2, 3, 4), dtype='float64', value=1.5)

--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -37,8 +37,9 @@ Typed array classes provide multi-dimensional access on top of a
 The dtype-erased class `SimpleArray` wraps any of the typed classes behind a
 single Python type.  It is constructed with a shape and a dtype string (or
 from a numpy `ndarray`) and dispatches operations to the concrete typed
-class it holds.  The `typed` property returns the wrapped typed array, and
-the `plex` property on a typed array returns the erased wrapper.
+class it holds.  The `typed` property returns a typed copy of the wrapped
+array, and the `plex` property on a typed array returns an erased copy;
+neither bridge shares memory with the original.
 
 Growable typed buffers collect elements one by one, in the spirit of
 `std::vector`:

--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -91,6 +91,8 @@ tagged with one of three parity labels:
 :maxdepth: 2
 
 memory
+construct
+collector
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
This PR adds the second installment of the SimpleArray Python API behavior document.

The new construct.md defines the construction surface of the typed array classes: the dtype table mapping the 13 classes to their C++ value types and numpy dtypes, shape arguments as int or tuple, the optional fill value and alignment keywords, and the error behavior for invalid shapes and dtype strings. It also covers the dtype-erased plex constructors and dtype-string mapping, fill, clone as the canonical deep-copy spelling, and alignment as a solvcon-specific extension motivated by SIMD.

The new collector.md defines the SimpleCollector growable typed buffers: push_back, reserve, expand, clear, capacity, element access, and as_array converting to a SimpleArray by sharing the accumulated memory, plus the accumulate-then-convert workflow and the exported roster.

The buffer index toctree gains the two entries. The Sphinx build passes with no new warnings. Diff is 395 insertions across 3 files.

Plan tracked in #103.