### PR TITLE
Step 6: Register every test suite with CTest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+# Called at the top level so that CTest covers every suite, not only the C++
+# cases that gtests/ discovers.
+enable_testing()
+
 # The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
 # Debug build must match their runtime and configuration or it corrupts the heap
 # (issue #1058). Both default on; turn one off to link debug dependencies when
@@ -335,5 +339,7 @@ message(STATUS "USE_GOOGLETEST: ${USE_GOOGLETEST}")
 if(USE_GOOGLETEST)
 add_subdirectory(gtests)
 endif() # USE_GOOGLETEST
+
+add_subdirectory(tests)
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -35,6 +35,56 @@
       }
     },
     {
+      "name": "dev-base",
+      "hidden": true,
+      "inherits": "base",
+      "generator": "Ninja",
+      "$comment": "The developer presets for Linux and macOS. The host filter is a notEquals against Windows rather than a list, because CLion accepts only equals and notEquals and would silently ignore anything else. Ninja is already a documented dependency of the development environment (contrib/dependency/build-scdv.sh installs it), and it is what makes an IDE build incremental. These trees are separate from the ones the Makefile builds under build/rel<pyvminor>, so the two never fight over a cache.",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "cacheVariables": {
+        "BUILD_QT": { "type": "BOOL", "value": "ON" }
+      },
+      "vendor": {
+        "jetbrains.com/clion": { "enablePythonIntegration": true },
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Linux", "macOS"]
+        }
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "displayName": "Developer Release",
+      "description": "Optimized _solvcon and pilot for Linux and macOS.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
+      }
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "displayName": "Developer Debug",
+      "description": "Debuggable _solvcon and pilot for Linux and macOS.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
+      }
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "displayName": "Developer Release, no Qt",
+      "description": "Optimized _solvcon without the pilot, for a headless host.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "BUILD_QT": { "type": "BOOL", "value": "OFF" }
+      }
+    },
+    {
       "name": "win-base",
       "hidden": true,
       "inherits": "base",
@@ -82,6 +132,85 @@
     }
   ],
   "buildPresets": [
+    {
+      "name": "dev-base",
+      "hidden": true,
+      "$comment": "The module target is _solvcon_py, not _solvcon: it copies the built extension to the repository root under its ABI-tagged name, which is where solvcon.core looks for it first and what the make build produces.",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Linux", "macOS"]
+        }
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release",
+      "description": "Build the extension module and the pilot, Release.",
+      "targets": ["_solvcon_py", "pilot"]
+    },
+    {
+      "name": "dev-rel-module",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, module only",
+      "description": "Build the extension module alone, Release.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-rel-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, C++ test binary",
+      "description": "Build the C++ gtest binary, Release.",
+      "targets": ["test_nopython"]
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug",
+      "description": "Build the extension module and the pilot, Debug.",
+      "targets": ["_solvcon_py", "pilot"]
+    },
+    {
+      "name": "dev-dbg-module",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, module only",
+      "description": "Build the extension module alone, Debug.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-dbg-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, C++ test binary",
+      "description": "Build the C++ gtest binary, Debug.",
+      "targets": ["test_nopython"]
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt",
+      "description": "Build the extension module alone, without the pilot.",
+      "targets": ["_solvcon_py"]
+    },
+    {
+      "name": "dev-noqt-gtest",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt, C++ test binary",
+      "description": "Build the C++ gtest binary, without the pilot.",
+      "targets": ["test_nopython"]
+    },
     {
       "name": "win-base",
       "hidden": true,

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -274,5 +274,97 @@
       "description": "Build the C++ gtest binary, Debug.",
       "targets": ["test_nopython"]
     }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "$comment": "Test presets are read by the command line, by CI, and by VS Code, but not by CLion, where the suites are reached through the CTest integration against the configured build directory instead. That is what the add_test registrations in tests/CMakeLists.txt buy: ctest covers the C++ cases, the Python suite, and the pilot suite everywhere, with or without a preset.",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "dev-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "dev-rel-cpp",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, C++ suite",
+      "description": "Run the C++ cases alone.",
+      "filter": { "include": { "label": "cpp" } }
+    },
+    {
+      "name": "dev-rel-python",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, Python suite",
+      "description": "Run the Python suite alone.",
+      "filter": { "include": { "label": "python" } }
+    },
+    {
+      "name": "dev-rel-pilot",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, pilot suite",
+      "description": "Run the Python suite inside the pilot binary.",
+      "filter": { "include": { "label": "pilot" } }
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt",
+      "description": "Run the C++ and Python suites; there is no pilot suite."
+    },
+    {
+      "name": "win-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"]
+        }
+      }
+    },
+    {
+      "name": "win-rel",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,6 @@ WHICH_PYTHON := $(shell which python3)
 REALPATH_PYTHON := $(realpath $(WHICH_PYTHON))
 export DIRNAME_PYTHON := $(dir $(REALPATH_PYTHON))
 
-pyextsuffix := $(shell if [ -x "$(DIRNAME_PYTHON)/python3-config" ]; then \
-	$(DIRNAME_PYTHON)/python3-config --extension-suffix; fi)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
 ifeq ($(CMAKE_BUILD_TYPE), Debug)
@@ -312,14 +310,17 @@ pyformat:
 format: pyformat
 	@$(MAKE) FORCE_CLANG_FORMAT=inplace cformat
 
+# The extension suffix is computed by cpp/binary/pymod_solvcon/CMakeLists.txt,
+# so the removal goes through its target rather than recomputing the suffix.
+# A tree that was never configured has no target to call and nothing to remove.
 .PHONY: clean
 clean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	cmake --build $(BUILD_PATH) --target remove_solvcon_py
 	make -C $(BUILD_PATH) clean
 
 .PHONY: cmakeclean
 cmakeclean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	@if [ -f $(BUILD_PATH)/CMakeCache.txt ]; then \
+		cmake --build $(BUILD_PATH) --target remove_solvcon_py; \
+	fi
 	rm -rf $(BUILD_PATH)

--- a/contrib/cmake/CMakeUserPresets.json.example
+++ b/contrib/cmake/CMakeUserPresets.json.example
@@ -6,10 +6,10 @@
   "configurePresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "description": "A checked-in preset plus the paths of a local dependency prefix.",
-      "$comment": "Change inherits to the preset you build. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
+      "$comment": "Change inherits to the preset you build; a Windows build inherits win-rel and the win-rel-* build presets instead. Only presets whose condition holds on this host are offered, so a preset for another host cannot be inherited into a usable one. The build tree is named after the preset, so this one gets build/local rather than sharing its parent's. PYTHON_EXECUTABLE is the interpreter the extension is built against; pybind11_path is what python3 -m pybind11 --cmakedir prints for it; CMAKE_PREFIX_PATH is where Qt6, PySide6, and the rest of the prefix live. In CLion the jetbrains.com/clion vendor key enablePythonIntegration, already set in the checked-in presets, supplies PYTHON_EXECUTABLE from the IDE's selected interpreter, so that one line can be dropped.",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {
           "type": "FILEPATH",
@@ -23,19 +23,19 @@
   "buildPresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "configurePreset": "local",
       "displayName": "Local dependency prefix"
     },
     {
       "name": "local-module",
-      "inherits": "win-rel-module",
+      "inherits": "dev-rel-module",
       "configurePreset": "local",
       "displayName": "Local dependency prefix, module only"
     },
     {
       "name": "local-gtest",
-      "inherits": "win-rel-gtest",
+      "inherits": "dev-rel-gtest",
       "configurePreset": "local",
       "displayName": "Local dependency prefix, C++ test binary"
     }

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -52,11 +52,21 @@ cmake_print_variables(PYTHON_VENV_BIN)
 execute_process(
     COMMAND ${PYTHON_VENV_BIN}/python3-config --extension-suffix
     OUTPUT_VARIABLE PYEXTSUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 add_custom_target(_solvcon_py
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_solvcon> ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
     DEPENDS _solvcon)
+
+# Remove the built extension from the source tree. The suffix is already
+# computed here, so the make clean targets call this instead of shelling out
+# to python3-config a second time to recompute it.
+add_custom_target(remove_solvcon_py
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        ${SOLVCON_PY_DIR}/_solvcon${PYEXTSUFFIX}
+        ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
+    COMMENT "removing the built _solvcon extension")
 
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${SOLVCON_INCLUDE_DIR}/solvcon DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -48,6 +48,20 @@ a preset build and a make build never share a cache.  They do share where the
 extension module lands, `solvcon/` and the repository root, so whichever built
 last is the one Python imports.
 
+Test presets run the suites CTest has registered.  There is one per configure
+preset, plus label-filtered ones on `dev-rel`:
+
+```sh
+ctest --preset dev-rel            # every suite
+ctest --preset dev-rel-cpp        # the C++ cases alone
+ctest --preset dev-rel-python     # the Python suite alone
+ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+```
+
+CLion reads no test presets, so a CLion user reaches the same suites through
+its CTest integration against the configured build tree.  That works because
+the suites are registered with `add_test()`, not because a preset names them.
+
 One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
 `PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
 different interpreter reuses a stale cache.  Reconfigure with `--fresh` after

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -17,7 +17,15 @@ cmake --build --preset <name>
 A preset that names a toolchain the current host cannot run carries a
 `condition`, so it does not appear in the listing there.  On Linux and macOS
 the make targets described in {doc}`/start/build_solvcon` remain the primary
-entry point.
+entry point; the presets are what an IDE reads.
+
+| Configure preset | Host          | What it configures                    |
+|:-----------------|:--------------|:--------------------------------------|
+| `dev-rel`        | Linux, macOS  | optimized module and pilot            |
+| `dev-dbg`        | Linux, macOS  | debuggable module and pilot           |
+| `dev-noqt`       | Linux, macOS  | optimized module, no pilot            |
+| `win-rel`        | Windows       | optimized module and pilot, MSVC      |
+| `win-dbg`        | Windows       | debuggable module and pilot, MSVC     |
 
 Each configure preset comes with three build presets, one per thing that is
 actually built:
@@ -29,9 +37,25 @@ actually built:
 | `<preset>-gtest`      | the C++ gtest binary               |
 
 `cmake --build --preset <name>` therefore needs no `--target` argument.  The
-build tree is `build/<configure preset>`, named through the `${presetName}`
-macro so that a preset inheriting another gets its own tree rather than
-writing into its parent's.
+`dev-noqt` preset has no pilot to build, so it has only the plain and `-gtest`
+entries.
+
+The build tree is `build/<configure preset>`, named through the
+`${presetName}` macro so that a preset inheriting another gets its own tree
+rather than writing into its parent's.  It is one tree per preset, which is
+what both IDEs assume, and it is not the Makefile's `build/rel<pyvminor>`, so
+a preset build and a make build never share a cache.  They do share where the
+extension module lands, `solvcon/` and the repository root, so whichever built
+last is the one Python imports.
+
+One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
+`PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
+different interpreter reuses a stale cache.  Reconfigure with `--fresh` after
+switching interpreters:
+
+```bash
+cmake --preset dev-rel --fresh
+```
 
 ## Machine paths belong in `CMakeUserPresets.json`
 
@@ -65,7 +89,7 @@ that go with it:
   "configurePresets": [
     {
       "name": "local",
-      "inherits": "win-rel",
+      "inherits": "dev-rel",
       "displayName": "Local dependency prefix",
       "cacheVariables": {
         "PYTHON_EXECUTABLE": {

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -20,6 +20,31 @@ After `make gtest` has built the binary, a single C++ test can be run directly:
 
 where `<pyvminor>` is the active Python major and minor version, e.g. `314`.
 
+## Through CTest
+
+Every suite is also registered with CTest, so `ctest` runs the C++ cases, the
+Python suite, and the pilot suite from one command against a configured build
+tree.  This is what an IDE drives, and it is how the C++ cases become
+individually selectable.
+
+```sh
+ctest --preset dev-rel            # every suite
+ctest --preset dev-rel-cpp        # the C++ cases alone
+ctest --preset dev-rel-python     # the Python suite alone
+ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+```
+
+The presets are described in {doc}`/devguide/presets`.  Against a build tree
+that was configured without one, the same selection is `ctest -L cpp`,
+`ctest -L python`, or `ctest -L pilot` from inside the tree.
+
+The C++ cases are registered by `gtest_discover_tests`, which enumerates them
+by running the built binary, so `test_nopython` has to be built before `ctest`
+can see them.  The `<preset>-gtest` build preset builds it.
+
+`make pytest` and `make run_pilot_pytest` are unchanged and remain the way to
+forward `PYTEST_OPTS` to a subset.
+
 ## Automatic Testing on GitHub Actions
 
 Continuous integration runs on GitHub Actions. The workflows live in

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -15,8 +15,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
-
 if (APPLE)
     find_library(APPLE_FWK_ACCELERATE Accelerate REQUIRED)
 endif () # APPLE
@@ -62,7 +60,8 @@ target_link_libraries(
 )
 
 include(GoogleTest)
-gtest_discover_tests(test_nopython)
+# The label lets a test preset select the C++ cases alone.
+gtest_discover_tests(test_nopython PROPERTIES LABELS "cpp")
 
 add_custom_target(run_gtest
     COMMAND $<TARGET_FILE:test_nopython>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+# Register the Python suites with CTest so that ctest is the one test entry
+# point on every platform, alongside the C++ cases that gtest_discover_tests
+# registers. Each suite carries its own environment through a test property,
+# which is what a per-suite value needs: a configure preset's environment map
+# would have to give both suites the same answer.
+
+# SKIP_PYTHON_EXECUTABLE leaves PYTHON_EXECUTABLE unset, and the suite has no
+# interpreter to run under without it.
+if(PYTHON_EXECUTABLE)
+    add_test(
+        NAME pytest
+        COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set_tests_properties(pytest PROPERTIES
+        LABELS "python"
+        ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+    )
+else()
+    message(STATUS "PYTHON_EXECUTABLE is unset; not registering the pytest suite")
+endif()
+
+if(BUILD_QT)
+    # The pilot runs the same suite inside its own embedded interpreter. On
+    # Linux it needs the shiboken6 shared library on the loader path, which
+    # the workflow used to export by hand.
+    add_test(
+        NAME pilot_pytest
+        COMMAND $<TARGET_FILE:pilot> --mode=pytest
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set(SOLVCON_PILOT_TEST_ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}")
+    if(NOT "${SHIBOKEN6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+        list(APPEND SOLVCON_PILOT_TEST_ENVIRONMENT
+            "LD_LIBRARY_PATH=${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
+    endif()
+    set_tests_properties(pilot_pytest PROPERTIES
+        LABELS "pilot"
+        ENVIRONMENT "${SOLVCON_PILOT_TEST_ENVIRONMENT}"
+    )
+endif()
+
+# SOLVCON_TEST_SHOW_WINDOWS is deliberately absent from both properties.
+# tests/conftest.py keeps the GUI windows off the screen unless it is set, and
+# a test property would override whatever the caller chose. Leaving it to the
+# environment keeps the developer default off the screen and lets a runner,
+# which has no desktop to take over, export it for the run.
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 6 of the CMake presets plan. Related to #120. Stacked on #127.

`gtests/CMakeLists.txt` has been calling `gtest_discover_tests` all along, so the C++ suite was fully registered with CTest and nothing used it: every caller built the `run_gtest` custom target instead, which runs the binary directly and loses CTest's per-test reporting, filtering, and parallel execution. The Python suites were not registered at all.

This registers both Python suites with `add_test()` and moves `enable_testing()` to the top level, so it no longer depends on `USE_GOOGLETEST` being on. `ctest` is now the one test entry point on every host: the C++ cases, the Python suite, and the pilot suite.

Each suite carries its own environment through a test property, which is what a per-suite value needs, since a configure preset's `environment` map would have to give both suites the same answer. The pilot suite gets the shiboken6 directory on `LD_LIBRARY_PATH`, which `devbuild.yml` used to export by hand before calling `make run_pilot_pytest`.

`SOLVCON_TEST_SHOW_WINDOWS` is deliberately left out of both properties. A test property overrides rather than defaults, and the two callers want opposite answers: a developer wants the GUI windows off the screen, and a runner with no desktop to take over exports it to map them. Leaving it to the environment keeps both behaviours exactly as they are today.

Test presets select the suites by label. There is one per configure preset, plus `cpp`, `python`, and `pilot` filters on `dev-rel`. CLion reads no test presets, so a CLion user reaches the same suites through its CTest integration against the configured build tree; that works because of the `add_test()` registrations, which is the part of this step that benefits CLion.

Feature 10 rides along because it removes the same kind of duplication. `cpp/binary/pymod_solvcon/CMakeLists.txt` already computes the extension suffix, so it gains a `remove_solvcon_py` target, and `make clean` and `make cmakeclean` call it instead of shelling out to `python3-config` a second time to recompute the same suffix. The Makefile's `pyextsuffix` variable is gone with its last user. The `execute_process` that computes the suffix also gained `OUTPUT_STRIP_TRAILING_WHITESPACE`, which it should always have had.

`make pytest`, `make run_pilot_pytest`, and `make gtest` are untouched and keep working, including the `PYTEST_OPTS` forwarding that `ctest` cannot express.

## Verification

All on Linux, from a `dev-rel` preset tree.

- `ctest --preset dev-rel`: 238 tests, 100% passed, in 95 s. Label summary: `cpp` 236 tests, `python` 1, `pilot` 1.
- `ctest --preset dev-rel-cpp`: 236 tests passed.
- `ctest --preset dev-rel-python` and `ctest --preset dev-rel-pilot`: 1 test each, passed, 46 s each, matching the 1799 passed / 19 skipped / 3 xfailed / 511 subtests the two suites report when run by hand.
- `make clean` removes both copies of the built extension, exactly as before, now through the CMake target.
- `make cmakeclean` removes them and the tree, and run a second time against a tree that no longer exists it succeeds and does nothing, which is what the guard is for.
- `cmake --list-presets=test` lists the six presets visible on Linux.
