### PR TITLE
Step 3: Document the CMakeUserPresets.json seam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ thirdparty/install/
 thirdparty/archive/
 tmp/
 setup.mk
+CMakeUserPresets.json
 *.egg-info/
 *.pyc
 *.pyo

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,9 @@
       },
       "environment": {
         "PYTHONPATH": "${sourceDir}"
+      },
+      "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true }
       }
     },
     {
@@ -36,7 +39,7 @@
       "hidden": true,
       "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -47,6 +50,7 @@
         "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
       },
       "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true },
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "hostOS": ["Windows"],
           "intelliSenseMode": "windows-msvc-x64"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -5,10 +5,38 @@
   "$comment": "Schema version 10 is the highest that CMake 4.0.1, the project minimum, understands; it is also the highest CLion reads. Raising it further would lift the CMake floor and drop CLion support.",
   "configurePresets": [
     {
+      "name": "base",
+      "hidden": true,
+      "$comment": "The knobs that hold on every host, at the values the Makefile passes on every configure. HIDE_SYMBOL keeps the C++ symbols out of the module's dynamic table, DEBUG_SYMBOL keeps a build debuggable, LINT_AS_ERRORS makes a clang-tidy report fail the build once USE_CLANG_TIDY turns it on, SKIP_PYTHON_EXECUTABLE off lets CMake locate the interpreter, and SOLVCON_PROFILE and BUILD_METAL are the two features that are off unless a build asks for them. USE_GOOGLETEST is stated at the project default so that a preset build and a make build compile the same set of targets. CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core imports it in place, and CMAKE_INSTALL_PREFIX keeps a stray install inside the build tree.",
+      "cacheVariables": {
+        "HIDE_SYMBOL": { "type": "BOOL", "value": "ON" },
+        "DEBUG_SYMBOL": { "type": "BOOL", "value": "ON" },
+        "LINT_AS_ERRORS": { "type": "BOOL", "value": "ON" },
+        "SKIP_PYTHON_EXECUTABLE": { "type": "BOOL", "value": "OFF" },
+        "SOLVCON_PROFILE": { "type": "BOOL", "value": "OFF" },
+        "USE_CLANG_TIDY": { "type": "BOOL", "value": "OFF" },
+        "BUILD_METAL": { "type": "BOOL", "value": "OFF" },
+        "USE_GOOGLETEST": { "type": "BOOL", "value": "ON" },
+        "CMAKE_EXPORT_COMPILE_COMMANDS": { "type": "BOOL", "value": "ON" },
+        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/solvcon"
+        },
+        "CMAKE_INSTALL_PREFIX": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/fakeinstall"
+        }
+      },
+      "environment": {
+        "PYTHONPATH": "${sourceDir}"
+      }
+    },
+    {
       "name": "win-base",
       "hidden": true,
+      "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot, USE_GOOGLETEST is left off so a plain Windows build does not fetch googletest, BLA_VENDOR names the BLAS that the Windows dependency prefix provides, and CMAKE_LIBRARY_OUTPUT_DIRECTORY puts _solvcon next to the Python package so solvcon.core can import it in place.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -16,12 +44,7 @@
       },
       "cacheVariables": {
         "BUILD_QT": { "type": "BOOL", "value": "ON" },
-        "USE_GOOGLETEST": { "type": "BOOL", "value": "OFF" },
-        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
-        "CMAKE_LIBRARY_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/solvcon"
-        }
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
       },
       "vendor": {
         "microsoft.com/VisualStudioSettings/CMake/1.0": {

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,9 @@
 # setup.py shell out to "make", and its module-copy target runs
 # "python3-config"; neither exists on Windows.  This drives CMake directly
 # through the win-rel / win-dbg presets in CMakePresets.json, adding only the
-# scdv-specific cache variables, and places the module by hand.
+# scdv-specific cache variables, and places the module by hand.  Those three
+# path variables belong in CMakeUserPresets.json; pass -Preset <name> to build
+# such a preset and the script leaves them to it.
 #
 # It finds a CMake >= 4.0.1 (solvcon's minimum; the VS 2022 Build Tools bundle
 # only 3.31.6, so it falls back to VS 2026's 4.x) and compiles with the same
@@ -22,6 +24,10 @@
 #       active scdv (or -ScdvBase), then place the module.
 #   .\build.ps1 -ScdvBase <dir>       activate the scdv at <dir> first
 #   .\build.ps1 -BuildType Debug      use the win-dbg preset
+#   .\build.ps1 -Preset local         use a preset from CMakeUserPresets.json,
+#                                     which is expected to supply the
+#                                     dependency-prefix paths itself (see
+#                                     contrib/cmake/CMakeUserPresets.json.example)
 #   .\build.ps1 -NoQt                 build only _solvcon (BUILD_QT=OFF)
 #   .\build.ps1 -Test                 then run "pytest tests\" headless
 #   .\build.ps1 -Pilot                then launch the pilot GUI
@@ -43,6 +49,7 @@ param(
     [string]$ScdvBase,
     [string]$Repo,
     [ValidateSet('Release', 'Debug')][string]$BuildType = 'Release',
+    [string]$Preset,
     [switch]$NoQt,
     [switch]$Gtest,
     [switch]$Test,
@@ -94,8 +101,19 @@ if (-not $Repo) { $Repo = $PSScriptRoot }
 if (-not (Test-Path -LiteralPath (Join-Path $Repo 'CMakePresets.json'))) {
     throw "no CMakePresets.json under -Repo '$Repo'; point it at a solvcon checkout"
 }
-$preset = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
-$bld = Join-Path $Repo "build\$preset"
+# A named preset is taken verbatim, so a preset from CMakeUserPresets.json can
+# be built; -BuildType then selects nothing, since the named preset states its
+# own build type.  PowerShell variable names are case-insensitive, so the
+# resolved name cannot be spelled $preset next to the -Preset parameter.
+if ($Preset) {
+    if ($PSBoundParameters.ContainsKey('BuildType')) {
+        throw '-Preset and -BuildType are exclusive: the named preset states its own build type'
+    }
+    $presetName = $Preset
+} else {
+    $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
+}
+$bld = Join-Path $Repo "build\$presetName"
 $solvconDir = Join-Path $Repo 'solvcon'
 
 # --- MSVC environment -------------------------------------------------------
@@ -186,42 +204,50 @@ if (-not (Test-Path -LiteralPath $py)) {
 
 # --- Configure and build via the preset -------------------------------------
 
-$pybind = & $py -m pybind11 --cmakedir
-Assert-LastExit 'pybind11 --cmakedir'
 # The preset holds the static knobs (generator, build type, BUILD_QT,
 # USE_GOOGLETEST, BLA_VENDOR, output dirs); pass the scdv-specific cache
 # variables on top.  -NoQt overrides the preset's BUILD_QT=ON.
-$extra = @(
-    "-DPYTHON_EXECUTABLE=$py",
-    "-Dpybind11_path=$pybind",
-    "-DCMAKE_PREFIX_PATH=$usr"
-)
+$extra = @()
+if ($Preset) {
+    # A named preset comes from CMakeUserPresets.json, whose whole purpose is
+    # to carry the paths of one machine's dependency prefix, so leave them to
+    # it rather than overriding them from the command line.
+    Write-Host "preset $presetName supplies the dependency-prefix paths"
+} else {
+    $pybind = & $py -m pybind11 --cmakedir
+    Assert-LastExit 'pybind11 --cmakedir'
+    $extra += @(
+        "-DPYTHON_EXECUTABLE=$py",
+        "-Dpybind11_path=$pybind",
+        "-DCMAKE_PREFIX_PATH=$usr"
+    )
+}
 if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
-# -Gtest turns on the gtest binary (USE_GOOGLETEST is OFF in the preset), and
-# -Sanitize (which implies -Gtest) builds it under AddressSanitizer. The gtest
-# binary links the ASan runtime directly so ASan initializes at process start,
-# unlike loading an instrumented .pyd into a stock python.exe.
-if ($Gtest) { $extra += '-DUSE_GOOGLETEST=ON' }
+# -Gtest adds the gtest binary to the target list below; the preset already
+# states USE_GOOGLETEST, so nothing has to be turned on here. -Sanitize (which
+# implies -Gtest) builds that binary under AddressSanitizer. It links the ASan
+# runtime directly so ASan initializes at process start, unlike loading an
+# instrumented .pyd into a stock python.exe.
 if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON' }
 
 Push-Location $Repo
 try {
-    Write-Host "configuring solvcon (preset $preset, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
-    & $cmake --preset $preset @extra
+    Write-Host "configuring solvcon (preset $presetName, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
+    & $cmake --preset $presetName @extra
     Assert-LastExit 'cmake configure'
 
     $targets = @('_solvcon')
     if (-not $NoQt) { $targets += 'pilot' }
     if ($Gtest) { $targets += 'test_nopython' }
     Write-Host "building targets: $($targets -join ', ')"
-    & $cmake --build --preset $preset --target @targets
+    & $cmake --build --preset $presetName --target @targets
     Assert-LastExit 'cmake build'
 } finally {
     Pop-Location
 }
 
 # _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the preset's binary dir, build\$preset).
+# a RUNTIME artifact (-> the preset's binary dir, build\$presetName).
 # Copy the module to the repo root as the top-level _solvcon: solvcon.core
 # imports it there first, and the tests' qualified type names assume that name.
 $pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -1,0 +1,31 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "$comment": "Copy this file to CMakeUserPresets.json at the repository root and edit the paths. It is gitignored, it implicitly includes CMakePresets.json, and both VS Code and CLion read it with no further configuration. Nothing here belongs in a checked-in preset: every value names a directory on one machine.",
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "displayName": "Local dependency prefix",
+      "description": "A checked-in preset plus the paths of a local dependency prefix.",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "$comment": "Change inherits to the preset you build. binaryDir is restated so this preset gets its own build tree instead of sharing the inherited one. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "/path/to/prefix/bin/python3"
+        },
+        "pybind11_path": "/path/to/prefix/lib/python3.14/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "/path/to/prefix"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "local",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix"
+    }
+  ]
+}

--- a/doc/source/devguide/index.md
+++ b/doc/source/devguide/index.md
@@ -5,6 +5,7 @@
 
 contributing
 testing
+presets
 style
 ```
 

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -1,0 +1,94 @@
+# CMake Presets
+
+`CMakePresets.json` at the repository root holds solvcon's build
+configuration: the generator, the build type, the cache variables, and the run
+environment.  It is checked in, so every contributor and every continuous
+integration job configures the same way, and both supported IDEs read it
+directly.
+
+List what the file offers on this host, then configure and build:
+
+```bash
+cmake --list-presets
+cmake --preset <name>
+cmake --build --preset <name>
+```
+
+A preset that names a toolchain the current host cannot run carries a
+`condition`, so it does not appear in the listing there.  On Linux and macOS
+the make targets described in {doc}`/start/build_solvcon` remain the primary
+entry point.
+
+## Machine paths belong in `CMakeUserPresets.json`
+
+Three cache variables name directories that exist on one machine only:
+
+| Variable            | What it names                                         |
+|:--------------------|:------------------------------------------------------|
+| `PYTHON_EXECUTABLE` | the interpreter the extension is built against        |
+| `pybind11_path`     | the pybind11 CMake package directory for that Python  |
+| `CMAKE_PREFIX_PATH` | the dependency prefix holding Qt6, PySide6, and so on |
+
+They must not be checked in, which is what `CMakeUserPresets.json` is for.
+CMake reads it automatically, it implicitly includes `CMakePresets.json`, and
+it is gitignored.  Both VS Code and CLion pick it up with no IDE settings at
+all, which is the only way a dependency prefix reaches an IDE build: there is
+no wrapper script to fall back on there.
+
+Copy the template and edit the paths:
+
+```bash
+cp contrib/cmake/CMakeUserPresets.json.example CMakeUserPresets.json
+```
+
+The template defines one configure preset and one build preset, both named
+`local`, that inherit a checked-in preset and add the three variables:
+
+```json
+{
+  "version": 10,
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "displayName": "Local dependency prefix",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "/path/to/prefix/bin/python3"
+        },
+        "pybind11_path": "/path/to/prefix/lib/python3.14/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "/path/to/prefix"
+      }
+    }
+  ]
+}
+```
+
+Change `inherits` to the preset you build.  `pybind11_path` is what
+`python3 -m pybind11 --cmakedir` prints for the interpreter named above it.
+After that, `cmake --preset local` configures from a bare checkout, and
+`local` appears in the IDE preset pickers alongside the checked-in presets.
+
+In CLion the `enablePythonIntegration` key in the `jetbrains.com/clion` vendor
+map, already set in the checked-in presets, hands the IDE's selected
+interpreter to the configure step.  A CLion user can therefore drop the
+`PYTHON_EXECUTABLE` line and keep only the other two.
+
+## IDE notes
+
+Nothing else needs to be configured, and a few things must not be.
+
+- VS Code CMake Tools turns preset mode on by itself once `CMakePresets.json`
+  exists.  In that mode it ignores `cmake.buildDirectory`,
+  `cmake.generator`, and `cmake.configureSettings` in `settings.json`, and it
+  disables kit selection, so a settings file that restates any of those only
+  causes confusion.
+- CLion imports the presets as read-only profiles and leaves a newly seen one
+  disabled until it is enabled in the CMake settings.
+- CLion reads configure and build presets only.  Anything expressed solely as
+  a test or workflow preset is invisible there, so the configure and build
+  presets stay self-sufficient.
+- Code navigation works from `compile_commands.json`, which the presets export.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/build_solvcon.md
+++ b/doc/source/start/build_solvcon.md
@@ -25,6 +25,10 @@ environment variables:
 | `SOLVCON_PROFILE`    | `OFF`     | enable the runtime profiler      |
 | `USE_CLANG_TIDY`     | `OFF`     | run clang-tidy during the build  |
 
+CMake itself is configured through `CMakePresets.json`; see
+{doc}`/devguide/presets` for the preset a Windows build or an IDE selects, and
+for where the paths of a local dependency prefix belong.
+
 After building, run the tests as described in {doc}`/devguide/testing`.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Step 3 of the CMake presets plan. Related to #120. Stacked on #124.

Three cache variables name directories that exist on one machine only: `PYTHON_EXECUTABLE`, `pybind11_path`, and `CMAKE_PREFIX_PATH`. `build.ps1` and the Makefile inject them on the command line, which is the reason no preset was usable from an IDE: an IDE runs `cmake --preset <name>` with nothing added, so configure fails at `find_package(pybind11 2.12.0 REQUIRED PATHS ${pybind11_path})`.

`CMakeUserPresets.json` is what those values are for. CMake reads it automatically, it implicitly includes `CMakePresets.json`, and both IDEs pick it up with no IDE settings at all. Since it cannot be checked in, its correctness rests entirely on documentation, so this step ships all three parts of that: a developer guide page describing the seam and the IDE behaviour that follows from it, a copyable template under `contrib/cmake/`, and a `.gitignore` entry.

`build.ps1` gains `-Preset <name>`, which builds a named preset and leaves the three path variables to it instead of overriding them. Without the switch the script behaves exactly as before. The switch is what makes the seam reachable from the script at all, because a user preset cannot redefine a checked-in preset's name, so it has to be selectable by name.

Two smaller things follow from step 2 and land here, both in `build.ps1`: its `-Gtest` switch stops passing `-DUSE_GOOGLETEST=ON`, which the preset now states, and keeps only its real job of adding the gtest binary to the target list; a stale comment saying the preset holds `USE_GOOGLETEST` off is corrected.

The checked-in presets also record the CLion `enablePythonIntegration` key, which hands the IDE's selected interpreter to the configure step. It is the one way `PYTHON_EXECUTABLE` gets resolved without a path being written down anywhere.

## Verification

- The template, copied to `CMakeUserPresets.json` in a tree where the host condition holds, is listed by `cmake --list-presets` as `local` alongside the two checked-in presets, so it parses, inherits, and resolves.
- `cmake --list-presets` on Linux still lists nothing, so the added vendor entry did not disturb the filtering.

## Note on the `-Preset` switch

PowerShell variable names are case-insensitive, so the resolved preset name cannot be spelled `$preset` beside the `-Preset` parameter; it is `$presetName`, with a comment saying why. `build.ps1` still recomputes the binary directory as `build\<preset>` rather than reading `binaryDir` from the JSON, so the template restates `binaryDir` as `${sourceDir}/build/${presetName}` to keep the two in agreement. Reading it from the file instead is step 4's job.
