### PR TITLE
Step 8: Make the Makefile a preset driver

### DIFF
--- a/.github/workflows/devbuild.yml
+++ b/.github/workflows/devbuild.yml
@@ -403,43 +403,26 @@ jobs:
           Get-Command flake8
           echo "::endgroup::"
 
-      - name: cmake ALL_BUILD
+      - name: cmake workflow
         run: |
-          echo "::group::cmake ALL_BUILD"
-          # Use the Ninja generator: CMAKE_<LANG>_COMPILER_LAUNCHER (the
-          # sccache hook) is honored only by Ninja/Makefile generators, not
-          # the Visual Studio (MSBuild) generator, which silently ignores it.
-          # No vcpkg toolchain: SOLVCON_USE_MKL makes solvcon link mkl_rt for
-          # both CBLAS and LAPACK, found via the CMAKE_*_PATH dirs above.
-          cmake -GNinja `
-            -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-            -DCMAKE_C_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_CXX_COMPILER_LAUNCHER=sccache `
-            -DCMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
-            -DSOLVCON_USE_MKL=ON `
-            -DCMAKE_INCLUDE_PATH="$env:MKL_INCLUDE_DIR" `
-            -DCMAKE_LIBRARY_PATH="$env:MKL_LIBRARY_DIR" `
-            -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-            -S${{ github.workspace }} `
-            -B${{ github.workspace }}/build
-          cmake --build ${{ github.workspace }}/build
-          echo "::endgroup::"
-
-      - name: cmake run_gtest
-        run: |
-          echo "::group::cmake run_gtest"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_gtest
-          echo "::endgroup::"
-
-      - name: cmake run_pilot_pytest
-        run: |
-          echo "::group::cmake run_pilot_pytest"
+          echo "::group::cmake workflow"
+          # The ci-win-* presets in CMakePresets.json state the whole
+          # configure: the Ninja generator, the sccache launchers, the MKL
+          # paths located above, and the knobs every build shares. The
+          # workflow preset then chains configure, build, and the CTest run
+          # that covers the C++ cases and the pilot suite.
+          # The two values a runner owns reach the preset through the
+          # environment.
+          $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
           # A runner has no desktop to take over, so let this job map its
           # windows, the way it has always run them.
           $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-          cmake --build ${{ github.workspace }}/build `
-            --target run_pilot_pytest
+          $preset = if ('${{ matrix.cmake_build_type }}' -eq 'Debug') {
+            'ci-win-dbg'
+          } else {
+            'ci-win-rel'
+          }
+          cmake --workflow --preset $preset
           echo "::endgroup::"
 
       - name: generate portable
@@ -483,14 +466,14 @@ jobs:
           # Remove redundant Qt DLLs from PySide6
           Remove-Item -Path $pyside6_path\Qt*.dll
 
-          # Configure and build the pilot. The build dir is already
-          # configured with the Ninja single-config generator above, so reuse
-          # it without --config and read pilot.exe from the non-config path.
-          cmake -Dpybind11_DIR="$(pybind11-config --cmakedir)" -S . -B build
-          cmake --build build --target pilot
+          # The workflow preset above already configured and built this tree
+          # with the Ninja single-config generator, so rebuild the pilot in
+          # place and read pilot.exe from the runtime output directory the
+          # preset names.
+          cmake --build --preset ci-win-rel --target pilot
 
           # Deploy the Qt environment for the pilot executable and copy necessary files
-          Copy-Item -Path ".\build\cpp\binary\pilot\pilot.exe" -Destination $destination
+          Copy-Item -Path ".\build\ci-win-rel\pilot.exe" -Destination $destination
           windeployqt --release "$destination\pilot.exe"
           Copy-Item -Path ".\solvcon" -Destination $destination -Recurse
           # Also include potential thirdparty
@@ -674,39 +657,19 @@ jobs:
         echo "$pyside6_path;$shiboken6_path" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
         echo "::endgroup::"
 
-    - name: cmake ALL_BUILD USE_SANITIZER=ON
+    - name: cmake workflow USE_SANITIZER=ON
       run: |
-        echo "::group::cmake ALL_BUILD USE_SANITIZER=ON"
-        # Instrument both the gtest binary and the Qt pilot: BUILD_QT=ON and
-        # USE_GOOGLETEST=ON build both, USE_SANITIZER=ON adds /fsanitize=address.
+        echo "::group::cmake workflow USE_SANITIZER=ON"
+        # The ci-win-asan preset instruments both the gtest binary and the Qt
+        # pilot: BUILD_QT and USE_GOOGLETEST build both, USE_SANITIZER adds
+        # /fsanitize=address, and the vcpkg toolchain supplies BLAS and LAPACK.
         # The MSVC toolset bin dir that setup-msvc-dev puts on PATH also carries
         # the ASan runtime DLL the instrumented binaries load at start.
-        cmake -GNinja `
-          -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} `
-          -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" `
-          -DVCPKG_TARGET_TRIPLET="x64-windows" `
-          -Dpybind11_DIR="$(pybind11-config --cmakedir)" `
-          -DBUILD_QT=ON `
-          -DUSE_GOOGLETEST=ON `
-          -DUSE_SANITIZER=ON `
-          -S${{ github.workspace }} `
-          -B${{ github.workspace }}/build
-        cmake --build ${{ github.workspace }}/build
-        echo "::endgroup::"
-
-    - name: cmake run_gtest
-      run: |
-        echo "::group::cmake run_gtest"
-        cmake --build ${{ github.workspace }}/build --target run_gtest
-        echo "::endgroup::"
-
-    - name: cmake run_pilot_pytest
-      run: |
-        echo "::group::cmake run_pilot_pytest"
+        $env:PYBIND11_DIR = "$(pybind11-config --cmakedir)"
         # A runner has no desktop to take over, so let this job map its
         # windows, the way it has always run them.
         $env:SOLVCON_TEST_SHOW_WINDOWS = "ON"
-        cmake --build ${{ github.workspace }}/build --target run_pilot_pytest
+        cmake --workflow --preset ci-win-asan
         echo "::endgroup::"
 
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -129,6 +129,60 @@
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
       }
+    },
+    {
+      "name": "ci-win-base",
+      "hidden": true,
+      "inherits": "win-base",
+      "$comment": "What the Windows CI jobs configure. A preset a workflow names on the command line cannot be hidden, so the leaves below appear in the IDE preset pickers; the ci- prefix and the descriptions are what tell a person to pick something else. The values a runner owns arrive through $env{}: the job exports them and the preset names them, which keeps a runner path out of the checked-in file while still letting CI stop spelling out a cmake command line.",
+      "cacheVariables": {
+        "pybind11_DIR": "$env{PYBIND11_DIR}"
+      }
+    },
+    {
+      "name": "ci-win-mkl",
+      "hidden": true,
+      "inherits": "ci-win-base",
+      "$comment": "SOLVCON_USE_MKL makes solvcon link mkl_rt for both CBLAS and LAPACK, found through the include and library paths the job locates in the Intel wheels. sccache is honoured by the Ninja generator only, which is why these presets do not use the Visual Studio generator. Embedded debug information keeps sccache able to cache the compile, since a separate PDB is not reproducible.",
+      "cacheVariables": {
+        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
+        "CMAKE_MSVC_DEBUG_INFORMATION_FORMAT": "Embedded",
+        "SOLVCON_USE_MKL": { "type": "BOOL", "value": "ON" },
+        "CMAKE_INCLUDE_PATH": "$env{MKL_INCLUDE_DIR}",
+        "CMAKE_LIBRARY_PATH": "$env{MKL_LIBRARY_DIR}"
+      }
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "ci-win-mkl",
+      "displayName": "CI: Windows Release",
+      "description": "For the Windows CI job. A developer wants win-rel instead.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" }
+      }
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "ci-win-mkl",
+      "displayName": "CI: Windows Debug",
+      "description": "For the Windows CI job. A developer wants win-dbg instead.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Debug" }
+      }
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "ci-win-base",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "For the Windows sanitizer CI job. A developer wants win-rel instead.",
+      "$comment": "The sanitizer job takes BLAS and LAPACK from vcpkg rather than the MKL wheels, and it does not use sccache: an instrumented compile is not worth caching against the uninstrumented one under the same key.",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": { "type": "STRING", "value": "Release" },
+        "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
+        "VCPKG_TARGET_TRIPLET": "x64-windows",
+        "USE_SANITIZER": { "type": "BOOL", "value": "ON" }
+      }
     }
   ],
   "buildPresets": [
@@ -273,6 +327,27 @@
       "displayName": "Windows Debug, C++ test binary",
       "description": "Build the C++ gtest binary, Debug.",
       "targets": ["test_nopython"]
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Build everything the Windows CI job builds."
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Build everything the Windows CI job builds."
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "win-base",
+      "configurePreset": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Build everything the Windows sanitizer CI job builds."
     }
   ],
   "testPresets": [
@@ -365,6 +440,66 @@
       "configurePreset": "win-dbg",
       "displayName": "Windows Debug, every suite",
       "description": "Run the C++, Python, and pilot suites."
+    },
+    {
+      "name": "ci-win-base",
+      "hidden": true,
+      "inherits": "win-base",
+      "$comment": "The Windows CI jobs run the C++ cases and the pilot suite, which is the coverage they have always had; the plain Python suite runs on Linux and macOS. The label filter states that rather than leaving it implicit in which targets a job builds.",
+      "filter": { "include": { "label": "cpp|pilot" } }
+    },
+    {
+      "name": "ci-win-rel",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Run the C++ and pilot suites."
+    },
+    {
+      "name": "ci-win-dbg",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Run the C++ and pilot suites."
+    },
+    {
+      "name": "ci-win-asan",
+      "inherits": "ci-win-base",
+      "configurePreset": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Run the C++ and pilot suites under AddressSanitizer."
+    }
+  ],
+  "workflowPresets": [
+    {
+      "name": "ci-win-rel",
+      "displayName": "CI: Windows Release",
+      "description": "Configure, build, and test the Windows Release CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-rel" },
+        { "type": "build", "name": "ci-win-rel" },
+        { "type": "test", "name": "ci-win-rel" }
+      ]
+    },
+    {
+      "name": "ci-win-dbg",
+      "displayName": "CI: Windows Debug",
+      "description": "Configure, build, and test the Windows Debug CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-dbg" },
+        { "type": "build", "name": "ci-win-dbg" },
+        { "type": "test", "name": "ci-win-dbg" }
+      ]
+    },
+    {
+      "name": "ci-win-asan",
+      "displayName": "CI: Windows AddressSanitizer",
+      "description": "Configure, build, and test the Windows sanitizer CI job.",
+      "steps": [
+        { "type": "configure", "name": "ci-win-asan" },
+        { "type": "build", "name": "ci-win-asan" },
+        { "type": "test", "name": "ci-win-asan" }
+      ]
     }
   ]
 }

--- a/Makefile
+++ b/Makefile
@@ -22,25 +22,37 @@ BUILD_PATH_EXT ?=
 # Additional configuration can be loaded from SETUP_FILE.
 RUNENV += PYTHONPATH=$(SOLVCON_ROOT)
 
-SKIP_PYTHON_EXECUTABLE ?= OFF
-HIDE_SYMBOL ?= ON
-DEBUG_SYMBOL ?= ON
-SOLVCON_PROFILE ?= OFF
-BUILD_METAL ?= OFF
-BUILD_QT ?= ON
-USE_CLANG_TIDY ?= OFF
+# The configure knobs are written down once, in CMakePresets.json; see
+# doc/source/devguide/presets.md. A knob set on the command line, in the
+# environment, or in setup.mk is layered on the selected preset as a -D flag,
+# and nothing else is passed, so a make build and a preset build stay the same
+# build. Setting a knob to its preset value therefore costs nothing.
+CMAKE_KNOBS = SKIP_PYTHON_EXECUTABLE HIDE_SYMBOL DEBUG_SYMBOL SOLVCON_PROFILE \
+	BUILD_METAL BUILD_QT USE_CLANG_TIDY LINT_AS_ERRORS USE_GOOGLETEST \
+	USE_SANITIZER CMAKE_INSTALL_PREFIX CMAKE_LIBRARY_OUTPUT_DIRECTORY \
+	CMAKE_PREFIX_PATH
+CMAKE_OVERRIDES = $(strip $(foreach knob,$(CMAKE_KNOBS), \
+	$(if $(filter-out undefined default,$(origin $(knob))),\
+	-D$(knob)=$($(knob)))))
+
 CMAKE_BUILD_TYPE ?= Release
+# The build type picks the preset, so it needs no -D of its own. Override
+# CMAKE_PRESET to build another one, for instance a preset of your own from
+# CMakeUserPresets.json.
+ifeq ($(CMAKE_BUILD_TYPE), Debug)
+	CMAKE_PRESET ?= dev-dbg
+else
+	CMAKE_PRESET ?= dev-rel
+endif
 # Number of online processors. Drives both build parallelism (MAKE_PARALLEL
 # below) and the lint targets. getconf works on both Linux and macOS; fall
 # back to 1 if unavailable. Override to cap parallelism, e.g. NPROC=2.
 NPROC ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || echo 1)
 MAKE_PARALLEL ?= -j $(NPROC)
 SOLVCON_ROOT ?= $(shell pwd)
-CMAKE_INSTALL_PREFIX ?= $(SOLVCON_ROOT)/build/fakeinstall
-CMAKE_LIBRARY_OUTPUT_DIRECTORY ?= $(SOLVCON_ROOT)/solvcon
-# Use CMAKE_PREFIX_PATH to make it easier to build with Qt, e.g.,
-# CMAKE_PREFIX_PATH=/path/to/qt/6.2.3/macos
-CMAKE_PREFIX_PATH ?=
+# Set CMAKE_PREFIX_PATH to make it easier to build with Qt, e.g.,
+# CMAKE_PREFIX_PATH=/path/to/qt/6.2.3/macos. It is one of the knobs above, so
+# it reaches CMake only when it is set.
 CMAKE_ARGS ?=
 VERBOSE ?=
 FORCE_CLANG_FORMAT ?=
@@ -96,30 +108,16 @@ cmake: $(BUILD_PATH)/Makefile
 .PHONY: xcode
 xcode: $(BUILD_PATH)_xcode/Makefile
 
-CMAKE_CMD = cmake $(SOLVCON_ROOT) \
-	-DCMAKE_PREFIX_PATH=$(CMAKE_PREFIX_PATH) \
-	-DCMAKE_INSTALL_PREFIX=$(CMAKE_INSTALL_PREFIX) \
-	-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$(CMAKE_LIBRARY_OUTPUT_DIRECTORY) \
-	-DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
-	-DSKIP_PYTHON_EXECUTABLE=$(SKIP_PYTHON_EXECUTABLE) \
-	-DHIDE_SYMBOL=$(HIDE_SYMBOL) \
-	-DDEBUG_SYMBOL=$(DEBUG_SYMBOL) \
-	-DBUILD_METAL=$(BUILD_METAL) \
-	-DBUILD_QT=$(BUILD_QT) \
-	-DUSE_CLANG_TIDY=$(USE_CLANG_TIDY) \
-	-DLINT_AS_ERRORS=ON \
-	-DSOLVCON_PROFILE=$(SOLVCON_PROFILE) \
-	$(CMAKE_ARGS)
+# The preset carries the configure; -B and -G layer on top of it. The build
+# tree keeps its ABI tag, which a preset cannot compute, and the generator
+# stays the one the clean target and the workflows expect from a make build.
+CMAKE_CMD = cmake --preset $(CMAKE_PRESET) $(CMAKE_OVERRIDES) $(CMAKE_ARGS)
 
-$(BUILD_PATH)/Makefile: CMakeLists.txt Makefile
-	mkdir -p $(BUILD_PATH) ; \
-	cd $(BUILD_PATH) ; \
-	env $(RUNENV) $(CMAKE_CMD)
+$(BUILD_PATH)/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH) -G "Unix Makefiles"
 
-$(BUILD_PATH)_xcode/Makefile: CMakeLists.txt Makefile
-	mkdir -p $(BUILD_PATH)_xcode ; \
-	cd $(BUILD_PATH)_xcode ; \
-	env $(RUNENV) $(CMAKE_CMD) -G Xcode
+$(BUILD_PATH)_xcode/Makefile: CMakeLists.txt CMakePresets.json Makefile
+	env $(RUNENV) $(CMAKE_CMD) -B $(BUILD_PATH)_xcode -G Xcode
 
 .PHONY: buildext
 buildext: cmake

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -62,6 +62,20 @@ CLion reads no test presets, so a CLion user reaches the same suites through
 its CTest integration against the configured build tree.  That works because
 the suites are registered with `add_test()`, not because a preset names them.
 
+Workflow presets chain configure, build, and test into one command:
+
+```bash
+cmake --workflow --preset ci-win-rel
+```
+
+They exist for CI.  The `ci-` presets are what the Windows jobs name instead
+of spelling out a `cmake` command line, and the two values a runner owns, the
+pybind11 package directory and the MKL paths, reach them through `$env{}`
+rather than being written into the file.  A preset that a command line names
+cannot be `hidden`, so the `ci-` presets do appear in the preset pickers; the
+prefix and their descriptions are what say to pick something else.  CLion does
+not show workflow presets at all.
+
 One consequence is worth knowing.  `_solvcon` is an ABI-tagged extension and
 `PYTHON_EXECUTABLE` is a cache variable, so pointing the same preset at a
 different interpreter reuses a stale cache.  Reconfigure with `--fresh` after

--- a/doc/source/devguide/presets.md
+++ b/doc/source/devguide/presets.md
@@ -16,8 +16,10 @@ cmake --build --preset <name>
 
 A preset that names a toolchain the current host cannot run carries a
 `condition`, so it does not appear in the listing there.  On Linux and macOS
-the make targets described in {doc}`/start/build_solvcon` remain the primary
-entry point; the presets are what an IDE reads.
+the make targets described in {doc}`/start/build_solvcon` remain the entry
+point every contributor uses, and they configure through these presets: the
+Makefile adds the ABI-tagged build directory, the generator, and whatever
+`make VAR=value` sets, and nothing else.
 
 | Configure preset | Host          | What it configures                    |
 |:-----------------|:--------------|:--------------------------------------|

--- a/doc/source/devguide/testing.md
+++ b/doc/source/devguide/testing.md
@@ -60,7 +60,9 @@ The fast set runs on every pull request and `master` push:
 - `standalone_buffer`: the standalone buffer build on ubuntu.
 - `build`: `make gtest` plus `make pytest` with Qt off and on, and the pilot,
   on ubuntu and macOS (Release).
-- `build_windows` (Release): the Windows build and tests.
+- `build_windows` (Release): the Windows build and tests, driven by the
+  `ci-win-rel` workflow preset, which chains configure, build, and the CTest
+  run over the C++ cases and the pilot suite.
 
 The heavy set runs on the nightly schedule only:
 

--- a/doc/source/start/build_solvcon.md
+++ b/doc/source/start/build_solvcon.md
@@ -14,8 +14,15 @@ version, e.g. `314`.
 
 ## Build Options
 
-Key options can be set in `setup.mk` (which is read by `Makefile`) or as
-environment variables:
+The Makefile configures through `cmake --preset`, so the defaults are the ones
+in `CMakePresets.json`: `dev-rel` for a release build and `dev-dbg` for a debug
+one.  It adds only the ABI-tagged build directory, the generator, and whatever
+options are set below, each of which becomes a `-D` flag layered on the preset.
+Set `CMAKE_PRESET` to build a different preset, for instance one of your own
+from `CMakeUserPresets.json`.
+
+Key options can be set on the command line, in `setup.mk` (which is read by
+`Makefile`), or as environment variables:
 
 | Variable             | Default   | Purpose                          |
 |:---------------------|:----------|:---------------------------------|


### PR DESCRIPTION
Step 8 of the CMake presets plan. Related to #120. Stacked on #129.

The Makefile expanded twelve `-D` flags of its own on every configure, which is the last place the build configuration was written down twice. It now configures through `cmake --preset` and adds only what a preset cannot carry.

- The preset comes from `CMAKE_BUILD_TYPE`: `dev-dbg` for a debug build, `dev-rel` otherwise. `CMAKE_PRESET` overrides it, so a preset of your own from `CMakeUserPresets.json` can be built through the make targets.
- `-B` keeps the ABI-tagged build directory, which a preset cannot compute, and `-G` keeps the generator a make build has always used, so `make clean`'s recursive `make -C` and the workflows' `rm -f build/*/Makefile` keep working unchanged.
- Every knob is layered as a `-D` flag only when it is actually set, on the command line, in the environment, or in `setup.mk`. `$(origin)` is what makes that distinction, which is why the `?=` defaults for those knobs are gone: the preset is now the one place the defaults are written down, and a knob nobody set is not passed at all.

`make VAR=value` therefore keeps working for every documented option, and gains `LINT_AS_ERRORS`, `USE_GOOGLETEST`, and `USE_SANITIZER`, which previously had to go through `CMAKE_ARGS`.

Nothing else moves. Features 12 to 15 stay in the Makefile, as the plan says they must: the lint targets are not rewired through a preset, so they still run in a checkout that has never been configured, and the interpreter arithmetic stays where it is because the ABI-tagged build path stays.

## Verification

All on Linux, against the existing `build/rel314` tree.

- The cache of a preset-driven `make cmake` was compared entry by entry against the cache the hand-written `-D` block produced: 874 entries each, two differences. `CMAKE_EXPORT_COMPILE_COMMANDS` is now `ON`, which the preset states and the old make build left empty, so `compile_commands.json` now exists for a make build. `USE_GOOGLETEST` is spelled `ON` rather than `True`. No knob differs.
- `make cmake BUILD_QT=OFF`, `make cmake USE_CLANG_TIDY=ON CMAKE_ARGS=...`, and `make cmake CMAKE_BUILD_TYPE=Debug` produce the expected command lines; the last one selects `dev-dbg` and writes `build/dbg314` with `CMAKE_BUILD_TYPE=Debug`, `HIDE_SYMBOL=ON`, `LINT_AS_ERRORS=ON`, and the Unix Makefiles generator.
- `make buildext`, `make gtest` (236 passed), `make pytest` (1799 passed, 19 skipped, 3 xfailed, 511 subtests), `make pytest PYTEST_OPTS="-k SimpleArrayBasicTC -q"` (59 passed, 1756 deselected), `make pilot`, and `make run_pilot_pytest` all succeed.
- `make flake8` succeeds without a configure, which is the reason the lint targets stay out of this.
