### PR TITLE
Step4: Document indexing, shape, and layout manipulation

### DIFF
--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -95,6 +95,7 @@ memory
 construct
 collector
 ndarray
+indexing
 ```
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/index.md
+++ b/doc/source/compute/buffer/index.md
@@ -62,9 +62,9 @@ as a clone of it.  This document is normative: it defines the desired
 behavior, and the implementation converges to it over time.  With respect to
 numpy the desired behavior falls into three categories:
 
-1. Some behavior deliberately matches numpy.  Element indexing, the buffer
-   protocol, and dtype naming follow numpy so that arrays move between the
-   two worlds without surprises.
+1. Some behavior deliberately matches numpy.  The index arithmetic of
+   element access, the buffer protocol, and dtype naming follow numpy so
+   that arrays move between the two worlds without surprises.
 2. Some behavior deliberately diverges from numpy.  The arrays serve the
    solvers first: ghost regions extend an array below index zero for
    solver halo data, alignment is an explicit constructor argument for SIMD
@@ -85,6 +85,12 @@ tagged with one of three parity labels:
 - "converging to numpy": the numpy behavior is the target, but the current
   implementation is not there yet; the tag is followed by what still
   differs.
+
+Where the desired behavior itself is not yet settled, a page marks the
+question as an open decision: the current behavior is recorded as fact,
+but no target is committed until the decision lands.  An open decision
+differs from target behavior, which states a settled intent awaiting
+implementation.
 
 ## Contents
 

--- a/doc/source/compute/buffer/indexing.md
+++ b/doc/source/compute/buffer/indexing.md
@@ -428,10 +428,10 @@ assert solvcon.SimpleArrayFloat64((1, 4)).is_f_contiguous
 
 Zero-extent dimensions diverge from numpy: the zero extent collapses
 the running stride expectation, so an empty shape mixing a zero-extent
-dimension with a longer one reports only one of the flags (for
-example, `SimpleArrayFloat64((0, 4))` is C-contiguous but not
-F-contiguous), where numpy flags every empty array as both.  Only an
-empty shape whose dimensions are all degenerate reports both, as
+dimension with a longer one need not report both flags (for example,
+`SimpleArrayFloat64((0, 4))` is C-contiguous but not F-contiguous),
+where numpy flags every empty array as both.  An empty shape whose
+dimensions are all degenerate reports both, as
 {doc}`Numpy and Buffer-Protocol Interoperation <ndarray>` records for
 the wrap-side consequence of the same flags.
 

--- a/doc/source/compute/buffer/indexing.md
+++ b/doc/source/compute/buffer/indexing.md
@@ -1,0 +1,444 @@
+# Indexing, Shape, and Layout Manipulation
+
+Every array in the SimpleArray family reads and writes single elements
+through the subscript operator, describes its layout through a set of
+properties, and manipulates its shape and memory order through `reshape`
+and the transpose family.  This page defines those operations: which keys
+the subscript accepts, which right-hand sides assignment takes, what the
+layout properties report, and how the shape and layout of an array are
+changed.  The index origin is ghost-aware: an array carrying a ghost
+region addresses its ghost elements at negative indices, and the bounds
+below shift accordingly.  A dedicated page on ghost regions follows this
+one; the present page assumes arrays without a ghost region.
+
+## Element Access
+
+Element access diverges from numpy: a subscript must select exactly one
+element, and the result is a Python scalar, never a subarray or a view.
+A one-dimensional array takes a single integer, and a multi-dimensional
+array takes a full tuple with one integer per dimension:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.ndarray.flat[:] = range(24)
+assert sarr[1, 2, 3] == 23.0
+
+sarr1d = solvcon.SimpleArrayInt32(7, value=3)
+assert sarr1d[0] == 3
+```
+
+The returned scalar is the Python built-in matching the element type:
+`float` for the floating-point classes, `int` for the integer classes,
+and `bool` for `SimpleArrayBool`.  The complex classes return solvcon's
+own scalar types, as defined in
+{doc}`Numpy and Buffer-Protocol Interoperation <ndarray>`.  Numpy
+instead returns its own scalar types (`numpy.float64` and friends);
+returning the plain Python scalar is the desired behavior.
+
+Partial indexing does not produce subarrays.  Where numpy resolves
+`ndarr[0]` on a three-dimensional array to a two-dimensional view, the
+SimpleArray classes require the index to address one element and raise
+`IndexError` otherwise:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr[0]
+# IndexError: SimpleArray::normalize_index(): cannot use scalar index
+# for 3-dimensional array
+sarr[0, 1]
+# IndexError: SimpleArray: dimension of input indices [0, 1] != array
+# dimension 3
+```
+
+### Negative Indices
+
+Negative indices wrap from the end of each dimension, matching the
+Python sequence convention that numpy also follows: a negative index
+`i` resolves to `n + i` for a dimension of length `n`, so the valid
+interval per dimension is `[-n, n)`:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((4, 3, 2))
+sarr.ndarray.flat[:] = range(24)
+assert sarr[-1, -1, -1] == 23.0
+assert sarr[-4, -3, -2] == 0.0
+sarr[-1, -1, -1] = 230.0
+assert sarr[3, 2, 1] == 230.0
+```
+
+### Out-of-Range Errors
+
+An index outside the valid interval raises `IndexError`, matching
+numpy's exception type.  The message names the offending index and the
+violated bound:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(3)
+sarr[3]
+# IndexError: SimpleArray: index 3 >= 3 (shape[0]: 3 - nghost: 0)
+sarr[-4]
+# IndexError: SimpleArray: index -4 < -nghost - shape[0]: -3
+
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr[0, 3, 0]
+# IndexError: SimpleArray: dim 1 in [0, 3, 0] >= shape[1]: 3
+```
+
+### No Slices on Read
+
+`__getitem__` accepts no slice and no ellipsis; only the integer and
+integer-tuple forms above exist.  Passing a slice raises `TypeError`
+from the binding's argument matching:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(6)
+sarr[0:3]
+# TypeError: __getitem__(): incompatible function arguments. ...
+```
+
+This diverges from numpy, where a slice returns a view sharing the
+memory of the source.  Whether the family should grow slice reads, and
+whether such a read would return a sharing view or a copy, is an open
+decision; this page records only the current behavior.  Until the
+decision lands, the zero-copy path to sliced reads is the `ndarray`
+property: `sarr.ndarray[0:3]` is a numpy view over the array's memory.
+
+## Element and Region Assignment
+
+`__setitem__` accepts two families of keys: the scalar keys of the read
+path, assigning one element, and slice or ellipsis keys, assigning a
+whole region from a sequence.  A key and value combination outside the
+two families raises `RuntimeError` with the message "unsupported
+operation."; in particular a scalar value cannot be assigned to a slice
+(numpy would broadcast it over the region).
+
+### Scalar Assignment
+
+With an integer key on a one-dimensional array or a full integer tuple
+on a multi-dimensional array, the value is cast to the element type and
+stored:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr[0, 0, 0] = 10      # a Python int converts to float64
+assert sarr[0, 0, 0] == 10.0
+```
+
+The cast follows pybind11 conversion, not numpy value coercion: a
+Python `int` converts to a floating-point element, but a value the
+element type cannot represent exactly is rejected with `RuntimeError`
+rather than truncated.  Assigning `2.5` to an integer array or `300`
+to an `int8` array both raise, where numpy would truncate or wrap.
+The complex classes accept both solvcon's own complex scalars and
+Python or numpy complex values, as defined in
+{doc}`Numpy and Buffer-Protocol Interoperation <ndarray>`.
+
+### Slice and Ellipsis Assignment
+
+With a slice or ellipsis key, the right-hand side is a sequence whose
+elements fill the selected region.  Four key shapes are accepted:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+ndarr = np.arange(24, dtype='float64').reshape((2, 3, 4))
+
+sarr[...] = ndarr                    # ellipsis: the whole array
+sarr[0:1] = np.ones((1, 3, 4))       # lone slice: first dimension
+sarr[::2, ::3, ::4] = np.zeros((1, 1, 1))  # tuple of slices
+sarr[::2, ...] = np.ones((1, 3, 4))  # tuple mixing slices and ellipsis
+```
+
+A lone slice applies to the first dimension and the remaining
+dimensions take their full extent.  In a tuple, slices fill dimensions
+from the left, an ellipsis expands to full-extent slices for the
+unnamed middle dimensions, and slices after the ellipsis fill from the
+right.  Steps and negative bounds follow the Python slice rules.  The
+syntax is validated: more slices than dimensions raise `RuntimeError`
+("syntax error. dimensions mismatches"), more than one ellipsis raises
+`RuntimeError` ("syntax error. no more than one ellipsis."), and a
+zero step raises `ValueError` ("slice step cannot be zero").
+
+### Accepted Right-Hand Sides
+
+The sequence on the right-hand side may be a numpy `ndarray`, a
+`list`, or a `tuple` (including nested lists and tuples, which convert
+through `numpy.array`):
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3))
+sarr[:, :] = [[1, 2, 3], [4, 5, 6]]
+sarr[:1, :2] = ((7, 8),)
+```
+
+A SimpleArray is not accepted: assigning one array into a slice of
+another raises `RuntimeError` ("unsupported operation.").  This
+diverges from numpy, where an array of the library's own kind is the
+most natural right-hand side.  Whether the accepted set should grow
+SimpleArray sources is an open decision; the working spelling today
+routes through numpy, for example `sarr[...] = other.ndarray`.
+
+### Shape Checking
+
+The shape of the right-hand side must equal the shape selected by the
+key exactly, dimension count included.  There is no numpy-style
+broadcasting of scalars or lower-dimensional sources, which diverges
+from numpy assignment.  A mismatch raises `RuntimeError` naming both
+shapes:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((4, 6, 8))
+sarr[::2, ::3, ::4] = np.zeros((2, 3, 4))
+# RuntimeError: Broadcast input array from shape(2, 3, 4) into
+# shape(2, 2, 2)
+```
+
+### Dtype Casting
+
+The element type of a sequence right-hand side does not need to match
+the array: any dtype of the element-type table in
+{doc}`Construction and Data Types <construct>` is converted
+element-wise during the copy, so an `int32` or `float32` source fills a
+`float64` array.  Two conversions are refused: mixing complex and
+non-complex types raises `RuntimeError` ("Cannot convert between
+complex and non-complex types"), and a dtype outside the table, such
+as a string dtype, raises `RuntimeError` ("input array data type not
+support!").
+
+## Shape and Layout Properties
+
+Five read-only properties describe the layout.  `shape`, `size`,
+`itemsize`, and `nbytes` match numpy: the shape tuple, the total
+element count, the byte size of one element, and the total byte count.
+`stride` diverges from numpy: it counts elements where numpy `strides`
+counts bytes, per the convention defined in
+{doc}`Construction and Data Types <construct>`;
+{doc}`Numpy and Buffer-Protocol Interoperation <ndarray>` shows the
+same view in both units:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+assert sarr.shape == (2, 3, 4)
+assert sarr.stride == (12, 4, 1)  # elements; numpy reports (96, 32, 8)
+assert sarr.size == 24
+assert sarr.itemsize == 8
+assert sarr.nbytes == 192
+```
+
+### len()
+
+`len()` diverges from numpy: it returns the total element count, equal
+to `size`, for any dimensionality.  Numpy returns the length of the
+first dimension:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+assert len(sarr) == 24
+assert len(sarr.ndarray) == 2  # numpy counts the first dimension
+```
+
+The desired behavior is the total element count: the arrays serve the
+solvers as element containers, and `len()` reports the container size
+the way `len()` does on a `ConcreteBuffer` or a collector.
+{doc}`Construction and Data Types <construct>` notes the divergence
+where the property first appears; this page carries the full
+statement.
+
+## Reshape
+
+`reshape(shape)` returns a new array of the given shape over the same
+buffer.  The receiver keeps its shape; the result shares the memory,
+so a write through either side is visible through the other:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr2 = sarr.reshape(24)
+assert sarr2.shape == (24,)
+sarr2[5] = 42.0
+assert sarr[0, 1, 1] == 42.0
+assert sarr.shape == (2, 3, 4)  # the receiver is unchanged
+```
+
+The shape argument takes a single integer or a tuple, like the
+constructors, and the result is always row-major over the shared
+buffer.  The element count of the new shape must cover the underlying
+buffer exactly (for an allocated array, equal the element count of the
+array); a mismatch raises `RuntimeError`:
+
+```python
+sarr.reshape(23)
+# RuntimeError: SimpleArray: shape byte count 184 differs from
+# available buffer byte count 192 at data offset 0
+```
+
+The operation diverges from numpy in the failure modes, not the happy
+path: numpy `reshape` also returns a sharing view for a compatible
+layout, but falls back to a silent copy when the layout does not
+permit a view, infers a dimension given as `-1`, and raises
+`ValueError` on a count mismatch.  The SimpleArray `reshape` never
+copies, never infers, and raises `RuntimeError`; the desired behavior
+is that the result always shares the buffer.
+
+## Transpose
+
+The transpose family diverges from numpy, which has no in-place
+transpose and returns sharing views from `.transpose()` and `.T`.
+
+### transpose
+
+The full signature is `transpose(axis=None, inplace=True, copy=False)`.
+With `axis=None` all axes are reversed; with a tuple, the i-th new
+axis is sourced from the `axis[i]`-th old axis, exactly the numpy
+`transpose` axis convention:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.transpose()
+assert sarr.shape == (4, 3, 2)
+
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.transpose((0, 2, 1))
+assert sarr.shape == (2, 4, 3)
+```
+
+The `axis` tuple must have one entry per dimension and every entry
+must be a valid axis; violations raise `RuntimeError`
+("SimpleArray::transpose: axis size mismatch" and
+"SimpleArray::transpose: axis out of range").  A repeated axis is not
+currently detected, where numpy raises on a repeated axis; rejecting
+the repeat is target behavior.
+
+The `inplace` and `copy` flags select what is transposed and how:
+
+- `inplace=True` (default) transposes the receiver itself;
+  `inplace=False` leaves the receiver untouched and transposes an
+  independent deep copy.
+- `copy=False` (default) flips only the metadata: shape and stride are
+  permuted and no element moves, so the transposed array is
+  F-contiguous when the source was C-contiguous.  `copy=True`
+  physically rearranges the elements into a fresh C-contiguous buffer.
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.transpose()                  # metadata flip of sarr itself
+assert sarr.is_f_contiguous
+
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr.transpose(copy=True)         # physical transpose of sarr itself
+assert sarr.is_c_contiguous
+
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+sarr2 = sarr.transpose(inplace=False)
+assert sarr.shape == (2, 3, 4)    # the receiver is unchanged
+assert sarr2.shape == (4, 3, 2)
+```
+
+The method also returns an array, and the returned object never shares
+memory with the receiver: even with `inplace=True` the return value is
+an independent deep copy taken after the mutation.  Treat the in-place
+mutation as the primary effect and the return value as a detached
+copy.  Whether the return value should instead be the receiver (to
+support chaining) is an open decision; do not rely on the returned
+object aliasing the receiver.
+
+### transpose_copy
+
+`transpose_copy()` returns a fresh C-contiguous array with the axes
+reversed and the elements physically rearranged, leaving the receiver
+untouched; it is the counterpart of
+`numpy.ascontiguousarray(ndarr.T)`:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.arange(6.).reshape((2, 3)))
+tc = sarr.transpose_copy()
+assert tc.shape == (3, 2)
+assert tc.is_c_contiguous
+assert sarr.shape == (2, 3)
+```
+
+A zero- or one-dimensional array has no axes to reverse, so the result
+is a plain deep copy.  Two applications round-trip: transposing the
+transpose reproduces the original shape and content.
+
+### T
+
+The `T` property returns a deep-copied transposed array: the buffer is
+cloned and the metadata of the clone is reversed, so the result never
+shares memory with the receiver and the receiver is unchanged.  This
+diverges from numpy, where `.T` is a zero-copy view:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3), value=1.0)
+t = sarr.T
+assert t.shape == (3, 2)
+assert t.is_f_contiguous          # metadata flip of a C-ordered clone
+sarr[0, 0] = 5.0
+assert t[0, 0] == 1.0             # the copy does not see the write
+```
+
+## Contiguity
+
+### is_c_contiguous and is_f_contiguous
+
+The two read-only properties report whether the stride describes a
+row-major (C) or column-major (Fortran) layout over the shape,
+matching the numpy `flags.c_contiguous` and `flags.f_contiguous`
+semantics under the property spelling of the family.  Dimensions of
+extent zero or one place no constraint, so a degenerate shape (a
+single row, column, or element) reports both as `True`, as numpy does:
+
+```python
+sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
+assert sarr.is_c_contiguous and not sarr.is_f_contiguous
+sarr.transpose()
+assert sarr.is_f_contiguous and not sarr.is_c_contiguous
+assert solvcon.SimpleArrayFloat64((1, 4)).is_f_contiguous
+```
+
+### to_row_major and to_column_major
+
+`to_row_major()` and `to_column_major()` return a fresh array with the
+same shape and values whose stride is C-contiguous or F-contiguous
+respectively.  The result is always a new buffer: when the receiver
+already has the requested layout the buffer is cloned, and otherwise a
+fresh buffer is allocated and the elements are copied in the new
+order.  The receiver is never modified:
+
+```python
+ndarr = np.arange(6, dtype='float64').reshape((2, 3))
+sarr = solvcon.SimpleArrayFloat64(array=ndarr[::-1, ::-1])
+rm = sarr.to_row_major()
+assert rm.is_c_contiguous
+cm = sarr.to_column_major()
+assert cm.is_f_contiguous
+assert cm.stride == (1, 2)
+```
+
+The numpy counterparts `numpy.ascontiguousarray` and
+`numpy.asfortranarray` return the input unchanged when it already has
+the requested layout; always returning an independent copy diverges
+from numpy, keeping buffer ownership explicit per the design stance of
+{doc}`the family overview <index>`.
+
+## The Dtype-Erased SimpleArray
+
+The dtype-erased `SimpleArray` exposes the access and property core of
+this page with the typed semantics: `__len__`, the scalar read and
+write forms, the slice and ellipsis assignment parser, and the
+`shape`, `stride`, `size`, `itemsize`, and `nbytes` properties all
+behave as on the typed classes.
+
+`reshape` on the erased wrapper accepts the same shapes and applies
+the same element-count check, but the result currently does not share
+the buffer: the erased result is built through a copying bridge, so a
+write through the reshaped array stays in the copy.  Sharing the
+buffer as the typed `reshape` does is target behavior.
+
+The layout-manipulation operations (`transpose`, `transpose_copy`,
+`T`, `to_row_major`, `to_column_major`) and the contiguity properties
+are not yet exposed on the erased wrapper.  The binding policy keeps
+the erased and typed interfaces identical, so providing them with the
+typed semantics is target behavior; until then, the `typed` bridge of
+{doc}`Construction and Data Types <construct>` reaches the typed
+implementations on a copy.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/compute/buffer/indexing.md
+++ b/doc/source/compute/buffer/indexing.md
@@ -6,15 +6,17 @@ properties, and manipulates its shape and memory order through `reshape`
 and the transpose family.  This page defines those operations: which keys
 the subscript accepts, which right-hand sides assignment takes, what the
 layout properties report, and how the shape and layout of an array are
-changed.  The index origin is ghost-aware: an array carrying a ghost
-region addresses its ghost elements at negative indices, and the bounds
-below shift accordingly.  A dedicated page on ghost regions follows this
-one; the present page assumes arrays without a ghost region.
+changed.  Arrays carrying a ghost region shift the index origin; a
+dedicated page on ghost regions follows this one, and the present page
+assumes arrays without one.
 
 ## Element Access
 
-Element access diverges from numpy: a subscript must select exactly one
-element, and the result is a Python scalar, never a subarray or a view.
+Element access matches numpy in the index arithmetic and the error
+behavior (negative wrapping and `IndexError`), and diverges from numpy
+in the subscript scope and the return type: a subscript must select
+exactly one element, and the result is a Python scalar, never a
+subarray or a view.
 A one-dimensional array takes a single integer, and a multi-dimensional
 array takes a full tuple with one integer per dimension:
 
@@ -108,9 +110,12 @@ property: `sarr.ndarray[0:3]` is a numpy view over the array's memory.
 `__setitem__` accepts two families of keys: the scalar keys of the read
 path, assigning one element, and slice or ellipsis keys, assigning a
 whole region from a sequence.  A key and value combination outside the
-two families raises `RuntimeError` with the message "unsupported
-operation."; in particular a scalar value cannot be assigned to a slice
-(numpy would broadcast it over the region).
+two families raises `RuntimeError`; in particular a scalar value cannot
+be assigned to a slice key (numpy would broadcast it over the region).
+The message depends on the rejection path: a scalar on a lone slice or
+an ellipsis reports "unsupported operation.", while a scalar on a tuple
+of slices fails earlier, in the key cast, with a pybind11 "Unable to
+cast" message.
 
 ### Scalar Assignment
 
@@ -128,7 +133,8 @@ The cast follows pybind11 conversion, not numpy value coercion: a
 Python `int` converts to a floating-point element, but a value the
 element type cannot represent exactly is rejected with `RuntimeError`
 rather than truncated.  Assigning `2.5` to an integer array or `300`
-to an `int8` array both raise, where numpy would truncate or wrap.
+to an `int8` array both raise, where numpy truncates the float
+(storing 2) and raises `OverflowError` for the out-of-range integer.
 The complex classes accept both solvcon's own complex scalars and
 Python or numpy complex values, as defined in
 {doc}`Numpy and Buffer-Protocol Interoperation <ndarray>`.
@@ -198,11 +204,14 @@ The element type of a sequence right-hand side does not need to match
 the array: any dtype of the element-type table in
 {doc}`Construction and Data Types <construct>` is converted
 element-wise during the copy, so an `int32` or `float32` source fills a
-`float64` array.  Two conversions are refused: mixing complex and
+`float64` array.  Three conversions are refused.  Mixing complex and
 non-complex types raises `RuntimeError` ("Cannot convert between
-complex and non-complex types"), and a dtype outside the table, such
-as a string dtype, raises `RuntimeError` ("input array data type not
-support!").
+complex and non-complex types").  A complex source fills only the
+complex array of the same precision, so a `complex64` source into a
+`SimpleArrayComplex128` also raises `RuntimeError`, reusing the same
+message even though both sides are complex.  A dtype outside the
+table, such as a string dtype, raises `RuntimeError` ("input array
+data type not support!").
 
 ## Shape and Layout Properties
 
@@ -220,11 +229,18 @@ sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
 assert sarr.shape == (2, 3, 4)
 assert sarr.stride == (12, 4, 1)  # elements; numpy reports (96, 32, 8)
 assert sarr.size == 24
-assert sarr.itemsize == 8
 assert sarr.nbytes == 192
+plex = solvcon.SimpleArray((2, 3, 4), dtype='float64')
+assert plex.itemsize == 8
 ```
 
-### len()
+On the typed classes, reading `itemsize` currently raises `TypeError`:
+the binding registers the zero-argument C++ getter as an instance
+property, which pybind11 rejects at access time.  Per the parity
+policy this is a defect, not a divergence; the example above reads the
+property through the erased wrapper, where it works.
+
+### The `len()` Function
 
 `len()` diverges from numpy: it returns the total element count, equal
 to `size`, for any dimensionality.  Numpy returns the length of the
@@ -270,25 +286,39 @@ sarr.reshape(23)
 # available buffer byte count 192 at data offset 0
 ```
 
-The operation diverges from numpy in the failure modes, not the happy
-path: numpy `reshape` also returns a sharing view for a compatible
-layout, but falls back to a silent copy when the layout does not
-permit a view, infers a dimension given as `-1`, and raises
-`ValueError` on a count mismatch.  The SimpleArray `reshape` never
-copies, never infers, and raises `RuntimeError`; the desired behavior
-is that the result always shares the buffer.
+The operation diverges from numpy beyond the failure modes.  Numpy
+`reshape` also returns a sharing view for a compatible layout, but
+falls back to a silent copy when the layout does not permit a view,
+infers a dimension given as `-1`, and raises `ValueError` on a count
+mismatch.  The SimpleArray `reshape` never copies, never infers, and
+raises `RuntimeError`; the desired behavior is that the result always
+shares the buffer.  Because the result is always row-major over the
+shared buffer, reshaping a non-contiguous array reinterprets the
+storage order rather than the logical order.  After an in-place
+transpose the elements come back in their original storage sequence,
+where the numpy `.T.reshape` spelling copies them in transposed
+logical order:
+
+```python
+sarr = solvcon.SimpleArrayFloat64(array=np.arange(6.).reshape((2, 3)))
+sarr.transpose()
+assert [sarr.reshape(6)[i] for i in range(6)] == [0, 1, 2, 3, 4, 5]
+ndarr = np.arange(6.).reshape((2, 3))
+assert ndarr.T.reshape(6).tolist() == [0, 3, 1, 4, 2, 5]
+```
 
 ## Transpose
 
 The transpose family diverges from numpy, which has no in-place
 transpose and returns sharing views from `.transpose()` and `.T`.
 
-### transpose
+### The `transpose` Method
 
 The full signature is `transpose(axis=None, inplace=True, copy=False)`.
 With `axis=None` all axes are reversed; with a tuple, the i-th new
-axis is sourced from the `axis[i]`-th old axis, exactly the numpy
-`transpose` axis convention:
+axis is sourced from the `axis[i]`-th old axis, following the numpy
+`transpose` axis convention except that the entries must be
+non-negative, where numpy also accepts negative axis numbers:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -301,7 +331,7 @@ assert sarr.shape == (2, 4, 3)
 ```
 
 The `axis` tuple must have one entry per dimension and every entry
-must be a valid axis; violations raise `RuntimeError`
+must be a valid non-negative axis; violations raise `RuntimeError`
 ("SimpleArray::transpose: axis size mismatch" and
 "SimpleArray::transpose: axis out of range").  A repeated axis is not
 currently detected, where numpy raises on a repeated axis; rejecting
@@ -313,9 +343,11 @@ The `inplace` and `copy` flags select what is transposed and how:
   `inplace=False` leaves the receiver untouched and transposes an
   independent deep copy.
 - `copy=False` (default) flips only the metadata: shape and stride are
-  permuted and no element moves, so the transposed array is
-  F-contiguous when the source was C-contiguous.  `copy=True`
-  physically rearranges the elements into a fresh C-contiguous buffer.
+  permuted and no element moves.  Under the full axis reversal the
+  flip of a C-contiguous source is F-contiguous; a partial permutation
+  such as `(0, 2, 1)` generally yields a layout that is neither.
+  `copy=True` physically rearranges the elements into a fresh
+  C-contiguous buffer.
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -340,7 +372,7 @@ copy.  Whether the return value should instead be the receiver (to
 support chaining) is an open decision; do not rely on the returned
 object aliasing the receiver.
 
-### transpose_copy
+### The `transpose_copy` Method
 
 `transpose_copy()` returns a fresh C-contiguous array with the axes
 reversed and the elements physically rearranged, leaving the receiver
@@ -359,7 +391,7 @@ A zero- or one-dimensional array has no axes to reverse, so the result
 is a plain deep copy.  Two applications round-trip: transposing the
 transpose reproduces the original shape and content.
 
-### T
+### The `T` Property
 
 The `T` property returns a deep-copied transposed array: the buffer is
 cloned and the metadata of the clone is reversed, so the result never
@@ -377,14 +409,14 @@ assert t[0, 0] == 1.0             # the copy does not see the write
 
 ## Contiguity
 
-### is_c_contiguous and is_f_contiguous
+### The `is_c_contiguous` and `is_f_contiguous` Properties
 
 The two read-only properties report whether the stride describes a
 row-major (C) or column-major (Fortran) layout over the shape,
 matching the numpy `flags.c_contiguous` and `flags.f_contiguous`
 semantics under the property spelling of the family.  Dimensions of
-extent zero or one place no constraint, so a degenerate shape (a
-single row, column, or element) reports both as `True`, as numpy does:
+extent one place no constraint, so a degenerate shape (a single row,
+column, or element) reports both as `True`, as numpy does:
 
 ```python
 sarr = solvcon.SimpleArrayFloat64((2, 3, 4))
@@ -394,7 +426,16 @@ assert sarr.is_f_contiguous and not sarr.is_c_contiguous
 assert solvcon.SimpleArrayFloat64((1, 4)).is_f_contiguous
 ```
 
-### to_row_major and to_column_major
+Zero-extent dimensions diverge from numpy: the zero extent collapses
+the running stride expectation, so an empty shape mixing a zero-extent
+dimension with a longer one reports only one of the flags (for
+example, `SimpleArrayFloat64((0, 4))` is C-contiguous but not
+F-contiguous), where numpy flags every empty array as both.  Only an
+empty shape whose dimensions are all degenerate reports both, as
+{doc}`Numpy and Buffer-Protocol Interoperation <ndarray>` records for
+the wrap-side consequence of the same flags.
+
+### The `to_row_major` and `to_column_major` Conversions
 
 `to_row_major()` and `to_column_major()` return a fresh array with the
 same shape and values whose stride is C-contiguous or F-contiguous
@@ -425,7 +466,9 @@ The dtype-erased `SimpleArray` exposes the access and property core of
 this page with the typed semantics: `__len__`, the scalar read and
 write forms, the slice and ellipsis assignment parser, and the
 `shape`, `stride`, `size`, `itemsize`, and `nbytes` properties all
-behave as on the typed classes.
+behave as defined on this page.  For `itemsize` the erased wrapper is
+currently the only working spelling, per the typed-binding defect
+noted above.
 
 `reshape` on the erased wrapper accepts the same shapes and applies
 the same element-count check, but the result currently does not share


### PR DESCRIPTION
This PR adds the fourth installment of the SimpleArray Python API behavior document: the indexing, shape, and layout page.

The new indexing.md defines element access returning Python scalars, negative-index wrapping, and the exact out-of-range errors. It records the central divergence that __getitem__ accepts no slices and never returns views, and marks the slicing target semantics as an open decision. It defines __setitem__ scalar assignment and the slice and ellipsis broadcast path with the accepted right-hand-side types, noting that a SimpleArray right-hand side is currently rejected and giving the working ndarray spelling.

It also defines the shape and layout properties (shape, element-counted stride, size, itemsize, nbytes, and len as the total element count with the full divergence statement), reshape sharing the buffer with its exact mismatch error, the transpose family including the in-place default and the detached return value, to_row_major and to_column_major, the contiguity flags with the size-1-axis relaxation, and T as a deep-copied transposed array in contrast to the numpy view. Erased-wrapper gaps are recorded as target behavior per the binding-parity policy.

The Sphinx build passes with no new warnings. Diff is 445 insertions across 2 files.

Plan tracked in #103.