### PR TITLE
Step 7: Drive the Windows CI jobs from workflow presets

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -403,43 +403,26 @@ jobs:
           Get-Command flake8
           echo "::endgroup::"
 
-      - name: cmake ALL_BUILD
+      - name: cmake workflow
         run: |
-          echo "::group::cmake ALL_BUILD"
-          # Use the Ninja generator: CMAKE_<LANG>_COMPILER_LAUNCHER (the
-          # sccache hook) is honored only by Ninja/Makefile generators, not
-          # the Visual Studio (MSBuild) generator, which silently ignores it.
-          # No vcpkg toolchain: SOLVCON_USE_MKL makes solvcon link mkl_rt for
-          # both CBLAS and LAPACK, found via the CMAKE_*_PATH dirs above.
-          cmake -GNinja `
-            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
-            -DSOLVCON_USE_MKL=ON `
-            -DCMAKE_INCLUDE_PATH="$env:MKL_INCLUDE_DIR" `
-            -DCMAKE_LIBRARY_PATH="$env:MKL_LIBRARY_DIR" `
-            -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-            -S${{ github.workspace }} `
-            -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build
-          echo "::endgroup::"
-
-      - name: cmake run_gtest
-        run: |
-          echo "::group::cmake run_gtest"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_gtest
-          echo "::endgroup::"
-
-      - name: cmake run_pilot_pytest
-        run: |
-          echo "::group::cmake run_pilot_pytest"
+          echo "::group::cmake workflow"
+          # The ci-win-* presets in CMakePresets.json state the whole
+          # configure: the Ninja generator, the sccache launchers, the MKL
+          # paths located above, and the knobs every build shares. The
+          # workflow preset then chains configure, build, and the CTest run
+          # that covers the C++ cases and the pilot suite.
+          # The two values a runner owns reach the preset through the
+          # environment.
+          $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
           # A runner has no desktop to take over, so let this job map its
           # windows, the way it has always run them.
           $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_pilot_pytest
+          $preset = if ('${{ matrix.cmake_build_type }}' -eq 'Debug') {
+            'ci-win-dbg'
+          } else {
+            'ci-win-rel'
+          }
+          cmake --workflow --preset $preset
           echo "::endgroup::"
 
       - name: generate portable
@@ -483,14 +466,14 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the pilot. The build dir is already
-          # configured with the Ninja single-config generator above, so reuse
-          # it without --config and read pilot.exe from the non-config path.
-          cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --target pilot
+          # The workflow preset above already configured and built this tree
+          # with the Ninja single-config generator, so rebuild the pilot in
+          # place and read pilot.exe from the runtime output directory the
+          # preset names.
+          cmake --build --preset ci-win-rel --target pilot
 
           # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\pilot\pilot.exe" -Destination $destination
+          Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
           # Also include potential thirdparty
@@ -674,39 +657,19 @@ jobs:
         echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "::endgroup::"
 
-    - name: cmake ALL_BUILD USE_SANITIZER=ON
+    - name: cmake workflow USE_SANITIZER=ON
       run: |
-        echo "::group::cmake ALL_BUILD USE_SANITIZER=ON"
-        # Instrument both the gtest binary and the Qt pilot: BUILD_QT=ON and
-        # USE_GOOGLETEST=ON build both, USE_SANITIZER=ON adds /fsanitize=address.
+        echo "::group::cmake workflow USE_SANITIZER=ON"
+        # The ci-win-asan preset instruments both the gtest binary and the Qt
+        # pilot: BUILD_QT and USE_GOOGLETEST build both, USE_SANITIZER adds
+        # /fsanitize=address, and the vcpkg toolchain supplies BLAS and LAPACK.
         # The MSVC toolset bin dir that setup-msvc-dev puts on PATH also carries
         # the ASan runtime DLL the instrumented binaries load at start.
-        cmake -GNinja `
-          -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-          -DVCPKG_TARGET_TRIPLET="x64-windows" `
-          -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-          -DBUILD_QT=ON `
-          -DUSE_GOOGLETEST=ON `
-          -DUSE_SANITIZER=ON `
-          -S${{ github.workspace }} `
-          -B${{ github.workspace }}/build
-        cmake --build ${{ github.workspace }}/build
-        echo "::endgroup::"
-
-    - name: cmake run_gtest
-      run: |
-        echo "::group::cmake run_gtest"
-        cmake --build ${{ github.workspace }}/build --target run_gtest
-        echo "::endgroup::"
-
-    - name: cmake run_pilot_pytest
-      run: |
-        echo "::group::cmake run_pilot_pytest"
+        $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
         # A runner has no desktop to take over, so let this job map its
         # windows, the way it has always run them.
         $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-        cmake --build ${{ github.workspace }}/build --target run_pilot_pytest
+        cmake --workflow --preset ci-win-asan
         echo "::endgroup::"
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,10 @@ project(solvcon)
 
 cmake_policy(SET CMP0148 OLD)
 
+# Called at the top level so that CTest covers every suite, not only the C++
+# cases that gtests/ discovers.
+enable_testing()
+
 # The Python, Qt6, and PySide6 that MSVC links ship release binaries only, so a
 # Debug build must match their runtime and configuration or it corrupts the heap
 # (issue #1058). Both default on; turn one off to link debug dependencies when
@@ -335,5 +339,7 @@ message(STATUS "USE_GOOGLETEST: ${USE_GOOGLETEST}")
 if(USE_GOOGLETEST)
 add_subdirectory(gtests)
 endif() # USE_GOOGLETEST
+
+add_subdirectory(tests)
 
 # vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,6 +129,60 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
       }
+    },
+    {
+      "name": "ci-win-base",
+      "hidden": true,
+      "inherits": "win-base",
+      "$comment": "What the Windows CI jobs configure. A preset a workflow names on the command line cannot be hidden, so the leaves below appear in the IDE preset pickers; the ci- prefix and the descriptions are what tell a person to pick something else. The values a runner owns arrive through $env{}: the job exports them and the preset names them, which keeps a runner path out of the checked-in file while still letting CI stop spelling out a cmake command line.",
+      "cacheVariables": {
+        "pybind11_DIR": "$env{PYBIND11_DIR}"
+      }
+    },
+    {
+      "name": "ci-win-mkl",
+      "hidden": true,
+      "inherits": "ci-win-base",
+      "$comment": "SOLVCON_USE_MKL makes solvcon link mkl_rt for both CBLAS and LAPACK, found through the include and library paths the job locates in the Intel wheels. sccache is honoured by the Ninja generator only, which is why these presets do not use the Visual Studio generator. Embedded debug information keeps sccache able to cache the compile, since a separate PDB is not reproducible.",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
+        "SOLVCON_USE_MKL": { "type": "BOOL", "value": "ON" },
+        "CMAKE_INCLUDE_PATH": "$env{MKL_INCLUDE_DIR}",
+        "CMAKE_LIBRARY_PATH": "$env{MKL_LIBRARY_DIR}"
+      }
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "ci-win-mkl",
+      "displayName": "CI: Windows Release",
+      "description": "For the Windows CI job. A developer wants win-rel instead.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
+      }
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "ci-win-mkl",
+      "displayName": "CI: Windows Debug",
+      "description": "For the Windows CI job. A developer wants win-dbg instead.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
+      }
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "ci-win-base",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "For the Windows sanitizer CI job. A developer wants win-rel instead.",
+      "$comment": "The sanitizer job takes BLAS and LAPACK from vcpkg rather than the MKL wheels, and it does not use sccache: an instrumented compile is not worth caching against the uninstrumented one under the same key.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "USE_SANITIZER": { "type": "BOOL", "value": "ON" }
+      }
     }
   ],
   "buildPresets": [
@@ -273,6 +327,27 @@
       "displayName": "Windows Debug, C++ test binary",
       "description": "Build the C++ gtest binary, Debug.",
       "targets": ["test_nopython"]
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Build everything the Windows CI job builds."
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Build everything the Windows CI job builds."
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Build everything the Windows sanitizer CI job builds."
     }
   ],
   "testPresets": [
@@ -365,6 +440,66 @@
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug, every suite",
       "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "ci-win-base",
+      "hidden": true,
+      "inherits": "win-base",
+      "$comment": "The Windows CI jobs run the C++ cases and the pilot suite, which is the coverage they have always had; the plain Python suite runs on Linux and macOS. The label filter states that rather than leaving it implicit in which targets a job builds.",
+      "filter": { "include": { "label": "cpp|pilot" } }
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Run the C++ and pilot suites."
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Run the C++ and pilot suites."
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Run the C++ and pilot suites under AddressSanitizer."
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Configure, build, and test the Windows Release CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-rel" },
+        { "type": "build", "name": "ci-win-rel" },
+        { "type": "test", "name": "ci-win-rel" }
+      ]
+    },
+    {
+      "name": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Configure, build, and test the Windows Debug CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-dbg" },
+        { "type": "build", "name": "ci-win-dbg" },
+        { "type": "test", "name": "ci-win-dbg" }
+      ]
+    },
+    {
+      "name": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Configure, build, and test the Windows sanitizer CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-asan" },
+        { "type": "build", "name": "ci-win-asan" },
+        { "type": "test", "name": "ci-win-asan" }
+      ]
     }
   ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -274,5 +274,97 @@
       "description": "Build the C++ gtest binary, Debug.",
       "targets": ["test_nopython"]
     }
+  ],
+  "testPresets": [
+    {
+      "name": "base",
+      "hidden": true,
+      "$comment": "Test presets are read by the command line, by CI, and by VS Code, but not by CLion, where the suites are reached through the CTest integration against the configured build directory instead. That is what the add_test registrations in tests/CMakeLists.txt buy: ctest covers the C++ cases, the Python suite, and the pilot suite everywhere, with or without a preset.",
+      "output": { "outputOnFailure": true }
+    },
+    {
+      "name": "dev-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "notEquals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "dev-rel",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "dev-rel-cpp",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, C++ suite",
+      "description": "Run the C++ cases alone.",
+      "filter": { "include": { "label": "cpp" } }
+    },
+    {
+      "name": "dev-rel-python",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, Python suite",
+      "description": "Run the Python suite alone.",
+      "filter": { "include": { "label": "python" } }
+    },
+    {
+      "name": "dev-rel-pilot",
+      "inherits": "dev-base",
+      "configurePreset": "dev-rel",
+      "displayName": "Developer Release, pilot suite",
+      "description": "Run the Python suite inside the pilot binary.",
+      "filter": { "include": { "label": "pilot" } }
+    },
+    {
+      "name": "dev-dbg",
+      "inherits": "dev-base",
+      "configurePreset": "dev-dbg",
+      "displayName": "Developer Debug, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "dev-noqt",
+      "inherits": "dev-base",
+      "configurePreset": "dev-noqt",
+      "displayName": "Developer Release, no Qt",
+      "description": "Run the C++ and Python suites; there is no pilot suite."
+    },
+    {
+      "name": "win-base",
+      "hidden": true,
+      "inherits": "base",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "hostOS": ["Windows"]
+        }
+      }
+    },
+    {
+      "name": "win-rel",
+      "inherits": "win-base",
+      "configurePreset": "win-rel",
+      "displayName": "Windows Release, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "win-dbg",
+      "displayName": "Windows Debug, every suite",
+      "description": "Run the C++, Python, and pilot suites."
+    }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,6 @@ WHICH_PYTHON := $(shell which python3)
 REALPATH_PYTHON := $(realpath $(WHICH_PYTHON))
 export DIRNAME_PYTHON := $(dir $(REALPATH_PYTHON))
 
-pyextsuffix := $(shell if [ -x "$(DIRNAME_PYTHON)/python3-config" ]; then \
-	$(DIRNAME_PYTHON)/python3-config --extension-suffix; fi)
 pyvminor := $(shell python3 -c 'import sys; print("%d%d" % sys.version_info[0:2])')
 
 ifeq ($(CMAKE_BUILD_TYPE), Debug)
@@ -312,14 +310,17 @@ pyformat:
 format: pyformat
 	@$(MAKE) FORCE_CLANG_FORMAT=inplace cformat
 
+# The extension suffix is computed by cpp/binary/pymod_solvcon/CMakeLists.txt,
+# so the removal goes through its target rather than recomputing the suffix.
+# A tree that was never configured has no target to call and nothing to remove.
 .PHONY: clean
 clean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	cmake --build $(BUILD_PATH) --target remove_solvcon_py
 	make -C $(BUILD_PATH) clean
 
 .PHONY: cmakeclean
 cmakeclean:
-	rm -f $(SOLVCON_ROOT)/solvcon/_solvcon$(pyextsuffix)
-	rm -f $(SOLVCON_ROOT)/_solvcon$(pyextsuffix)
+	@if [ -f $(BUILD_PATH)/CMakeCache.txt ]; then \
+		cmake --build $(BUILD_PATH) --target remove_solvcon_py; \
+	fi
 	rm -rf $(BUILD_PATH)

--- a/cpp/binary/pymod_solvcon/CMakeLists.txt
+++ b/cpp/binary/pymod_solvcon/CMakeLists.txt
@@ -52,11 +52,21 @@ cmake_print_variables(PYTHON_VENV_BIN)
 execute_process(
     COMMAND ${PYTHON_VENV_BIN}/python3-config --extension-suffix
     OUTPUT_VARIABLE PYEXTSUFFIX
+    OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
 add_custom_target(_solvcon_py
     COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:_solvcon> ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
     DEPENDS _solvcon)
+
+# Remove the built extension from the source tree. The suffix is already
+# computed here, so the make clean targets call this instead of shelling out
+# to python3-config a second time to recompute it.
+add_custom_target(remove_solvcon_py
+    COMMAND ${CMAKE_COMMAND} -E rm -f
+        ${SOLVCON_PY_DIR}/_solvcon${PYEXTSUFFIX}
+        ${SOLVCON_PY_DIR}/../_solvcon${PYEXTSUFFIX}
+    COMMENT "removing the built _solvcon extension")
 
 message(STATUS "CMAKE_INSTALL_INCLUDEDIR: ${CMAKE_INSTALL_INCLUDEDIR}")
 install(DIRECTORY ${SOLVCON_INCLUDE_DIR}/solvcon DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -48,6 +48,20 @@ a preset build and a make build never share a cache.  They do share where the
 extension module lands, `solvcon/` and the repository root, so whichever built
 last is the one Python imports.
 
+Test presets run the suites CTest has registered.  There is one per configure
+preset, plus label-filtered ones on `dev-rel`:
+
+```sh
+ctest --preset dev-rel            # every suite
+ctest --preset dev-rel-cpp        # the C++ cases alone
+ctest --preset dev-rel-python     # the Python suite alone
+ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+```
+
+CLion reads no test presets, so a CLion user reaches the same suites through
+its CTest integration against the configured build tree.  That works because
+the suites are registered with `add_test()`, not because a preset names them.
+
 One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
 `PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
 different interpreter reuses a stale cache.  Reconfigure with `--fresh` after

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -62,6 +62,20 @@ CLion reads no test presets, so a CLion user reaches the same suites through
 its CTest integration against the configured build tree.  That works because
 the suites are registered with `add_test()`, not because a preset names them.
 
+Workflow presets chain configure, build, and test into one command:
+
+```bash
+cmake --workflow --preset ci-win-rel
+```
+
+They exist for CI.  The `ci-` presets are what the Windows jobs name instead
+of spelling out a `cmake` command line, and the two values a runner owns, the
+pybind11 package directory and the MKL paths, reach them through `$env{}`
+rather than being written into the file.  A preset that a command line names
+cannot be `hidden`, so the `ci-` presets do appear in the preset pickers; the
+prefix and their descriptions are what say to pick something else.  CLion does
+not show workflow presets at all.
+
 One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
 `PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
 different interpreter reuses a stale cache.  Reconfigure with `--fresh` after

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -60,7 +60,9 @@ The fast set runs on every pull request and `master` push:
 - `standalone_buffer`: the standalone buffer build on ubuntu.
 - `build`: `make gtest` plus `make pytest` with Qt off and on, and the pilot,
   on ubuntu and macOS (Release).
-- `build_windows` (Release): the Windows build and tests.
+- `build_windows` (Release): the Windows build and tests, driven by the
+  `ci-win-rel` workflow preset, which chains configure, build, and the CTest
+  run over the C++ cases and the pilot suite.
 
 The heavy set runs on the nightly schedule only:
 

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -20,6 +20,31 @@ After `make gtest` has built the binary, a single C++ test can be run directly:
 
 where `<pyvminor>` is the active Python major and minor version, e.g. `314`.
 
+## Through CTest
+
+Every suite is also registered with CTest, so `ctest` runs the C++ cases, the
+Python suite, and the pilot suite from one command against a configured build
+tree.  This is what an IDE drives, and it is how the C++ cases become
+individually selectable.
+
+```sh
+ctest --preset dev-rel            # every suite
+ctest --preset dev-rel-cpp        # the C++ cases alone
+ctest --preset dev-rel-python     # the Python suite alone
+ctest --preset dev-rel-pilot      # the Python suite inside the pilot binary
+```
+
+The presets are described in {doc}`/devguide/presets`.  Against a build tree
+that was configured without one, the same selection is `ctest -L cpp`,
+`ctest -L python`, or `ctest -L pilot` from inside the tree.
+
+The C++ cases are registered by `gtest_discover_tests`, which enumerates them
+by running the built binary, so `test_nopython` has to be built before `ctest`
+can see them.  The `<preset>-gtest` build preset builds it.
+
+`make pytest` and `make run_pilot_pytest` are unchanged and remain the way to
+forward `PYTEST_OPTS` to a subset.
+
 ## Automatic Testing on GitHub Actions
 
 Continuous integration runs on GitHub Actions. The workflows live in

--- a/gtests/CMakeLists.txt
+++ b/gtests/CMakeLists.txt
@@ -15,8 +15,6 @@ FetchContent_Declare(
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(googletest)
 
-enable_testing()
-
 if (APPLE)
     find_library(APPLE_FWK_ACCELERATE Accelerate REQUIRED)
 endif () # APPLE
@@ -62,7 +60,8 @@ target_link_libraries(
 )
 
 include(GoogleTest)
-gtest_discover_tests(test_nopython)
+# The label lets a test preset select the C++ cases alone.
+gtest_discover_tests(test_nopython PROPERTIES LABELS "cpp")
 
 add_custom_target(run_gtest
     COMMAND $<TARGET_FILE:test_nopython>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,54 @@
+# Copyright (c) 2026, solvcon team <contact@solvcon.net>
+# BSD 3-Clause License, see COPYING
+
+cmake_minimum_required(VERSION 4.0.1)
+
+# Register the Python suites with CTest so that ctest is the one test entry
+# point on every platform, alongside the C++ cases that gtest_discover_tests
+# registers. Each suite carries its own environment through a test property,
+# which is what a per-suite value needs: a configure preset's environment map
+# would have to give both suites the same answer.
+
+# SKIP_PYTHON_EXECUTABLE leaves PYTHON_EXECUTABLE unset, and the suite has no
+# interpreter to run under without it.
+if(PYTHON_EXECUTABLE)
+    add_test(
+        NAME pytest
+        COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tests
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set_tests_properties(pytest PROPERTIES
+        LABELS "python"
+        ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}"
+    )
+else()
+    message(STATUS "PYTHON_EXECUTABLE is unset; not registering the pytest suite")
+endif()
+
+if(BUILD_QT)
+    # The pilot runs the same suite inside its own embedded interpreter. On
+    # Linux it needs the shiboken6 shared library on the loader path, which
+    # the workflow used to export by hand.
+    add_test(
+        NAME pilot_pytest
+        COMMAND $<TARGET_FILE:pilot> --mode=pytest
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    )
+    set(SOLVCON_PILOT_TEST_ENVIRONMENT "PYTHONPATH=${PROJECT_SOURCE_DIR}")
+    if(NOT "${SHIBOKEN6_PYTHON_PACKAGE_PATH}" STREQUAL "")
+        list(APPEND SOLVCON_PILOT_TEST_ENVIRONMENT
+            "LD_LIBRARY_PATH=${SHIBOKEN6_PYTHON_PACKAGE_PATH}")
+    endif()
+    set_tests_properties(pilot_pytest PROPERTIES
+        LABELS "pilot"
+        ENVIRONMENT "${SOLVCON_PILOT_TEST_ENVIRONMENT}"
+    )
+endif()
+
+# SOLVCON_TEST_SHOW_WINDOWS is deliberately absent from both properties.
+# tests/conftest.py keeps the GUI windows off the screen unless it is set, and
+# a test property would override whatever the caller chose. Leaving it to the
+# environment keeps the developer default off the screen and lets a runner,
+# which has no desktop to take over, export it for the run.
+
+# vim: set ff=unix fenc=utf8 nobomb et sw=4 ts=4 sts=4:


### PR DESCRIPTION
Step 7 of the CMake presets plan. Related to #120. Stacked on #128.

`devbuild.yml` spelled out its own `cmake -GNinja -D...` block twice, once for the Windows build job and once for the Windows sanitizer job, and neither drove the Makefile or the presets. Nothing kept those blocks in agreement with the preset file, and they had already drifted: the preset held `USE_GOOGLETEST` off while both jobs turned it on, and `BLA_VENDOR: OpenBLAS` while both built against MKL or vcpkg.

This adds `ci-win-rel`, `ci-win-dbg`, and `ci-win-asan`, which inherit the Windows presets and add exactly what a runner needs, plus workflow presets chaining configure, build, and the CTest run. Each job now names one preset instead of restating a command line.

The values a runner owns stay out of the checked-in file. The pybind11 package directory and the MKL include and library paths reach the presets through `$env{}`, which the jobs export. The sccache launchers and the vcpkg toolchain are properties of the job rather than of a machine, so they are stated in the `ci-` presets themselves.

The test stage filters on the `cpp` and `pilot` labels, which is the coverage these jobs have always had; the plain Python suite runs on Linux and macOS. Where the jobs used to build the `run_gtest` and `run_pilot_pytest` targets, they now run `ctest`, so the C++ cases report individually rather than as one target invocation.

The dependency on #128 is not optional: a workflow preset's third stage is a test preset, and there was nothing for it to run until the suites were registered.

## What changes for the jobs

- The build tree moves from `build/` to `build/ci-win-<type>`, and `pilot.exe` now lands in the runtime output directory the preset names. The nightly portable-artifact step reads it from there and reuses the tree the workflow already configured instead of reconfiguring.
- `_solvcon.pyd` now lands in `solvcon/` rather than deep in the build tree, since the `ci-` presets inherit `CMAKE_LIBRARY_OUTPUT_DIRECTORY` from `base`. The pilot suite does not need it placed (the pilot binary carries `_solvcon` in its own inittab), and the portable artifact, which copies `solvcon/` wholesale, gains it.
- The base knobs come along: `HIDE_SYMBOL` and `LINT_AS_ERRORS` are inert here, the first because MSVC ignores visibility attributes and the second because `USE_CLANG_TIDY` is off, and `DEBUG_SYMBOL` was already at its default.

## Verification

- The workflow YAML parses, and both jobs' step lists are as intended.
- The resolved cache variables of all three `ci-` presets were printed through their inheritance chains and compared against the `-D` flags the two jobs pass today. Every flag is accounted for, plus the shared `base` knobs listed above.
- `cmake --list-presets` on Linux is unchanged and still lists only the three developer presets. With the host condition inverted, the three `ci-` configure presets, their build presets, and their test presets all resolve.

The real check is a CI run on this pull request, which exercises `build_windows` (Release). Two things it cannot cover:

- `build_windows` Debug and the nightly portable-artifact step, which run on the schedule only.
- `sanitizer_windows`, which is nightly-only and gated behind `MMGH_FORCE_SANITIZER`; that variable is not set on this repository, so its cut-over is reviewed rather than executed.
