### PR TITLE
Step 1: Raise the preset schema and add IDE metadata

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,41 +1,95 @@
 {
-  "version": 6,
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "$comment": "Schema version 10 is the highest that CMake 4.0.1, the project minimum, understands; it is also the highest CLion reads. Raising it further would lift the CMake floor and drop CLion support.",
   "configurePresets": [
     {
       "name": "win-base",
       "hidden": true,
       "generator": "Ninja",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot, USE_GOOGLETEST is left off so a plain Windows build does not fetch googletest, BLA_VENDOR names the BLAS that the Windows dependency prefix provides, and CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core can import it in place.",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
       "cacheVariables": {
-        "BUILD_QT": "ON",
-        "USE_GOOGLETEST": "OFF",
-        "BLA_VENDOR": "OpenBLAS",
-        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": "${sourceDir}/solvcon"
+        "BUILD_QT": { "type": "BOOL", "value": "ON" },
+        "USE_GOOGLETEST": { "type": "BOOL", "value": "OFF" },
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
+        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/solvcon"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"],
+          "intelliSenseMode": "windows-msvc-x64"
+        }
       }
     },
     {
       "name": "win-rel",
-      "displayName": "Windows Release (Ninja, MSVC)",
       "inherits": "win-base",
+      "displayName": "Windows Release (Ninja, MSVC)",
+      "description": "Optimized _solvcon and pilot built with MSVC through Ninja.",
       "binaryDir": "${sourceDir}/build/win-rel",
+      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/win-rel"
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/win-rel"
+        }
       }
     },
     {
       "name": "win-dbg",
-      "displayName": "Windows Debug (Ninja, MSVC)",
       "inherits": "win-base",
+      "displayName": "Windows Debug (Ninja, MSVC)",
+      "description": "Debuggable _solvcon and pilot built with MSVC through Ninja.",
       "binaryDir": "${sourceDir}/build/win-dbg",
+      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/win-dbg"
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/win-dbg"
+        }
       }
     }
   ],
   "buildPresets": [
-    { "name": "win-rel", "configurePreset": "win-rel" },
-    { "name": "win-dbg", "configurePreset": "win-dbg" }
+    {
+      "name": "win-base",
+      "hidden": true,
+      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts.",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"]
+        }
+      }
+    },
+    {
+      "name": "win-rel",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release",
+      "description": "Build the Windows Release configuration."
+    },
+    {
+      "name": "win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug",
+      "description": "Build the Windows Debug configuration."
+    }
   ]
 }


### PR DESCRIPTION
Step 1 of the CMake presets plan. Related to #120.

`CMakePresets.json` declared schema version 6, the CMake 3.25 level, although the project already requires CMake 4.0.1. Version 10 is the highest version that both that floor and CLion understand, so this raises the file to 10 and takes the three things it buys: the `$schema` key that makes an editor validate the file while it is being edited, typed cache variables that render correctly in `ccmake` and the IDE cache editors, and `$comment` entries that record why a knob is set.

The Windows presets were also unconditional, so `cmake --list-presets` offered them on Linux and macOS, where Ninja with MSVC cannot configure, and the IDE preset pickers did the same. They are now filtered twice: a CMake `condition` on `${hostSystemName}`, which the command line and CLion honour, and a `hostOS` entry in the `microsoft.com/VisualStudioSettings/CMake/1.0` vendor map, which is what VS Code filters on. Neither alone hides a preset everywhere. A build preset does not inherit its configure preset's condition, so the filter is restated on a hidden build preset that both Windows build presets inherit.

Nothing here changes the build. The generator, the binary directory, and every cache variable value are the same as before.

## Verification

- `cmake --list-presets` and `cmake --list-presets=build` on Linux list nothing, where both previously offered the two Windows presets.
- The same file with the condition inverted to `Linux` lists both configure presets and both build presets, so the entries are well formed and the filter is what hides them.
- The resolved generator, `binaryDir`, and cache variable values were compared against the previous revision preset by preset and are identical.
