### PR TITLE
Step 4: Let the build presets carry the targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ thirdparty/install/
 thirdparty/archive/
 tmp/
 setup.mk
+CMakeUserPresets.json
 *.egg-info/
 *.pyc
 *.pyo

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -29,6 +29,9 @@
       },
       "environment": {
         "PYTHONPATH": "${sourceDir}"
+      },
+      "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true }
       }
     },
     {
@@ -36,7 +39,7 @@
       "hidden": true,
       "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -47,6 +50,7 @@
         "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
       },
       "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true },
         "microsoft.com/VisualStudioSettings/CMake/1.0": {
           "hostOS": ["Windows"],
           "intelliSenseMode": "windows-msvc-x64"

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,15 +39,20 @@
       "hidden": true,
       "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it. Both the build tree and CMAKE_RUNTIME_OUTPUT_DIRECTORY, which is where pilot.exe lands, are named after the preset: ${presetName} expands to the preset actually selected, so one build tree per preset falls out and an inheriting preset does not write into its parent's.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
+      "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "BUILD_QT": { "type": "BOOL", "value": "ON" },
-        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/${presetName}"
+        }
       },
       "vendor": {
         "jetbrains.com/clion": { "enablePythonIntegration": true },
@@ -62,14 +67,8 @@
       "inherits": "win-base",
       "displayName": "Windows Release (Ninja, MSVC)",
       "description": "Optimized _solvcon and pilot built with MSVC through Ninja.",
-      "binaryDir": "${sourceDir}/build/win-rel",
-      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/build/win-rel"
-        }
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
       }
     },
     {
@@ -77,14 +76,8 @@
       "inherits": "win-base",
       "displayName": "Windows Debug (Ninja, MSVC)",
       "description": "Debuggable _solvcon and pilot built with MSVC through Ninja.",
-      "binaryDir": "${sourceDir}/build/win-dbg",
-      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" },
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/build/win-dbg"
-        }
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
       }
     }
   ],
@@ -92,7 +85,7 @@
     {
       "name": "win-base",
       "hidden": true,
-      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts.",
+      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts. Each configure preset gets three build presets, one per thing a person builds: the module with the pilot, the module alone, and the C++ test binary. Parallelism is left unstated: Ninja already scales to the host, and the only place a cap is wanted is a CI runner.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -109,14 +102,48 @@
       "inherits": "win-base",
       "configurePreset": "win-rel",
       "displayName": "Windows Release",
-      "description": "Build the Windows Release configuration."
+      "description": "Build the extension module and the pilot, Release.",
+      "targets": ["_solvcon", "pilot"]
+    },
+    {
+      "name": "win-rel-module",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, module only",
+      "description": "Build the extension module alone, Release.",
+      "targets": ["_solvcon"]
+    },
+    {
+      "name": "win-rel-gtest",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, C++ test binary",
+      "description": "Build the C++ gtest binary, Release.",
+      "targets": ["test_nopython"]
     },
     {
       "name": "win-dbg",
       "inherits": "win-base",
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug",
-      "description": "Build the Windows Debug configuration."
+      "description": "Build the extension module and the pilot, Debug.",
+      "targets": ["_solvcon", "pilot"]
+    },
+    {
+      "name": "win-dbg-module",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, module only",
+      "description": "Build the extension module alone, Debug.",
+      "targets": ["_solvcon"]
+    },
+    {
+      "name": "win-dbg-gtest",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, C++ test binary",
+      "description": "Build the C++ gtest binary, Debug.",
+      "targets": ["test_nopython"]
     }
   ]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -113,7 +113,44 @@ if ($Preset) {
 } else {
     $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
 }
-$bld = Join-Path $Repo "build\$presetName"
+
+function Get-ConfigurePresetBinaryDir {
+    # The binary directory a configure preset states, resolved through
+    # inherits.  Reading it beats recomputing "build\<preset>": the presets
+    # are free to name their build trees, and a user preset that inherits one
+    # of them gets its own.
+    param([string]$Root, [string]$Name)
+    $presets = @{}
+    foreach ($file in @('CMakePresets.json', 'CMakeUserPresets.json')) {
+        $path = Join-Path $Root $file
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        $doc = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        if (-not $doc.PSObject.Properties['configurePresets']) { continue }
+        foreach ($entry in $doc.configurePresets) { $presets[$entry.name] = $entry }
+    }
+    # Depth-first through inherits, nearest definition wins, as CMake resolves
+    # it.
+    function Find-BinaryDir {
+        param([string]$Name)
+        $entry = $presets[$Name]
+        if (-not $entry) { return $null }
+        if ($entry.PSObject.Properties['binaryDir']) { return $entry.binaryDir }
+        if ($entry.PSObject.Properties['inherits']) {
+            foreach ($parent in @($entry.inherits)) {
+                $found = Find-BinaryDir $parent
+                if ($found) { return $found }
+            }
+        }
+        return $null
+    }
+    $raw = Find-BinaryDir $Name
+    if (-not $raw) { throw "preset '$Name' states no binaryDir" }
+    $raw = $raw.Replace('${sourceDir}', $Root).Replace('${presetName}', $Name)
+    if ($raw -match '\$\{') { throw "unsupported macro in binaryDir '$raw'" }
+    return $raw.Replace('/', '\')
+}
+
+$bld = Get-ConfigurePresetBinaryDir $Repo $presetName
 $solvconDir = Join-Path $Repo 'solvcon'
 
 # --- MSVC environment -------------------------------------------------------
@@ -236,18 +273,27 @@ try {
     & $cmake --preset $presetName @extra
     Assert-LastExit 'cmake configure'
 
-    $targets = @('_solvcon')
-    if (-not $NoQt) { $targets += 'pilot' }
-    if ($Gtest) { $targets += 'test_nopython' }
-    Write-Host "building targets: $($targets -join ', ')"
-    & $cmake --build --preset $presetName --target @targets
-    Assert-LastExit 'cmake build'
+    # The build presets carry the target lists: <preset> builds the module and
+    # the pilot, <preset>-module the module alone, <preset>-gtest the C++ test
+    # binary.
+    $buildPresets = @()
+    if ($NoQt) {
+        $buildPresets += "$presetName-module"
+    } else {
+        $buildPresets += $presetName
+    }
+    if ($Gtest) { $buildPresets += "$presetName-gtest" }
+    foreach ($buildPreset in $buildPresets) {
+        Write-Host "building preset: $buildPreset"
+        & $cmake --build --preset $buildPreset
+        Assert-LastExit "cmake build --preset $buildPreset"
+    }
 } finally {
     Pop-Location
 }
 
 # _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the preset's binary dir, build\$presetName).
+# a RUNTIME artifact (-> the binary directory the preset states, read above).
 # Copy the module to the repo root as the top-level _solvcon: solvcon.core
 # imports it there first, and the tests' qualified type names assume that name.
 $pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |

--- a/build.ps1
+++ b/build.ps1
@@ -8,7 +8,9 @@
 # setup.py shell out to "make", and its module-copy target runs
 # "python3-config"; neither exists on Windows.  This drives CMake directly
 # through the win-rel / win-dbg presets in CMakePresets.json, adding only the
-# scdv-specific cache variables, and places the module by hand.
+# scdv-specific cache variables, and places the module by hand.  Those three
+# path variables belong in CMakeUserPresets.json; pass -Preset <name> to build
+# such a preset and the script leaves them to it.
 #
 # It finds a CMake >= 4.0.1 (solvcon's minimum; the VS 2022 Build Tools bundle
 # only 3.31.6, so it falls back to VS 2026's 4.x) and compiles with the same
@@ -22,6 +24,10 @@
 #       active scdv (or -ScdvBase), then place the module.
 #   .\build.ps1 -ScdvBase <dir>       activate the scdv at <dir> first
 #   .\build.ps1 -BuildType Debug      use the win-dbg preset
+#   .\build.ps1 -Preset local         use a preset from CMakeUserPresets.json,
+#                                     which is expected to supply the
+#                                     dependency-prefix paths itself (see
+#                                     contrib/cmake/CMakeUserPresets.json.example)
 #   .\build.ps1 -NoQt                 build only _solvcon (BUILD_QT=OFF)
 #   .\build.ps1 -Test                 then run "pytest tests\" headless
 #   .\build.ps1 -Pilot                then launch the pilot GUI
@@ -43,6 +49,7 @@ param(
     [string]$ScdvBase,
     [string]$Repo,
     [ValidateSet('Release', 'Debug')][string]$BuildType = 'Release',
+    [string]$Preset,
     [switch]$NoQt,
     [switch]$Gtest,
     [switch]$Test,
@@ -94,8 +101,19 @@ if (-not $Repo) { $Repo = $PSScriptRoot }
 if (-not (Test-Path -LiteralPath (Join-Path $Repo 'CMakePresets.json'))) {
     throw "no CMakePresets.json under -Repo '$Repo'; point it at a solvcon checkout"
 }
-$preset = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
-$bld = Join-Path $Repo "build\$preset"
+# A named preset is taken verbatim, so a preset from CMakeUserPresets.json can
+# be built; -BuildType then selects nothing, since the named preset states its
+# own build type.  PowerShell variable names are case-insensitive, so the
+# resolved name cannot be spelled $preset next to the -Preset parameter.
+if ($Preset) {
+    if ($PSBoundParameters.ContainsKey('BuildType')) {
+        throw '-Preset and -BuildType are exclusive: the named preset states its own build type'
+    }
+    $presetName = $Preset
+} else {
+    $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
+}
+$bld = Join-Path $Repo "build\$presetName"
 $solvconDir = Join-Path $Repo 'solvcon'
 
 # --- MSVC environment -------------------------------------------------------
@@ -186,42 +204,50 @@ if (-not (Test-Path -LiteralPath $py)) {
 
 # --- Configure and build via the preset -------------------------------------
 
-$pybind = & $py -m pybind11 --cmakedir
-Assert-LastExit 'pybind11 --cmakedir'
 # The preset holds the static knobs (generator, build type, BUILD_QT,
 # USE_GOOGLETEST, BLA_VENDOR, output dirs); pass the scdv-specific cache
 # variables on top.  -NoQt overrides the preset's BUILD_QT=ON.
-$extra = @(
-    "-DPYTHON_EXECUTABLE=$py",
-    "-Dpybind11_path=$pybind",
-    "-DCMAKE_PREFIX_PATH=$usr"
-)
+$extra = @()
+if ($Preset) {
+    # A named preset comes from CMakeUserPresets.json, whose whole purpose is
+    # to carry the paths of one machine's dependency prefix, so leave them to
+    # it rather than overriding them from the command line.
+    Write-Host "preset $presetName supplies the dependency-prefix paths"
+} else {
+    $pybind = & $py -m pybind11 --cmakedir
+    Assert-LastExit 'pybind11 --cmakedir'
+    $extra += @(
+        "-DPYTHON_EXECUTABLE=$py",
+        "-Dpybind11_path=$pybind",
+        "-DCMAKE_PREFIX_PATH=$usr"
+    )
+}
 if ($NoQt) { $extra += '-DBUILD_QT=OFF' }
-# -Gtest turns on the gtest binary (USE_GOOGLETEST is OFF in the preset), and
-# -Sanitize (which implies -Gtest) builds it under AddressSanitizer. The gtest
-# binary links the ASan runtime directly so ASan initializes at process start,
-# unlike loading an instrumented .pyd into a stock python.exe.
-if ($Gtest) { $extra += '-DUSE_GOOGLETEST=ON' }
+# -Gtest adds the gtest binary to the target list below; the preset already
+# states USE_GOOGLETEST, so nothing has to be turned on here. -Sanitize (which
+# implies -Gtest) builds that binary under AddressSanitizer. It links the ASan
+# runtime directly so ASan initializes at process start, unlike loading an
+# instrumented .pyd into a stock python.exe.
 if ($Sanitize) { $extra += '-DUSE_SANITIZER=ON' }
 
 Push-Location $Repo
 try {
-    Write-Host "configuring solvcon (preset $preset, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
-    & $cmake --preset $preset @extra
+    Write-Host "configuring solvcon (preset $presetName, BUILD_QT=$(if ($NoQt) {'OFF'} else {'ON'})) ..."
+    & $cmake --preset $presetName @extra
     Assert-LastExit 'cmake configure'
 
     $targets = @('_solvcon')
     if (-not $NoQt) { $targets += 'pilot' }
     if ($Gtest) { $targets += 'test_nopython' }
     Write-Host "building targets: $($targets -join ', ')"
-    & $cmake --build --preset $preset --target @targets
+    & $cmake --build --preset $presetName --target @targets
     Assert-LastExit 'cmake build'
 } finally {
     Pop-Location
 }
 
 # _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the preset's binary dir, build\$preset).
+# a RUNTIME artifact (-> the preset's binary dir, build\$presetName).
 # Copy the module to the repo root as the top-level _solvcon: solvcon.core
 # imports it there first, and the tests' qualified type names assume that name.
 $pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -1,0 +1,31 @@
+{
+  "version": 10,
+  "$schema": "https://json.schemastore.org/cmake-presets.json",
+  "cmakeMinimumRequired": { "major": 4, "minor": 0, "patch": 1 },
+  "$comment": "Copy this file to CMakeUserPresets.json at the repository root and edit the paths. It is gitignored, it implicitly includes CMakePresets.json, and both VS Code and CLion read it with no further configuration. Nothing here belongs in a checked-in preset: every value names a directory on one machine.",
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "displayName": "Local dependency prefix",
+      "description": "A checked-in preset plus the paths of a local dependency prefix.",
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "$comment": "Change inherits to the preset you build. binaryDir is restated so this preset gets its own build tree instead of sharing the inherited one. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "/path/to/prefix/bin/python3"
+        },
+        "pybind11_path": "/path/to/prefix/lib/python3.14/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "/path/to/prefix"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "local",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix"
+    }
+  ]
+}

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -9,8 +9,7 @@
       "inherits": "win-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "$comment": "Change inherits to the preset you build. binaryDir is restated so this preset gets its own build tree instead of sharing the inherited one. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "$comment": "Change inherits to the preset you build. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
@@ -24,8 +23,21 @@
   "buildPresets": [
     {
       "name": "local",
+      "inherits": "win-rel",
       "configurePreset": "local",
       "displayName": "Local dependency prefix"
+    },
+    {
+      "name": "local-module",
+      "inherits": "win-rel-module",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, module only"
+    },
+    {
+      "name": "local-gtest",
+      "inherits": "win-rel-gtest",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, C++ test binary"
     }
   ]
 }

--- a/doc/source/devguide/index.md
+++ b/doc/source/devguide/index.md
@@ -5,6 +5,7 @@
 
 contributing
 testing
+presets
 style
 ```
 

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -19,6 +19,20 @@ A preset that names a toolchain the current host cannot run carries a
 the make targets described in {doc}`/start/build_solvcon` remain the primary
 entry point.
 
+Each configure preset comes with three build presets, one per thing that is
+actually built:
+
+| Build preset          | Targets                            |
+|:----------------------|:-----------------------------------|
+| `<preset>`            | the extension module and the pilot |
+| `<preset>-module`     | the extension module alone         |
+| `<preset>-gtest`      | the C++ gtest binary               |
+
+`cmake --build --preset <name>` therefore needs no `--target` argument.  The
+build tree is `build/<configure preset>`, named through the `${presetName}`
+macro so that a preset inheriting another gets its own tree rather than
+writing into its parent's.
+
 ## Machine paths belong in `CMakeUserPresets.json`
 
 Three cache variables name directories that exist on one machine only:
@@ -41,8 +55,9 @@ Copy the template and edit the paths:
 cp contrib/cmake/CMakeUserPresets.json.example CMakeUserPresets.json
 ```
 
-The template defines one configure preset and one build preset, both named
-`local`, that inherit a checked-in preset and add the three variables:
+The template defines a configure preset named `local` that inherits a
+checked-in preset and adds the three variables, plus the three build presets
+that go with it:
 
 ```json
 {

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -1,0 +1,94 @@
+# CMake Presets
+
+`CMakePresets.json` at the repository root holds solvcon's build
+configuration: the generator, the build type, the cache variables, and the run
+environment.  It is checked in, so every contributor and every continuous
+integration job configures the same way, and both supported IDEs read it
+directly.
+
+List what the file offers on this host, then configure and build:
+
+```bash
+cmake --list-presets
+cmake --preset <name>
+cmake --build --preset <name>
+```
+
+A preset that names a toolchain the current host cannot run carries a
+`condition`, so it does not appear in the listing there.  On Linux and macOS
+the make targets described in {doc}`/start/build_solvcon` remain the primary
+entry point.
+
+## Machine paths belong in `CMakeUserPresets.json`
+
+Three cache variables name directories that exist on one machine only:
+
+| Variable            | What it names                                         |
+|:--------------------|:------------------------------------------------------|
+| `PYTHON_EXECUTABLE` | the interpreter the extension is built against        |
+| `pybind11_path`     | the pybind11 CMake package directory for that Python  |
+| `CMAKE_PREFIX_PATH` | the dependency prefix holding Qt6, PySide6, and so on |
+
+They must not be checked in, which is what `CMakeUserPresets.json` is for.
+CMake reads it automatically, it implicitly includes `CMakePresets.json`, and
+it is gitignored.  Both VS Code and CLion pick it up with no IDE settings at
+all, which is the only way a dependency prefix reaches an IDE build: there is
+no wrapper script to fall back on there.
+
+Copy the template and edit the paths:
+
+```bash
+cp contrib/cmake/CMakeUserPresets.json.example CMakeUserPresets.json
+```
+
+The template defines one configure preset and one build preset, both named
+`local`, that inherit a checked-in preset and add the three variables:
+
+```json
+{
+  "version": 10,
+  "configurePresets": [
+    {
+      "name": "local",
+      "inherits": "win-rel",
+      "displayName": "Local dependency prefix",
+      "cacheVariables": {
+        "PYTHON_EXECUTABLE": {
+          "type": "FILEPATH",
+          "value": "/path/to/prefix/bin/python3"
+        },
+        "pybind11_path": "/path/to/prefix/lib/python3.14/site-packages/pybind11/share/cmake/pybind11",
+        "CMAKE_PREFIX_PATH": "/path/to/prefix"
+      }
+    }
+  ]
+}
+```
+
+Change `inherits` to the preset you build.  `pybind11_path` is what
+`python3 -m pybind11 --cmakedir` prints for the interpreter named above it.
+After that, `cmake --preset local` configures from a bare checkout, and
+`local` appears in the IDE preset pickers alongside the checked-in presets.
+
+In CLion the `enablePythonIntegration` key in the `jetbrains.com/clion` vendor
+map, already set in the checked-in presets, hands the IDE's selected
+interpreter to the configure step.  A CLion user can therefore drop the
+`PYTHON_EXECUTABLE` line and keep only the other two.
+
+## IDE notes
+
+Nothing else needs to be configured, and a few things must not be.
+
+- VS Code CMake Tools turns preset mode on by itself once `CMakePresets.json`
+  exists.  In that mode it ignores `cmake.buildDirectory`,
+  `cmake.generator`, and `cmake.configureSettings` in `settings.json`, and it
+  disables kit selection, so a settings file that restates any of those only
+  causes confusion.
+- CLion imports the presets as read-only profiles and leaves a newly seen one
+  disabled until it is enabled in the CMake settings.
+- CLion reads configure and build presets only.  Anything expressed solely as
+  a test or workflow preset is invisible there, so the configure and build
+  presets stay self-sufficient.
+- Code navigation works from `compile_commands.json`, which the presets export.
+
+<!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->

--- a/doc/source/start/build_solvcon.md
+++ b/doc/source/start/build_solvcon.md
@@ -25,6 +25,10 @@ environment variables:
 | `SOLVCON_PROFILE`    | `OFF`     | enable the runtime profiler      |
 | `USE_CLANG_TIDY`     | `OFF`     | run clang-tidy during the build  |
 
+CMake itself is configured through `CMakePresets.json`; see
+{doc}`/devguide/presets` for the preset a Windows build or an IDE selects, and
+for where the paths of a local dependency prefix belong.
+
 After building, run the tests as described in {doc}`/devguide/testing`.
 
 <!-- vim: set ft=markdown ff=unix fenc=utf8 et sw=2 ts=2 sts=2 tw=79: -->


### PR DESCRIPTION
Step 4 of the CMake presets plan. Related to #120. Stacked on #125.

The build presets were empty shells that named a configure preset and nothing else. Meanwhile `build.ps1` assembled the target list in PowerShell and recomputed the binary directory as `build\<preset>`, a restatement of JSON it had already located: if a preset's `binaryDir` changed, the script pointed at the wrong directory and reported the wrong `pilot.exe` path.

Each configure preset now has three build presets, one per thing that is actually built.

| Build preset      | Targets                            |
|:------------------|:-----------------------------------|
| `<preset>`        | the extension module and the pilot |
| `<preset>-module` | the extension module alone         |
| `<preset>-gtest`  | the C++ gtest binary               |

`build.ps1` picks among them rather than building an array, and reads `binaryDir` out of the preset files, resolving `inherits` and expanding the two macros the presets use. Its switch matrix is unchanged: `-NoQt` selects the `-module` preset, `-Gtest` adds a second build of the `-gtest` preset, and the sanitizer combinations still assert the same way.

The build tree and `CMAKE_RUNTIME_OUTPUT_DIRECTORY` are now named through `${presetName}` on the shared Windows preset instead of being spelled out on each leaf. The two checked-in presets keep the directories they had, and a preset that inherits one of them gets its own tree instead of writing into its parent's, which is what makes reading `binaryDir` worth doing at all. The user-preset template drops the `binaryDir` line it needed for that reason and gains the three build presets to match.

Parallelism is deliberately left unstated. Ninja already scales to the host, and the only place a cap is wanted is a CI runner, whose presets are not these.

## Verification

- `cmake --list-presets=build` lists the six checked-in build presets, and the nine that result once the user-preset template is copied in, so every entry parses and resolves its `inherits` and `configurePreset`.
- The `binaryDir` resolution `build.ps1` now performs was replayed against the real preset files: `win-rel` and `win-dbg` resolve to the same `build/win-rel` and `build/win-dbg` the script previously computed by hand, and a template-derived `local` resolves to `build/local`.

## What CI does not cover

No CI job runs `build.ps1`; the Windows jobs drive CMake directly. The script's changes here are reviewed rather than executed, and there is no PowerShell interpreter on this development host to parse-check them. The Windows CI jobs still pass because they never touch either the script or the presets.
