### PR TITLE
Make config path tests portable across separators

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -21,6 +21,10 @@ class ConfigPathTC(unittest.TestCase):
     #: Every variable the resolution consults, saved and restored per test.
     VARIABLES = ("SOLVCON_CONFIG_HOME", "XDG_CONFIG_HOME")
 
+    #: Sentinel roots built from segments, so no test hard-codes a separator.
+    SC_HOME = os.path.join(os.sep, "sc", "here")
+    XDG_HOME = os.path.join(os.sep, "xdg", "here")
+
     def setUp(self):
         self._saved = {k: os.environ.get(k) for k in self.VARIABLES}
         for name in self.VARIABLES:
@@ -34,25 +38,30 @@ class ConfigPathTC(unittest.TestCase):
                 os.environ[name] = value
 
     def test_honors_solvcon_config_home(self):
-        os.environ["SOLVCON_CONFIG_HOME"] = "/sc/here"
-        self.assertEqual(Config.config_home(), "/sc/here")
-        self.assertEqual(Config.default_path(), "/sc/here/pilot.json")
+        os.environ["SOLVCON_CONFIG_HOME"] = self.SC_HOME
+        self.assertEqual(Config.config_home(), self.SC_HOME)
+        self.assertEqual(
+            Config.default_path(),
+            os.path.join(self.SC_HOME, Config.FILENAME))
 
     def test_solvcon_config_home_precedes_xdg(self):
-        os.environ["SOLVCON_CONFIG_HOME"] = "/sc/here"
-        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
-        self.assertEqual(Config.config_home(), "/sc/here")
+        os.environ["SOLVCON_CONFIG_HOME"] = self.SC_HOME
+        os.environ["XDG_CONFIG_HOME"] = self.XDG_HOME
+        self.assertEqual(Config.config_home(), self.SC_HOME)
 
     def test_empty_solvcon_config_home_falls_through(self):
         os.environ["SOLVCON_CONFIG_HOME"] = ""
-        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
-        self.assertEqual(Config.config_home(), "/xdg/here/solvcon")
+        os.environ["XDG_CONFIG_HOME"] = self.XDG_HOME
+        self.assertEqual(
+            Config.config_home(), os.path.join(self.XDG_HOME, "solvcon"))
 
     def test_honors_xdg_config_home(self):
-        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
-        self.assertEqual(Config.config_home(), "/xdg/here/solvcon")
+        os.environ["XDG_CONFIG_HOME"] = self.XDG_HOME
         self.assertEqual(
-            Config.default_path(), "/xdg/here/solvcon/pilot.json")
+            Config.config_home(), os.path.join(self.XDG_HOME, "solvcon"))
+        self.assertEqual(
+            Config.default_path(),
+            os.path.join(self.XDG_HOME, "solvcon", Config.FILENAME))
 
     def test_falls_back_to_dot_config(self):
         home = os.path.expanduser("~")


### PR DESCRIPTION
## Problem

The Windows CI jobs fail at `run_pilot_pytest` because `ConfigPathTC` hardcoded POSIX forward slashes in its expected paths. On Windows, `Config.config_home` and `Config.default_path` compose paths with `os.path.join`, which uses the native backslash, so the assertions compared a backslash path against a forward-slash literal. The pilot pytest harness runs with `-x`, so the first such failure halted the whole Windows run.

## Where it fails

The pilot harness reported the first hardcoded-slash assertion (the rest run later and `-x` never reaches them, but they are broken the same way on Windows):

- Reported failure: https://github.com/solvcon/solvcon/blob/f4b8ca0ebad24d0ca07d772a1edd89463a2888a3/tests/test_config.py#L49
- Masked by `-x`, same defect: https://github.com/solvcon/solvcon/blob/f4b8ca0ebad24d0ca07d772a1edd89463a2888a3/tests/test_config.py#L39
- Masked by `-x`, same defect: https://github.com/solvcon/solvcon/blob/f4b8ca0ebad24d0ca07d772a1edd89463a2888a3/tests/test_config.py#L53
- Masked by `-x`, same defect: https://github.com/solvcon/solvcon/blob/f4b8ca0ebad24d0ca07d772a1edd89463a2888a3/tests/test_config.py#L55

The same root cause takes down every Windows job in the nightly devbuild run 30169592055:

- sanitizer_windows-2022: https://github.com/solvcon/solvcon/actions/runs/30169592055/job/89708324573
- build_windows-2022_Release: https://github.com/solvcon/solvcon/actions/runs/30169592055/job/89708599959
- build_windows-2022_Debug: https://github.com/solvcon/solvcon/actions/runs/30169592055/job/89708599961

It also failed the earlier push build: https://github.com/solvcon/solvcon/actions/runs/30162193521/job/89689331498

## Error log

```
tests\test_config.py::ConfigPathTC::test_empty_solvcon_config_home_falls_through FAILED [ 22%]
        os.environ["XDG_CONFIG_HOME"] = "/xdg/here"
>       self.assertEqual(Config.config_home(), "/xdg/here/solvcon")
E       AssertionError: '/xdg/here\solvcon' != '/xdg/here/solvcon'
E       - /xdg/here\solvcon
E       + /xdg/here/solvcon
tests\test_config.py:49: AssertionError
FAILED tests\test_config.py::ConfigPathTC::test_empty_solvcon_config_home_falls_through
======== 1 failed, 394 passed, 3 skipped, 218 subtests passed in 3.87s ========
ninja: build stopped: subcommand failed.
```

## Fix

Build the sentinel roots from segments with `os.sep` and compose every expected path with `os.path.join` and `Config.FILENAME`, so no test hardcodes a separator. The tests still verify env-var precedence and that `solvcon` and the filename get appended, but no longer assume a separator, so they pass on every platform. `Config.config_home` already used the portable idiom; only the tests needed to match it.

Verified on Windows: all six `ConfigPathTC` tests pass and flake8 is clean on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
