### PR TITLE
Step 5: Add the developer presets for Linux and macOS

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,6 +35,56 @@
       }
     },
     {
+      "name": "dev-base",
+      "hidden": true,
+      "inherits": "base",
+      "generator": "Ninja",
+      "$comment": "The developer presets for Linux and macOS. The host filter is a notEquals against Windows rather than a list, because CLion accepts only equals and notEquals and would silently ignore anything else. Ninja is already a documented dependency of the development environment (contrib/dependency/build-scdv.sh installs it), and it is what makes an IDE build incremental. These trees are separate from the ones the Makefile builds under build/rel<pyvminor>, so the two never fight over a cache.",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "BUILD_QT": { "type": "BOOL", "value": "ON" }
+      },
+      "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true },
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Linux", "macOS"]
+        }
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "displayName": "Developer Release",
+      "description": "Optimized _solvcon and pilot for Linux and macOS.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
+      }
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "displayName": "Developer Debug",
+      "description": "Debuggable _solvcon and pilot for Linux and macOS.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
+      }
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "displayName": "Developer Release, no Qt",
+      "description": "Optimized _solvcon without the pilot, for a headless host.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "BUILD_QT": { "type": "BOOL", "value": "OFF" }
+      }
+    },
+    {
       "name": "win-base",
       "hidden": true,
       "inherits": "base",
@@ -82,6 +132,85 @@
     }
   ],
   "buildPresets": [
+    {
+      "name": "dev-base",
+      "hidden": true,
+      "$comment": "The module target is _solvcon_py, not _solvcon: it copies the built extension to the repository root under its ABI-tagged name, which is where solvcon.core looks for it first and what the make build produces.",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Linux", "macOS"]
+        }
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release",
+      "description": "Build the extension module and the pilot, Release.",
+      "targets": ["_solvcon_py", "pilot"]
+    },
+    {
+      "name": "dev-rel-module",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, module only",
+      "description": "Build the extension module alone, Release.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-rel-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, C++ test binary",
+      "description": "Build the C++ gtest binary, Release.",
+      "targets": ["test_nopython"]
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug",
+      "description": "Build the extension module and the pilot, Debug.",
+      "targets": ["_solvcon_py", "pilot"]
+    },
+    {
+      "name": "dev-dbg-module",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, module only",
+      "description": "Build the extension module alone, Debug.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-dbg-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, C++ test binary",
+      "description": "Build the C++ gtest binary, Debug.",
+      "targets": ["test_nopython"]
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt",
+      "description": "Build the extension module alone, without the pilot.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-noqt-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt, C++ test binary",
+      "description": "Build the C++ gtest binary, without the pilot.",
+      "targets": ["test_nopython"]
+    },
     {
       "name": "win-base",
       "hidden": true,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,15 +39,20 @@
       "hidden": true,
       "inherits": "base",
       "generator": "Ninja",
-      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it.",
+      "$comment": "Windows builds go through Ninja and MSVC because the Makefile shells out to make and python3-config, neither of which exists there. BUILD_QT builds the pilot. BLA_VENDOR names the BLAS that the Windows dependency prefix ships; it steers only the find_package(LAPACK) fallback, and a build that sets SOLVCON_USE_MKL, as both Windows CI jobs do, never reaches that fallback. The CLion vendor entry is repeated from base because an inherited vendor map is replaced by the child's rather than merged with it. Both the build tree and CMAKE_RUNTIME_OUTPUT_DIRECTORY, which is where pilot.exe lands, are named after the preset: ${presetName} expands to the preset actually selected, so one build tree per preset falls out and an inheriting preset does not write into its parent's.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
         "rhs": "Windows"
       },
+      "binaryDir": "${sourceDir}/build/${presetName}",
       "cacheVariables": {
         "BUILD_QT": { "type": "BOOL", "value": "ON" },
-        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" }
+        "BLA_VENDOR": { "type": "STRING", "value": "OpenBLAS" },
+        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
+          "type": "PATH",
+          "value": "${sourceDir}/build/${presetName}"
+        }
       },
       "vendor": {
         "jetbrains.com/clion": { "enablePythonIntegration": true },
@@ -62,14 +67,8 @@
       "inherits": "win-base",
       "displayName": "Windows Release (Ninja, MSVC)",
       "description": "Optimized _solvcon and pilot built with MSVC through Ninja.",
-      "binaryDir": "${sourceDir}/build/win-rel",
-      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/build/win-rel"
-        }
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
       }
     },
     {
@@ -77,14 +76,8 @@
       "inherits": "win-base",
       "displayName": "Windows Debug (Ninja, MSVC)",
       "description": "Debuggable _solvcon and pilot built with MSVC through Ninja.",
-      "binaryDir": "${sourceDir}/build/win-dbg",
-      "$comment": "CMAKE_RUNTIME_OUTPUT_DIRECTORY keeps pilot.exe at the top of the build tree, where build.ps1 and the documentation look for it.",
       "cacheVariables": {
-        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" },
-        "CMAKE_RUNTIME_OUTPUT_DIRECTORY": {
-          "type": "PATH",
-          "value": "${sourceDir}/build/win-dbg"
-        }
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
       }
     }
   ],
@@ -92,7 +85,7 @@
     {
       "name": "win-base",
       "hidden": true,
-      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts.",
+      "$comment": "A build preset does not inherit the condition of its configure preset, so the host filter is restated here to keep the Windows entries out of the listing and the preset pickers on other hosts. Each configure preset gets three build presets, one per thing a person builds: the module with the pilot, the module alone, and the C++ test binary. Parallelism is left unstated: Ninja already scales to the host, and the only place a cap is wanted is a CI runner.",
       "condition": {
         "type": "equals",
         "lhs": "${hostSystemName}",
@@ -109,14 +102,48 @@
       "inherits": "win-base",
       "configurePreset": "win-rel",
       "displayName": "Windows Release",
-      "description": "Build the Windows Release configuration."
+      "description": "Build the extension module and the pilot, Release.",
+      "targets": ["_solvcon", "pilot"]
+    },
+    {
+      "name": "win-rel-module",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, module only",
+      "description": "Build the extension module alone, Release.",
+      "targets": ["_solvcon"]
+    },
+    {
+      "name": "win-rel-gtest",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, C++ test binary",
+      "description": "Build the C++ gtest binary, Release.",
+      "targets": ["test_nopython"]
     },
     {
       "name": "win-dbg",
       "inherits": "win-base",
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug",
-      "description": "Build the Windows Debug configuration."
+      "description": "Build the extension module and the pilot, Debug.",
+      "targets": ["_solvcon", "pilot"]
+    },
+    {
+      "name": "win-dbg-module",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, module only",
+      "description": "Build the extension module alone, Debug.",
+      "targets": ["_solvcon"]
+    },
+    {
+      "name": "win-dbg-gtest",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, C++ test binary",
+      "description": "Build the C++ gtest binary, Debug.",
+      "targets": ["test_nopython"]
     }
   ]
 }

--- a/build.ps1
+++ b/build.ps1
@@ -113,7 +113,44 @@ if ($Preset) {
 } else {
     $presetName = if ($BuildType -eq 'Debug') { 'win-dbg' } else { 'win-rel' }
 }
-$bld = Join-Path $Repo "build\$presetName"
+
+function Get-ConfigurePresetBinaryDir {
+    # The binary directory a configure preset states, resolved through
+    # inherits.  Reading it beats recomputing "build\<preset>": the presets
+    # are free to name their build trees, and a user preset that inherits one
+    # of them gets its own.
+    param([string]$Root, [string]$Name)
+    $presets = @{}
+    foreach ($file in @('CMakePresets.json', 'CMakeUserPresets.json')) {
+        $path = Join-Path $Root $file
+        if (-not (Test-Path -LiteralPath $path)) { continue }
+        $doc = Get-Content -LiteralPath $path -Raw | ConvertFrom-Json
+        if (-not $doc.PSObject.Properties['configurePresets']) { continue }
+        foreach ($entry in $doc.configurePresets) { $presets[$entry.name] = $entry }
+    }
+    # Depth-first through inherits, nearest definition wins, as CMake resolves
+    # it.
+    function Find-BinaryDir {
+        param([string]$Name)
+        $entry = $presets[$Name]
+        if (-not $entry) { return $null }
+        if ($entry.PSObject.Properties['binaryDir']) { return $entry.binaryDir }
+        if ($entry.PSObject.Properties['inherits']) {
+            foreach ($parent in @($entry.inherits)) {
+                $found = Find-BinaryDir $parent
+                if ($found) { return $found }
+            }
+        }
+        return $null
+    }
+    $raw = Find-BinaryDir $Name
+    if (-not $raw) { throw "preset '$Name' states no binaryDir" }
+    $raw = $raw.Replace('${sourceDir}', $Root).Replace('${presetName}', $Name)
+    if ($raw -match '\$\{') { throw "unsupported macro in binaryDir '$raw'" }
+    return $raw.Replace('/', '\')
+}
+
+$bld = Get-ConfigurePresetBinaryDir $Repo $presetName
 $solvconDir = Join-Path $Repo 'solvcon'
 
 # --- MSVC environment -------------------------------------------------------
@@ -236,18 +273,27 @@ try {
     & $cmake --preset $presetName @extra
     Assert-LastExit 'cmake configure'
 
-    $targets = @('_solvcon')
-    if (-not $NoQt) { $targets += 'pilot' }
-    if ($Gtest) { $targets += 'test_nopython' }
-    Write-Host "building targets: $($targets -join ', ')"
-    & $cmake --build --preset $presetName --target @targets
-    Assert-LastExit 'cmake build'
+    # The build presets carry the target lists: <preset> builds the module and
+    # the pilot, <preset>-module the module alone, <preset>-gtest the C++ test
+    # binary.
+    $buildPresets = @()
+    if ($NoQt) {
+        $buildPresets += "$presetName-module"
+    } else {
+        $buildPresets += $presetName
+    }
+    if ($Gtest) { $buildPresets += "$presetName-gtest" }
+    foreach ($buildPreset in $buildPresets) {
+        Write-Host "building preset: $buildPreset"
+        & $cmake --build --preset $buildPreset
+        Assert-LastExit "cmake build --preset $buildPreset"
+    }
 } finally {
     Pop-Location
 }
 
 # _solvcon.pyd is a LIBRARY artifact (-> solvcon\, per the preset); pilot.exe is
-# a RUNTIME artifact (-> the preset's binary dir, build\$presetName).
+# a RUNTIME artifact (-> the binary directory the preset states, read above).
 # Copy the module to the repo root as the top-level _solvcon: solvcon.core
 # imports it there first, and the tests' qualified type names assume that name.
 $pyd = Get-ChildItem -LiteralPath $solvconDir -Filter '_solvcon*.pyd' |

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -9,8 +9,7 @@
       "inherits": "win-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
-      "binaryDir": "${sourceDir}/build/${presetName}",
-      "$comment": "Change inherits to the preset you build. binaryDir is restated so this preset gets its own build tree instead of sharing the inherited one. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "$comment": "Change inherits to the preset you build. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
@@ -24,8 +23,21 @@
   "buildPresets": [
     {
       "name": "local",
+      "inherits": "win-rel",
       "configurePreset": "local",
       "displayName": "Local dependency prefix"
+    },
+    {
+      "name": "local-module",
+      "inherits": "win-rel-module",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, module only"
+    },
+    {
+      "name": "local-gtest",
+      "inherits": "win-rel-gtest",
+      "configurePreset": "local",
+      "displayName": "Local dependency prefix, C++ test binary"
     }
   ]
 }

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -6,10 +6,10 @@
   "configurePresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
-      "$comment": "Change inherits to the preset you build. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "$comment": "Change inherits to the preset you build; a Windows build inherits win-rel and the win-rel-* build presets instead. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
@@ -23,19 +23,19 @@
   "buildPresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "configurePreset": "local",
       "displayName": "Local dependency prefix"
     },
     {
       "name": "local-module",
-      "inherits": "win-rel-module",
+      "inherits": "dev-rel-module",
       "configurePreset": "local",
       "displayName": "Local dependency prefix, module only"
     },
     {
       "name": "local-gtest",
-      "inherits": "win-rel-gtest",
+      "inherits": "dev-rel-gtest",
       "configurePreset": "local",
       "displayName": "Local dependency prefix, C++ test binary"
     }

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -19,6 +19,20 @@ A preset that names a toolchain the current host cannot run carries a
 the make targets described in {doc}`/start/build_solvcon` remain the primary
 entry point.
 
+Each configure preset comes with three build presets, one per thing that is
+actually built:
+
+| Build preset          | Targets                            |
+|:----------------------|:-----------------------------------|
+| `<preset>`            | the extension module and the pilot |
+| `<preset>-module`     | the extension module alone         |
+| `<preset>-gtest`      | the C++ gtest binary               |
+
+`cmake --build --preset <name>` therefore needs no `--target` argument.  The
+build tree is `build/<configure preset>`, named through the `${presetName}`
+macro so that a preset inheriting another gets its own tree rather than
+writing into its parent's.
+
 ## Machine paths belong in `CMakeUserPresets.json`
 
 Three cache variables name directories that exist on one machine only:
@@ -41,8 +55,9 @@ Copy the template and edit the paths:
 cp contrib/cmake/CMakeUserPresets.json.example CMakeUserPresets.json
 ```
 
-The template defines one configure preset and one build preset, both named
-`local`, that inherit a checked-in preset and add the three variables:
+The template defines a configure preset named `local` that inherits a
+checked-in preset and adds the three variables, plus the three build presets
+that go with it:
 
 ```json
 {

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -17,7 +17,15 @@ cmake --build --preset <name>
 A preset that names a toolchain the current host cannot run carries a
 `condition`, so it does not appear in the listing there.  On Linux and macOS
 the make targets described in {doc}`/start/build_solvcon` remain the primary
-entry point.
+entry point; the presets are what an IDE reads.
+
+| Configure preset | Host          | What it configures                    |
+|:-----------------|:--------------|:--------------------------------------|
+| `dev-rel`        | Linux, macOS  | optimized module and pilot            |
+| `dev-dbg`        | Linux, macOS  | debuggable module and pilot           |
+| `dev-noqt`       | Linux, macOS  | optimized module, no pilot            |
+| `win-rel`        | Windows       | optimized module and pilot, MSVC      |
+| `win-dbg`        | Windows       | debuggable module and pilot, MSVC     |
 
 Each configure preset comes with three build presets, one per thing that is
 actually built:
@@ -29,9 +37,25 @@ actually built:
 | `<preset>-gtest`      | the C++ gtest binary               |
 
 `cmake --build --preset <name>` therefore needs no `--target` argument.  The
-build tree is `build/<configure preset>`, named through the `${presetName}`
-macro so that a preset inheriting another gets its own tree rather than
-writing into its parent's.
+`dev-noqt` preset has no pilot to build, so it has only the plain and `-gtest`
+entries.
+
+The build tree is `build/<configure preset>`, named through the
+`${presetName}` macro so that a preset inheriting another gets its own tree
+rather than writing into its parent's.  It is one tree per preset, which is
+what both IDEs assume, and it is not the Makefile's `build/rel<pyvminor>`, so
+a preset build and a make build never share a cache.  They do share where the
+extension module lands, `solvcon/` and the repository root, so whichever built
+last is the one Python imports.
+
+One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
+`PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
+different interpreter reuses a stale cache.  Reconfigure with `--fresh` after
+switching interpreters:
+
+```bash
+cmake --preset dev-rel --fresh
+```
 
 ## Machine paths belong in `CMakeUserPresets.json`
 
@@ -65,7 +89,7 @@ that go with it:
   "configurePresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {


### PR DESCRIPTION
Step 5 of the CMake presets plan. Related to #120. Stacked on #126.

Until now the preset file described Windows and nothing else, so a Linux or macOS contributor opening the repository in an IDE got an empty preset picker. This adds `dev-rel`, `dev-dbg`, and `dev-noqt`, which inherit `base` and are filtered to the hosts that can run them.

| Configure preset | Host         | What it configures          |
|:-----------------|:-------------|:-----------------------------|
| `dev-rel`        | Linux, macOS | optimized module and pilot   |
| `dev-dbg`        | Linux, macOS | debuggable module and pilot  |
| `dev-noqt`       | Linux, macOS | optimized module, no pilot   |

Three decisions are worth stating.

The host filter is a `notEquals` against `Windows` rather than a list of two hosts. CLion supports only `equals` and `notEquals`, and would silently ignore an `inList` or `anyOf`, changing which presets a CLion user sees.

The generator is Ninja. It is already a documented dependency of the development environment, `contrib/dependency/build-scdv.sh` installs it on both hosts, and it is what makes an IDE build incremental.

The binary directory stays `${sourceDir}/build/${presetName}` rather than reproducing the Makefile's ABI-tagged `build/rel<pyvminor>`. One tree per preset is what both IDEs assume, and a preset cannot compute the ABI tag anyway. The consequence is that pointing a preset at a different interpreter reuses a stale cache, so the documentation says to reconfigure with `--fresh` after switching interpreters. That leaves the Makefile's interpreter arithmetic exactly where it is, still necessary, and the two never share a build tree.

The module target for these presets is `_solvcon_py`, not `_solvcon`: it copies the built extension to the repository root under its ABI-tagged name, which is where `solvcon.core` looks first and what a make build produces. On Windows there is no `python3-config`, so `build.ps1` keeps placing the module by hand.

## Verification

Everything below ran on Linux from this branch, in a worktree with no prior build tree.

- `cmake --preset dev-rel` configures from a bare command line with nothing added.
- `cmake --build --preset dev-rel` builds the module and the pilot, 136/136 targets, and places `_solvcon.cpython-314-x86_64-linux-gnu.so` at the repository root.
- `python3 -m pytest tests/` against that build: 1799 passed, 19 skipped, 3 xfailed, 511 subtests passed.
- `pilot --mode=pytest` from that build: 1799 passed, 19 skipped, 3 xfailed, 511 subtests passed.
- `cmake --preset dev-dbg` and `cmake --preset dev-noqt` configure; the `dev-noqt` configure log reports `BUILD_QT: OFF` with the rest of the `base` knobs unchanged, and its build produces a module that reports `HAS_PILOT False`.
- The cache of the preset tree was compared against a `make cmake` tree entry by entry, 874 against 872 entries. The only differences are the build-tree paths, the generator (`Ninja` against `Unix Makefiles`) and the variables that follow from it, `CMAKE_EXPORT_COMPILE_COMMANDS` which the preset states and the make tree leaves empty, `USE_GOOGLETEST` spelled `ON` against `True`, and `CMAKE_PREFIX_PATH`, which reaches the make build from the environment and belongs in a user preset. No knob differs.
- `cmake --list-presets` lists the three developer presets and no Windows preset on Linux; with the user-preset template copied in, `local` joins them.

The IDE pass in the plan is a manual check and is not covered here.
