### PR TITLE
Step 2: Give the presets the Makefile's configure knobs

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,41 +1,95 @@
 {
-  "version": 6,
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
   "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "$comment": "Schema version 10 is the highest that CMake 4.0.1, the project minimum, understands; it is also the highest CLion reads. Raising it further would lift the CMake floor and drop CLion support.",
   "configurePresets": [
     {
       "name": "win-base",
       "hidden": true,
       "generator": "Ninja",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot, USE_GOOGLETEST is left off so a plain Windows build does not fetch googletest, BLA_VENDOR names the BLAS that the Windows dependency prefix provides, and CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core can import it in place.",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
       "cacheVariables": {
-        "BUILD_QT": "ON",
-        "USE_GOOGLETEST": "OFF",
-        "BLA_VENDOR": "OpenBLAS",
-        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": "${sourceDir}/solvcon"
+        "BUILD_QT": { "type": "BOOL", "value": "ON" },
+        "USE_GOOGLETEST": { "type": "BOOL", "value": "OFF" },
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
+        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/solvcon"
+        }
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"],
+          "intelliSenseMode": "windows-msvc-x64"
+        }
       }
     },
     {
       "name": "win-rel",
-      "displayName": "Windows Release (Ninja, MSVC)",
       "inherits": "win-base",
+      "displayName": "Windows Release (Ninja, MSVC)",
+      "description": "Optimized _solvcon and pilot built with MSVC through Ninja.",
       "binaryDir": "${sourceDir}/build/win-rel",
+      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Release",
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/win-rel"
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/win-rel"
+        }
       }
     },
     {
       "name": "win-dbg",
-      "displayName": "Windows Debug (Ninja, MSVC)",
       "inherits": "win-base",
+      "displayName": "Windows Debug (Ninja, MSVC)",
+      "description": "Debuggable _solvcon and pilot built with MSVC through Ninja.",
       "binaryDir": "${sourceDir}/build/win-dbg",
+      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": "${sourceDir}/build/win-dbg"
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/win-dbg"
+        }
       }
     }
   ],
   "buildPresets": [
-    { "name": "win-rel", "configurePreset": "win-rel" },
-    { "name": "win-dbg", "configurePreset": "win-dbg" }
+    {
+      "name": "win-base",
+      "hidden": true,
+      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts.",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"]
+        }
+      }
+    },
+    {
+      "name": "win-rel",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release",
+      "description": "Build the Windows Release configuration."
+    },
+    {
+      "name": "win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug",
+      "description": "Build the Windows Debug configuration."
+    }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,10 +5,38 @@
   "$comment": "Schema version 10 is the highest that CMake 4.0.1, the project minimum, understands; it is also the highest CLion reads. Raising it further would lift the CMake floor and drop CLion support.",
   "configurePresets": [
     {
+      "name": "base",
+      "hidden": true,
+      "$comment": "The knobs that hold on every host, at the values the Makefile passes on every configure. HIDE_SYMBOL keeps the C++ symbols out of the module's dynamic table, DEBUG_SYMBOL keeps a build debuggable, LINT_AS_ERRORS makes a clang-tidy report fail the build once USE_CLANG_TIDY turns it on, SKIP_PYTHON_EXECUTABLE off lets CMake locate the interpreter, and SOLVCON_PROFILE and BUILD_METAL are the two features that are off unless a build asks for them. USE_GOOGLETEST is stated at the project default so that a preset build and a make build compile the same set of targets. CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core imports it in place, and CMAKE_INSTALL_PREFIX keeps a stray install inside the build tree.",
+      "cacheVariables": {
+        "HIDE_SYMBOL": { "type": "BOOL", "value": "ON" },
+        "DEBUG_SYMBOL": { "type": "BOOL", "value": "ON" },
+        "LINT_AS_ERRORS": { "type": "BOOL", "value": "ON" },
+        "SKIP_PYTHON_EXECUTABLE": { "type": "BOOL", "value": "OFF" },
+        "SOLVCON_PROFILE": { "type": "BOOL", "value": "OFF" },
+        "USE_CLANG_TIDY": { "type": "BOOL", "value": "OFF" },
+        "BUILD_METAL": { "type": "BOOL", "value": "OFF" },
+        "USE_GOOGLETEST": { "type": "BOOL", "value": "ON" },
+        "CMAKE_EXPORT_COMPILE_COMMANDS": { "type": "BOOL", "value": "ON" },
+        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/solvcon"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/fakeinstall"
+        }
+      },
+      "environment": {
+        "PYTHONPATH": "${sourceDir}"
+      }
+    },
+    {
       "name": "win-base",
       "hidden": true,
+      "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot, USE_GOOGLETEST is left off so a plain Windows build does not fetch googletest, BLA_VENDOR names the BLAS that the Windows dependency prefix provides, and CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core can import it in place.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -16,12 +44,7 @@
       },
       "cacheVariables": {
         "BUILD_QT": { "type": "BOOL", "value": "ON" },
-        "USE_GOOGLETEST": { "type": "BOOL", "value": "OFF" },
-        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
-        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/solvcon"
-        }
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {


### PR DESCRIPTION
Step 2 of the CMake presets plan. Related to #120. Stacked on #123.

The Makefile passes twelve `-D` flags on every configure; the presets passed none of them, so a preset build silently took the `CMakeLists.txt` defaults. Two of those defaults differ from what the Makefile asks for: `HIDE_SYMBOL` is off, so the module keeps default symbol visibility, and `LINT_AS_ERRORS` is off, so a clang-tidy report does not fail the build. A developer comparing a preset build against a make build was not comparing the same build.

This adds a hidden `base` preset carrying the knobs that hold on every host at the Makefile's values, and has the Windows presets inherit it.

Two knobs needed a decision rather than a copy.

`USE_GOOGLETEST` is the one knob the presets set and the Makefile does not. The preset was the only place it was off: the project default is on, both Windows CI jobs turn it back on, and `build.ps1 -Gtest` has to re-add it. It is now stated at the project default, so a preset build and a make build compile the same set of targets, and a build that does not want the C++ suite says so on the command line.

`BLA_VENDOR` stays on the Windows presets, where the dependency prefix that ships OpenBLAS lives. It steers only the `find_package(LAPACK QUIET)` fallback in `cpp/solvcon/CMakeLists.txt`, and a build that sets `SOLVCON_USE_MKL`, as both Windows CI jobs do, returns before reaching that fallback. So the CI jobs do not actually contradict the preset, and the `$comment` now records that.

The `base` preset also carries the run environment: `PYTHONPATH` pointing at the source directory, the preset counterpart of the Makefile's `RUNENV`, so a target launched from an IDE finds the in-tree package the way a make-launched one does.

## Verification

- The resolved cache variables of `win-rel` were compared knob by knob against the `-D` flags `CMAKE_CMD` expands, at the Makefile's own default values. Every knob the Makefile passes now has the same value in the preset; the only textual differences are `$(SOLVCON_ROOT)` against `${sourceDir}`, which name the same directory.
- `cmake --list-presets` still lists nothing on Linux, and lists both presets with the host condition inverted, so the layering did not disturb the filtering.

## Risk

Turning on `HIDE_SYMBOL` changes the symbol visibility of the Windows `_solvcon`. On MSVC the visibility attributes it controls are inert, so the change is a no-op there. `LINT_AS_ERRORS` only feeds the clang-tidy command line, which `USE_CLANG_TIDY=OFF` does not build.
